### PR TITLE
fix(arm): Modify pgrep argument in localpv liveliness of arm version

### DIFF
--- a/docs/openebs-operator-arm-dev.yaml
+++ b/docs/openebs-operator-arm-dev.yaml
@@ -565,8 +565,8 @@ spec:
         livenessProbe:
           exec:
             command:
-            - pgrep -f
-            - ".*localpv"
+            - pgrep
+            - ".*provisioner"
           initialDelaySeconds: 30
           periodSeconds: 60
 ---


### PR DESCRIPTION
although pgrep -f .*localpv return 1 in the container, liveliness probe still fail and will cause the pod restart.

Fixes openebs/openebs#2712

Signed-off-by: wangzihao <wangzihao18@huawei.com>