### PR TITLE
fix(jiva-tool): remove unnecessary prints

### DIFF
--- a/scripts/jiva-tools/README.md
+++ b/scripts/jiva-tools/README.md
@@ -43,8 +43,10 @@ Repeat the following steps for each of the replica listed in Step 2.
 
 * Run the pre-upgrade script
   ```
-  :/openebs# ./jiva_preupgrade_checks.sh
+  :/openebs# bash ./jiva_preupgrade_checks.sh
   ```
+
+  NOTE: Consider setting 'exec' permissions on the file by doing `chmod +x ./jiva_preupgrade_checks.sh`
 
 * Verify that the last line says: `No discrepancies found among the files in this replica`
 
@@ -52,3 +54,4 @@ Repeat the following steps for each of the replica listed in Step 2.
 
 In step 3, if any of the replicas complained of discrepancies between chain length and img/meta files (or) chains length among replicas (or) total used size among replicas, there are chances of data loss and the upgrade has to be performed with the help of developer steps. The upgrade steps will involve further steps in determining which of the replicas may have missing data block access, taking them out of the replica list, upgrading the healthy replica and rebuilding the rouge replicas.
 
+Please provide the debug messages dumped to jiva_preupgrade_checks.out file, *.frag, *.fragout files from all replicas for further debugging.

--- a/scripts/jiva-tools/jiva_preupgrade_checks.sh
+++ b/scripts/jiva-tools/jiva_preupgrade_checks.sh
@@ -10,6 +10,8 @@
 # Please note that this script doesn't modify anything on the disk, but, 
 # dumps filefrag of img files output into *.frag and *.fragout files
 
+# NOTE: Debug messages will be dumped to jiva_preupgrade_checks.out file
+
 set -euf -o pipefail
 
 function getAttr() {
@@ -36,12 +38,12 @@ function createFragOut() {
 	fi
 }
 
-echo "volume.meta" > jiva_preupgrade_check.out
-cat volume.meta >> jiva_preupgrade_check.out
+echo "volume.meta" > jiva_preupgrade_checks.out
+cat volume.meta >> jiva_preupgrade_checks.out
 next=$(getAttr volume "Parent" 5)
 head=$(getAttr volume "Head" 2)
-echo "$head" >> jiva_preupgrade_check.out
-du -s "$head" >> jiva_preupgrade_check.out
+echo "$head" >> jiva_preupgrade_checks.out
+du -s "$head" >> jiva_preupgrade_checks.out
 size=$(du -s "$head" | awk '{print $1}')
 chainLen=1
 createFragOut "$head" $chainLen
@@ -54,7 +56,7 @@ do
 		echo "$next.meta"
 		du -s "$next"
 		cat "$next.meta"
-	} >> jiva_preupgrade_check.out
+	} >> jiva_preupgrade_checks.out
 	img_size=$(du -s "$next" | awk '{print $1}')
 	size=$((size + img_size))
 	next=$(getAttr "$next" "Parent" 2)
@@ -79,7 +81,7 @@ echo "meta files count:$metaCnt"
 
 	echo "img files count: $imgCnt"
 	echo "meta files count:$metaCnt"
-} >> jiva_preupgrade_check.out
+} >> jiva_preupgrade_checks.out
 
 if [ $chainLen -ne "$imgCnt" ]; then
 	echo "Chain Length does not match with available img files"

--- a/scripts/jiva-tools/jiva_preupgrade_checks.sh
+++ b/scripts/jiva-tools/jiva_preupgrade_checks.sh
@@ -36,23 +36,25 @@ function createFragOut() {
 	fi
 }
 
-#echo "volume.meta"
-#cat volume.meta
+echo "volume.meta" > jiva_preupgrade_check.out
+cat volume.meta >> jiva_preupgrade_check.out
 next=$(getAttr volume "Parent" 5)
 head=$(getAttr volume "Head" 2)
