### PR TITLE
Update NDM image tag from v0.3.0 to v0.3.1

### DIFF
--- a/docs/openebs-operator-0.8.1.yaml
+++ b/docs/openebs-operator-0.8.1.yaml
@@ -354,7 +354,7 @@ spec:
       hostNetwork: true
       containers:
       - name: node-disk-manager
-        image: quay.io/openebs/node-disk-manager-amd64:v0.3.0
+        image: quay.io/openebs/node-disk-manager-amd64:v0.3.1
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true


### PR DESCRIPTION
NDM version has been updated from 0.3.0 to 0.3.1 for OpenEBS 0.8.1 release.

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>