### PR TITLE
script(jiva): Add command to print the used snapshot size

### DIFF
--- a/scripts/jiva-tools/jiva_preupgrade_checks.sh
+++ b/scripts/jiva-tools/jiva_preupgrade_checks.sh
@@ -40,6 +40,8 @@ echo "volume.meta"
 #cat volume.meta
 next=$(getAttr volume "Parent" 5)
 head=$(getAttr volume "Head" 2)
+du -s $head
+size=`du -s $head | awk '{print $1}'`
 chainLen=1
 echo "$head"
 createFragOut "$head" $chainLen
@@ -49,10 +51,14 @@ do
 	chainLen=$((chainLen + 1))
 	createFragOut "$next" $chainLen
 	echo "$next.meta"
-	du -sh $next
+	du -s $next
 	cat "$next.meta"
+	img_size=`du -s $next | awk '{print $1}'`
+	size=$((size + img_size))
 	next=$(getAttr "$next" "Parent" 2)
 done
+
+echo "Total used size: $size"
 
 echo "ChainLen:$chainLen"
 
@@ -77,4 +83,3 @@ if [ $chainLen -ne "$metaCnt" ]; then
 fi
 
 echo "No discrepancies found among the files in this replica"
-

--- a/scripts/jiva-tools/jiva_preupgrade_checks.sh
+++ b/scripts/jiva-tools/jiva_preupgrade_checks.sh
@@ -49,6 +49,7 @@ do
 	chainLen=$((chainLen + 1))
 	createFragOut "$next" $chainLen
 	echo "$next.meta"
+	du -sh $next
 	cat "$next.meta"
 	next=$(getAttr "$next" "Parent" 2)
 done


### PR DESCRIPTION
Printing the used size of the snapshots/volume will make it easy to compare how much data difference is there between the replicas without comparing the lunmaps.