-#du -s $head
+echo "$head" >> jiva_preupgrade_check.out
+du -s "$head" >> jiva_preupgrade_check.out
 size=$(du -s "$head" | awk '{print $1}')
 chainLen=1
-#echo "$head"
 createFragOut "$head" $chainLen
 
 while [ "$next" != "" ]
 do
 	chainLen=$((chainLen + 1))
 	createFragOut "$next" $chainLen
-	#echo "$next.meta"
-	#du -s "$next"
-	#cat "$next.meta"
+	{
+		echo "$next.meta"
+		du -s "$next"
+		cat "$next.meta"
+	} >> jiva_preupgrade_check.out
 	img_size=$(du -s "$next" | awk '{print $1}')
 	size=$((size + img_size))
 	next=$(getAttr "$next" "Parent" 2)
@@ -60,25 +62,32 @@ done
 
 echo "Total used size: $size"
 
-echo "ChainLen:$chainLen"
+echo "Chain Length: $chainLen"
 
-#find . -iname '*.img'
 imgCnt=$(find . -iname '*.img' | wc -l)
+echo "img files count: $imgCnt"
 
-echo "img files count:$imgCnt"
-
-#find . -iname '*.img.meta'
 metaCnt=$(find . -iname '*.img.meta' | wc -l)
-
 echo "meta files count:$metaCnt"
 
+{
+	echo "Total used size: $size"
+	echo "Chain Length: $chainLen"
+
+	ls -ltr
+	find . -exec du -s {} \;
+
+	echo "img files count: $imgCnt"
+	echo "meta files count:$metaCnt"
+} >> jiva_preupgrade_check.out
+
 if [ $chainLen -ne "$imgCnt" ]; then
-	echo "chainLen and imgCnt doesn't match"
+	echo "Chain Length does not match with available img files"
 	exit 1
 fi
 
 if [ $chainLen -ne "$metaCnt" ]; then
-	echo "ChainLen and metaCnt doesn't match"
+	echo "Chain Length does not match with available meta files"
 	exit 1
 fi
 

--- a/scripts/jiva-tools/jiva_preupgrade_checks.sh
+++ b/scripts/jiva-tools/jiva_preupgrade_checks.sh
@@ -36,24 +36,24 @@ function createFragOut() {
 	fi
 }
 
-echo "volume.meta"
+#echo "volume.meta"
 #cat volume.meta
 next=$(getAttr volume "Parent" 5)
 head=$(getAttr volume "Head" 2)
-du -s $head
-size=`du -s $head | awk '{print $1}'`
+#du -s $head
+size=$(du -s "$head" | awk '{print $1}')
 chainLen=1
-echo "$head"
+#echo "$head"
 createFragOut "$head" $chainLen
 
 while [ "$next" != "" ]
 do
 	chainLen=$((chainLen + 1))
 	createFragOut "$next" $chainLen
-	echo "$next.meta"
-	du -s $next
-	cat "$next.meta"
-	img_size=`du -s $next | awk '{print $1}'`
+	#echo "$next.meta"
+	#du -s "$next"
+	#cat "$next.meta"
+	img_size=$(du -s "$next" | awk '{print $1}')
 	size=$((size + img_size))
 	next=$(getAttr "$next" "Parent" 2)
 done
@@ -62,12 +62,12 @@ echo "Total used size: $size"
 
 echo "ChainLen:$chainLen"
 
-find . -iname '*.img'
+#find . -iname '*.img'
 imgCnt=$(find . -iname '*.img' | wc -l)
 
 echo "img files count:$imgCnt"
 
-find . -iname '*.img.meta'
+#find . -iname '*.img.meta'
 metaCnt=$(find . -iname '*.img.meta' | wc -l)
 
 echo "meta files count:$metaCnt"


### PR DESCRIPTION
This PR removes unnecessary prints when running jiva preupgade checks script.
With these changes, output in positive case looks like:
```
Total used size: 0
ChainLen:1
img files count:1
meta files count:1
No discrepancies found among the files in this replica
```
Signed-off-by: Vitta <vitta@mayadata.io>