### PR TITLE
The operator yaml is updated to reflect 0.5.4

### DIFF
--- a/docs/openebs-operator.yaml
+++ b/docs/openebs-operator.yaml
@@ -76,7 +76,7 @@ spec:
       containers:
       - name: maya-apiserver
         imagePullPolicy: Always
-        image: openebs/m-apiserver:0.5.3
+        image: openebs/m-apiserver:0.5.4
         ports:
         - containerPort: 5656
         env:
@@ -91,11 +91,11 @@ spec:
         #- name: OPENEBS_IO_K8S_MASTER
         #  value: "http://172.28.128.3:8080"
         - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
-          value: "openebs/jiva:0.5.3"
+          value: "openebs/jiva:0.5.4"
         - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
-          value: "openebs/jiva:0.5.3"
+          value: "openebs/jiva:0.5.4"
         - name: OPENEBS_IO_VOLUME_MONITOR_IMAGE
-          value: "openebs/m-exporter:0.5.3"
+          value: "openebs/m-exporter:0.5.4"
         - name: OPENEBS_IO_JIVA_REPLICA_COUNT
           value: "3"
 ---


### PR DESCRIPTION
A new hotfix release (0.5.4) is now availale and the default image should point to this release.