### PR TITLE
feat(charts): add stable 1.9.0 openebs helm charts with automated chart tests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+#### Special notes for your reviewer:
+
+#### Checklist
+[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
+- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
+- [ ] Chart Version bumped
+- [ ] Variables are documented in the README.md
+- [ ] Title of the PR starts with chart name (e.g. `[stable/openebs]`)

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -1,0 +1,31 @@
+name: Lint and Test Charts
+
+on: [push, pull_request]
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Fetch history
+        run: git fetch --prune --unshallow
+
+      - name: Run chart-testing (lint)
+        id: lint
+        uses: helm/chart-testing-action@v1.0.0-rc.1
+        with:
+          command: lint
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.0.0-alpha.3
+        with:
+          installLocalPathProvisioner: true
+        # Only build a kind cluster if there are chart changes to test.
+        if: steps.lint.outputs.changed == 'true'
+
+      - name: Run chart-testing (install)
+        uses: helm/chart-testing-action@v1.0.0-rc.1
+        with:
+          command: install

--- a/README.md
+++ b/README.md
@@ -1,152 +1,36 @@
-# OpenEBS Helm Charts
 
-## Prerequisites
-- Install Helm.
-  You can find instructions to install Helm [here](https://github.com/helm/helm#install).
-  Linux users can run this installation script:
-  ```
-  curl https://raw.githubusercontent.com/helm/helm/master/scripts/get > get_helm.sh
-  chmod 700 get_helm.sh
-  ./get_helm.sh
-  ```
+# Kubernetes Helm Charts for OpenEBS
 
-- Package latest version of openebs 
-  ```
-  git clone https://github.com/openebs/openebs.git
-  helm package openebs/k8s/charts/openebs
-  ```
-  
-  Note the _tgz_ file created. 
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Lint and Test Charts](https://github.com/openebs/charts/workflows/Lint%20and%20Test%20Charts/badge.svg?branch=master)](https://github.com/openebs/charts/actions)
 
-## Update with new openebs chart
+# Usage
 
-```
-git clone https://github.com/openebs/charts.git
-mv openebs-*.tgz ./charts/docs
-cd charts
-helm repo index docs --url https://openebs.github.io/charts
+[Helm](https://helm.sh) must be installed to use the charts.
+Please refer to Helm's [documentation](https://helm.sh/docs/) to get started.
+
+Once Helm is set up properly, add the repo as follows:
+
+```console
+$ helm repo add openebs https://openebs.github.io/charts
 ```
 
-## Testing the new chart in minikube
+You can then run `helm search repo openebs` to see the charts.
 
-```
-vagrant@minikube-dev:~$ rm -rf ~/.helm && helm init --client-only
-Creating /home/vagrant/.helm 
-Creating /home/vagrant/.helm/repository 
-Creating /home/vagrant/.helm/repository/cache 
-Creating /home/vagrant/.helm/repository/local 
-Creating /home/vagrant/.helm/plugins 
-Creating /home/vagrant/.helm/starters 
-Creating /home/vagrant/.helm/cache/archive 
-Creating /home/vagrant/.helm/repository/repositories.yaml 
-$HELM_HOME has been configured at /home/vagrant/.helm.
-Not installing Tiller due to 'client-only' flag having been set
-Happy Helming!
+#### Using Helm 3
+
+First, create the namespace: `kubectl create namespace <OPENEBS NAMESPACE>`
+
+```bash
+helm install openebs --namespace <YOUR NAMESPACE>
 ```
 
-```
-vagrant@minikube-dev:~$ helm repo add openebs-charts https://openebs.github.io/charts/
-"openebs-charts" has been added to your repositories
-vagrant@minikube-dev:~$ helm repo update
-Hang tight while we grab the latest from your chart repositories...
-...Skip local chart repository
-...Successfully got an update from the "openebs-charts" chart repository
-...Successfully got an update from the "stable" chart repository
-Update Complete. ⎈ Happy Helming!⎈ 
+#### Using Helm 2
+
+```bash
+helm install openebs --namespace <YOUR NAMESPACE>
 ```
 
-Verify the latest chart version is listed first.
+## License
 
-```
-vagrant@minikube-dev:~$ cat ~/.helm/repository/cache/openebs-charts-index.yaml
-apiVersion: v1
-entries:
-  openebs:
-  - apiVersion: v1
-    appVersion: 0.4.0
-    created: 2017-10-31T11:36:51.573727018Z
-    description: Containerized Storage for Containers
-    digest: 61d91376b97883d7c01628f026ee8c4b7c3f25da2dc65affb1a4b6c958cd3f03
-    home: http://www.openebs.io/
-    icon: https://raw.githubusercontent.com/openebs/chitrakala/master/logo/png/logo-01.png
-    keywords:
-    - cloud-native-storage
-    - block-storage
-    - iSCSI
-    - storage
-    name: openebs
-    sources:
-    - https://github.com/openebs/openebs
-    urls:
-    - https://openebs.github.io/charts/openebs-0.4.0.tgz
-    version: 0.4.0
-generated: 2017-10-31T11:36:51.572803046Z
-vagrant@minikube-dev:~$ 
-```
-
-For testing the RBAC, tiller needs to be granted access to create openebs namespace and service accounts.
-
-```
-kubectl -n kube-system create sa tiller
-kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller
-kubectl -n kube-system patch deploy/tiller-deploy -p '{"spec": {"template": {"spec": {"serviceAccountName": "tiller"}}}}'
-kubectl -n kube-system patch deployment tiller-deploy -p '{"spec": {"template": {"spec": {"automountServiceAccountToken": true}}}}'
-```
-
-```
-vagrant@minikube-dev:~$ helm install openebs-charts/openebs
-NAME:   loopy-fox
-LAST DEPLOYED: Tue Oct 31 11:43:43 2017
-NAMESPACE: default
-STATUS: DEPLOYED
-
-RESOURCES:
-==> v1beta1/Deployment
-NAME                 DESIRED  CURRENT  UP-TO-DATE  AVAILABLE  AGE
-maya-apiserver       1        1        1           0          1s
-openebs-provisioner  1        1        1           0          1s
-
-==> v1/StorageClass
-NAME                TYPE
-openebs-cassandra   openebs.io/provisioner-iscsi  
-openebs-es-data-sc  openebs.io/provisioner-iscsi  
-openebs-jupyter     openebs.io/provisioner-iscsi  
-openebs-kafka       openebs.io/provisioner-iscsi  
-openebs-mongodb     openebs.io/provisioner-iscsi  
-openebs-percona     openebs.io/provisioner-iscsi  
-openebs-redis       openebs.io/provisioner-iscsi  
-openebs-standalone  openebs.io/provisioner-iscsi  
-openebs-standard    openebs.io/provisioner-iscsi  
-openebs-zk          openebs.io/provisioner-iscsi  
-
-==> v1/ServiceAccount
-NAME                   SECRETS  AGE
-openebs-maya-operator  1        1s
-
-==> v1beta1/ClusterRole
-NAME                   AGE
-openebs-maya-operator  1s
-
-==> v1beta1/ClusterRoleBinding
-NAME                   AGE
-openebs-maya-operator  1s
-
-==> v1/Service
-NAME                    CLUSTER-IP  EXTERNAL-IP  PORT(S)   AGE
-maya-apiserver-service  10.0.0.233  <none>       5656/TCP  1s
-
-
-NOTES:
-The OpenEBS has been installed. Check its status by running:
-  kubectl get pods -n default
-
-To use OpenEBS Volumes, your nodes should have the iSCSI initiator installed. 
-Please visit http://docs.openebs.io/ for instructions
-
-
-vagrant@minikube-dev:~$ 
-```
-
-
-## References
-- https://github.com/kubernetes/helm/blob/master/docs/chart_repository.md
+[Apache 2.0 License](./LICENSE).

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,0 +1,7 @@
+# See https://github.com/helm/chart-testing#configuration
+remote: origin
+chart-dirs:
+  - stable
+chart-repos:
+  - incubator=https://kubernetes-charts-incubator.storage.googleapis.com/
+helm-extra-args: --timeout=500s

--- a/stable/.helmignore
+++ b/stable/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+# OWNERS file for Kubernetes
+OWNERS

--- a/stable/openebs/Chart.yaml
+++ b/stable/openebs/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+version: 1.9.0
+name: openebs
+appVersion: 1.9.0
+description: Containerized Storage for Containers
+icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/openebs/icon/color/openebs-icon-color.png
+home: http://www.openebs.io/
+keywords:
+  - cloud-native-storage
+  - block-storage
+  - iSCSI
+  - storage
+sources:
+  - https://github.com/openebs/openebs
+maintainers:
+  - name: kmova
+    email: kiran.mova@openebs.io
+  - name: prateekpandey14
+    email: prateek.pandey@openebs.io

--- a/stable/openebs/OWNERS
+++ b/stable/openebs/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- kmova
+- prateekpandey14
+reviewers:
+- kmova
+- prateekpandey14

--- a/stable/openebs/README.md
+++ b/stable/openebs/README.md
@@ -1,0 +1,112 @@
+OpenEBS
+=======
+
+[OpenEBS](https://github.com/openebs/openebs) is an open source storage platform that provides persistent and containerized block storage for DevOps and container environments.
+
+OpenEBS can be deployed on any Kubernetes cluster - either in cloud, on-premise or developer laptop (minikube). OpenEBS itself is deployed as just another container on your cluster, and enables storage services that can be designated on a per pod, application, cluster or container level.
+
+Introduction
+------------
+
+This chart bootstraps OpenEBS deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+- Kubernetes 1.10+ with RBAC enabled
+- iSCSI PV support in the underlying infrastructure
+
+## Installing OpenEBS
+```
+helm install --namespace openebs stable/openebs
+```
+
+## Installing OpenEBS with the release name `my-release`:
+```
+helm install --name `my-release` --namespace openebs stable/openebs
+```
+
+## To uninstall/delete the `my-release` deployment:
+```
+helm ls --all
+helm delete `my-release`
+```
+
+
+## Configuration
+
+The following table lists the configurable parameters of the OpenEBS chart and their default values.
+
+| Parameter                               | Description                                   | Default                                   |
+| ----------------------------------------| --------------------------------------------- | ----------------------------------------- |
+| `rbac.create`                           | Enable RBAC Resources                         | `true`                                    |
+| `rbac.pspEnabled`                       | Create pod security policy resources          | `false`                                   |
+| `image.pullPolicy`                      | Container pull policy                         | `IfNotPresent`                            |
+| `apiserver.enabled`                     | Enable API Server                             | `true`                                    |
+| `apiserver.image`                       | Image for API Server                          | `quay.io/openebs/m-apiserver`             |
+| `apiserver.imageTag`                    | Image Tag for API Server                      | `1.9.0`                                   |
+| `apiserver.replicas`                    | Number of API Server Replicas                 | `1`                                       |
+| `apiserver.sparse.enabled`              | Create Sparse Pool based on Sparsefile        | `false`                                   |
+| `provisioner.enabled`                   | Enable Provisioner                            | `true`                                    |
+| `provisioner.image`                     | Image for Provisioner                         | `quay.io/openebs/openebs-k8s-provisioner` |
+| `provisioner.imageTag`                  | Image Tag for Provisioner                     | `1.9.0`                                   |
+| `provisioner.replicas`                  | Number of Provisioner Replicas                | `1`                                       |
+| `localprovisioner.enabled`              | Enable localProvisioner                       | `true`                                    |
+| `localprovisioner.image`                | Image for localProvisioner                    | `quay.io/openebs/provisioner-localpv`     |
+| `localprovisioner.imageTag`             | Image Tag for localProvisioner                | `1.9.0`                                   |
+| `localprovisioner.replicas`             | Number of localProvisioner Replicas           | `1`                                       |
+| `localprovisioner.basePath`             | BasePath for hostPath volumes on Nodes        | `/var/openebs/local`                      |
+| `webhook.enabled`                       | Enable admission server                       | `true`                                    |
+| `webhook.image`                         | Image for admission server                    | `quay.io/openebs/admission-server`        |
+| `webhook.imageTag`                      | Image Tag for admission server                | `1.9.0`                                   |
+| `webhook.replicas`                      | Number of admission server Replicas           | `1`                                       |
+| `snapshotOperator.enabled`              | Enable Snapshot Provisioner                   | `true`                                    |
+| `snapshotOperator.provisioner.image`    | Image for Snapshot Provisioner                | `quay.io/openebs/snapshot-provisioner`    |
+| `snapshotOperator.provisioner.imageTag` | Image Tag for Snapshot Provisioner            | `1.9.0`                                   |
+| `snapshotOperator.controller.image`     | Image for Snapshot Controller                 | `quay.io/openebs/snapshot-controller`     |
+| `snapshotOperator.controller.imageTag`  | Image Tag for Snapshot Controller             | `1.9.0`                                   |
+| `snapshotOperator.replicas`             | Number of Snapshot Operator Replicas          | `1`                                       |
+| `ndm.enabled`                           | Enable Node Disk Manager                      | `true`                                    |
+| `ndm.image`                             | Image for Node Disk Manager                   | `quay.io/openebs/node-disk-manager-amd64` |
+| `ndm.imageTag`                          | Image Tag for Node Disk Manager               | `v0.4.9`                                  |
+| `ndm.sparse.path`                       | Directory where Sparse files are created      | `/var/openebs/sparse`                     |
+| `ndm.sparse.size`                       | Size of the sparse file in bytes              | `10737418240`                             |
+| `ndm.sparse.count`                      | Number of sparse files to be created          | `0`                                       |
+| `ndm.filters.excludeVendors`            | Exclude devices with specified vendor         | `CLOUDBYT,OpenEBS`                        |
+| `ndm.filters.excludePaths`              | Exclude devices with specified path patterns  | `loop,fd0,sr0,/dev/ram,/dev/dm-,/dev/md`  |
+| `ndm.filters.includePaths`              | Include devices with specified path patterns  | `""`                                      |
+| `ndm.filters.excludePaths`              | Exclude devices with specified path patterns  | `loop,fd0,sr0,/dev/ram,/dev/dm-,/dev/md`  |
+| `ndm.probes.enableSeachest`             | Enable Seachest probe for NDM                 | `false`                                   |
+| `ndmOperator.enabled`                   | Enable NDM Operator                           | `true`                                    |
+| `ndmOperator.image`                     | Image for NDM Operator                        | `quay.io/openebs/node-disk-operator-amd64`|
+| `ndmOperator.imageTag`                  | Image Tag for NDM Operator                    | `v0.4.9`                                  |
+| `jiva.image`                            | Image for Jiva                                | `quay.io/openebs/jiva`                    |
+| `jiva.imageTag`                         | Image Tag for Jiva                            | `1.9.0`                                   |
+| `jiva.replicas`                         | Number of Jiva Replicas                       | `3`                                       |
+| `jiva.defaultStoragePath`               | hostpath used by default Jiva StorageClass    | `/var/openebs`                            |
+| `cstor.pool.image`                      | Image for cStor Pool                          | `quay.io/openebs/cstor-pool`              |
+| `cstor.pool.imageTag`                   | Image Tag for cStor Pool                      | `1.9.0`                                   |
+| `cstor.poolMgmt.image`                  | Image for cStor Pool  Management              | `quay.io/openebs/cstor-pool-mgmt`         |
+| `cstor.poolMgmt.imageTag`               | Image Tag for cStor Pool Management           | `1.9.0`                                   |
+| `cstor.target.image`                    | Image for cStor Target                        | `quay.io/openebs/cstor-istgt`             |
+| `cstor.target.imageTag`                 | Image Tag for cStor Target                    | `1.9.0`                                   |
+| `cstor.volumeMgmt.image`                | Image for cStor Volume  Management            | `quay.io/openebs/cstor-volume-mgmt`       |
+| `cstor.volumeMgmt.imageTag`             | Image Tag for cStor Volume Management         | `1.9.0`                                   |
+| `helper.image`                          | Image for helper                              | `quay.io/openebs/linux-utils`             |
+| `helper.imageTag`                       | Image Tag for helper                          | `1.9.0`                                   |
+| `policies.monitoring.image`             | Image for Prometheus Exporter                 | `quay.io/openebs/m-exporter`              |
+| `policies.monitoring.imageTag`          | Image Tag for Prometheus Exporter             | `1.9.0`                                   |
+| `analytics.enabled`                     | Enable sending stats to Google Analytics      | `true`                                    |
+| `analytics.pingInterval`                | Duration(hours) between sending ping stat     | `24h`                                     |
+| `defaultStorageConfig.enabled`          | Enable default storage class installation     | `true`                                    |
+| `varDirectoryPath.baseDir`              | To store debug info of OpenEBS containers     | `/var/openebs`                            |
+| `healthCheck.initialDelaySeconds`       | Delay before liveness probe is initiated      | `30`                                      |                              | 30                                                          |
+| `healthCheck.periodSeconds`             | How often to perform the liveness probe       | `60`                                      |                            | 10                                                          |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```shell
+helm install --name openebs -f values.yaml stable/openebs
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)

--- a/stable/openebs/templates/NOTES.txt
+++ b/stable/openebs/templates/NOTES.txt
@@ -1,0 +1,27 @@
+The OpenEBS has been installed. Check its status by running:
+$ kubectl get pods -n {{ .Release.Namespace }}
+
+For dynamically creating OpenEBS Volumes, you can either create a new StorageClass or
+use one of the default storage classes provided by OpenEBS.
+
+Use `kubectl get sc` to see the list of installed OpenEBS StorageClasses. A sample
+PVC spec using `openebs-jiva-default` StorageClass is given below:"
+
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: demo-vol-claim
+spec:
+  storageClassName: openebs-jiva-default
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5G
+---
+
+Please note that, OpenEBS uses iSCSI for connecting applications with the
+OpenEBS Volumes and your nodes should have the iSCSI initiator installed.
+
+For more information, visit our Slack at https://openebs.io/community or view the documentation online at http://docs.openebs.io/.

--- a/stable/openebs/templates/_helpers.tpl
+++ b/stable/openebs/templates/_helpers.tpl
@@ -1,0 +1,43 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "openebs.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "openebs.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "openebs.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "openebs.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "openebs.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/stable/openebs/templates/clusterrole.yaml
+++ b/stable/openebs/templates/clusterrole.yaml
@@ -1,0 +1,65 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "openebs.fullname" . }}
+  labels:
+    app: {{ template "openebs.name" . }}
+    chart: {{ template "openebs.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+- apiGroups: ["*"]
+  resources: ["nodes", "nodes/proxy"]
+  verbs: ["*"]
+- apiGroups: ["*"]
+  resources: ["namespaces", "services", "pods", "pods/exec", "deployments", "deployments/finalizers", "replicationcontrollers", "replicasets", "events", "endpoints", "configmaps", "secrets",  "jobs", "cronjobs" ]
+  verbs: ["*"]
+- apiGroups: ["*"]
+  resources: ["statefulsets", "daemonsets"]
+  verbs: ["*"]
+- apiGroups: ["*"]
+  resources: ["resourcequotas", "limitranges"]
+  verbs: ["list", "watch"]
+- apiGroups: ["*"]
+  resources: ["ingresses", "horizontalpodautoscalers", "verticalpodautoscalers", "poddisruptionbudgets", "certificatesigningrequests"]
+  verbs: ["list", "watch"]
+- apiGroups: ["*"]
+  resources: ["storageclasses", "persistentvolumeclaims", "persistentvolumes"]
+  verbs: ["*"]
+- apiGroups: ["volumesnapshot.external-storage.k8s.io"]
+  resources: ["volumesnapshots", "volumesnapshotdatas"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: [ "get", "list", "create", "update", "delete", "patch"]
+- apiGroups: ["*"]
+  resources: [ "disks", "blockdevices", "blockdeviceclaims"]
+  verbs: ["*" ]
+- apiGroups: ["*"]
+  resources: [ "cstorpoolclusters", "storagepoolclaims", "storagepoolclaims/finalizers", "cstorpoolclusters/finalizers", "storagepools"]
+  verbs: ["*" ]
+- apiGroups: ["*"]
+  resources: [ "castemplates", "runtasks"]
+  verbs: ["*" ]
+- apiGroups: ["*"]
+  resources: [ "cstorpools", "cstorpools/finalizers", "cstorvolumereplicas", "cstorvolumes", "cstorvolumeclaims", "cstorvolumepolicies"]
+  verbs: ["*" ]
+- apiGroups: ["*"]
+  resources: [ "cstorpoolinstances", "cstorpoolinstances/finalizers"]
+  verbs: ["*" ]
+- apiGroups: ["*"]
+  resources: [ "cstorbackups", "cstorrestores", "cstorcompletedbackups"]
+  verbs: ["*" ]
+- apiGroups: ["*"]
+  resources: [ "upgradetasks"]
+  verbs: ["*" ]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "watch", "list", "delete", "update", "create"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
+  verbs: ["get", "create", "list", "delete", "update", "patch"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+{{- end }}

--- a/stable/openebs/templates/clusterrolebinding.yaml
+++ b/stable/openebs/templates/clusterrolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "openebs.fullname" . }}
+  labels:
+    app: {{ template "openebs.name" . }}
+    chart: {{ template "openebs.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "openebs.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "openebs.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/stable/openebs/templates/cm-node-disk-manager.yaml
+++ b/stable/openebs/templates/cm-node-disk-manager.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.ndm.enabled }}
+# This is the node-disk-manager related config.
+# It can be used to customize the disks probes and filters
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "openebs.fullname" . }}-ndm-config
+  labels:
+    app: {{ template "openebs.name" . }}
+    chart: {{ template "openebs.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: ndm-config
+    openebs.io/component-name: ndm-config
+data:
+  # udev-probe is default or primary probe which should be enabled to run ndm
+  # filterconfigs contains configs of filters - in the form of include
+  # and exclude comma separated strings
+  node-disk-manager.config: |
+    probeconfigs:
+      - key: udev-probe
+        name: udev probe
+        state: true
+      - key: seachest-probe
+        name: seachest probe
+        state: {{ .Values.ndm.probes.enableSeachest }}
+      - key: smart-probe
+        name: smart probe
+        state: true
+    filterconfigs:
+      - key: os-disk-exclude-filter
+        name: os disk exclude filter
+        state: true
+        exclude: "/,/etc/hosts,/boot"
+      - key: vendor-filter
+        name: vendor filter
+        state: true
+        include: ""
+        exclude: "{{ .Values.ndm.filters.excludeVendors }}"
+      - key: path-filter
+        name: path filter
+        state: true
+        include: "{{ .Values.ndm.filters.includePaths }}"
+        exclude: "{{ .Values.ndm.filters.excludePaths }}"
+---
+{{- end }}

--- a/stable/openebs/templates/daemonset-ndm.yaml
+++ b/stable/openebs/templates/daemonset-ndm.yaml
@@ -1,0 +1,140 @@
+{{- if .Values.ndm.enabled }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ template "openebs.fullname" . }}-ndm
+  labels:
+    app: {{ template "openebs.name" . }}
+    chart: {{ template "openebs.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: ndm
+    openebs.io/component-name: ndm
+    openebs.io/version: {{ .Values.release.version }}
+spec:
+  updateStrategy:
+    type: "RollingUpdate"
+  selector:
+    matchLabels:
+      app: {{ template "openebs.name" . }}
+      release: {{ .Release.Name }}
+      component: ndm
+  template:
+    metadata:
+      labels:
+        app: {{ template "openebs.name" . }}
+        release: {{ .Release.Name }}
+        component: ndm
+        openebs.io/component-name: ndm
+        name: openebs-ndm
+        openebs.io/version: {{ .Values.release.version }}
+    spec:
+      serviceAccountName: {{ template "openebs.serviceAccountName" . }}
+      hostNetwork: true
+      containers:
+      - name: {{ template "openebs.name" . }}-ndm
+        image: "{{ .Values.ndm.image }}:{{ .Values.ndm.imageTag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        securityContext:
+          privileged: true
+        env:
+        # namespace in which NDM is installed will be passed to NDM Daemonset
+        # as environment variable
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        # pass hostname as env variable using downward API to the NDM container
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+{{- if .Values.ndm.sparse }}
+{{- if .Values.ndm.sparse.path }}
+        # specify the directory where the sparse files need to be created.
+        # if not specified, then sparse files will not be created.
+        - name: SPARSE_FILE_DIR
+          value: "{{ .Values.ndm.sparse.path }}"
+{{- end }}
+{{- if .Values.ndm.sparse.size }}
+        # Size(bytes) of the sparse file to be created.
+        - name: SPARSE_FILE_SIZE
+          value: "{{ .Values.ndm.sparse.size }}"
+{{- end }}
+{{- if .Values.ndm.sparse.count }}
+        # Specify the number of sparse files to be created
+        - name: SPARSE_FILE_COUNT
+          value: "{{ .Values.ndm.sparse.count }}"
+{{- end }}
+{{- end }}
+        # Process name used for matching is limited to the 15 characters
+        # present in the pgrep output.
+        # So fullname can be used here with pgrep (cmd is < 15 chars).
+        livenessProbe:
+          exec:
+            command:
+            - pgrep
+            - "ndm"
+          initialDelaySeconds: {{ .Values.ndm.healthCheck.initialDelaySeconds }}
+          periodSeconds: {{ .Values.ndm.healthCheck.periodSeconds }}
+        volumeMounts:
+        - name: config
+          mountPath: /host/node-disk-manager.config
+          subPath: node-disk-manager.config
+          readOnly: true
+        - name: udev
+          mountPath: /run/udev
+        - name: procmount
+          mountPath: /host/proc
+          readOnly: true
+        - name: basepath
+          mountPath: /var/openebs/ndm
+{{- if .Values.ndm.sparse }}
+{{- if .Values.ndm.sparse.path }}
+        - name: sparsepath
+          mountPath: {{ .Values.ndm.sparse.path }}
+{{- end }}
+{{- end }}
+      volumes:
+      - name: config
+        configMap:
+          name: {{ template "openebs.fullname" . }}-ndm-config
+      - name: udev
+        hostPath:
+          path: /run/udev
+          type: Directory
+      # mount /proc (to access mount file of process 1 of host) inside container
+      # to read mount-point of disks and partitions
+      - name: procmount
+        hostPath:
+          path: /proc
+          type: Directory
+      - name: basepath
+        hostPath:
+          path: "{{ .Values.varDirectoryPath.baseDir }}/ndm"
+          type: DirectoryOrCreate
+{{- if .Values.ndm.sparse }}
+{{- if .Values.ndm.sparse.path }}
+      - name: sparsepath
+        hostPath:
+          path: {{ .Values.ndm.sparse.path }}
+{{- end }}
+{{- end }}
+      # By default the node-disk-manager will be run on all kubernetes nodes
+      # If you would like to limit this to only some nodes, say the nodes
+      # that have storage attached, you could label those node and use
+      # nodeSelector.
+      #
+      # e.g. label the storage nodes with - "openebs.io/nodegroup"="storage-node"
+      # kubectl label node <node-name> "openebs.io/nodegroup"="storage-node"
+      #nodeSelector:
+      #  "openebs.io/nodegroup": "storage-node"
+{{- if .Values.ndm.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.ndm.nodeSelector | indent 8 }}
+{{- end }}
+{{- if .Values.ndm.tolerations }}
+      tolerations:
+{{ toYaml .Values.ndm.tolerations | indent 8 }}
+{{- end }}
+{{- end }}

--- a/stable/openebs/templates/deployment-admission-server.yaml
+++ b/stable/openebs/templates/deployment-admission-server.yaml
@@ -1,0 +1,71 @@
+{{- if .Values.webhook.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "openebs.fullname" . }}-admission-server
+  labels:
+    app: admission-webhook
+    chart: {{ template "openebs.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: admission-webhook
+    openebs.io/component-name: admission-webhook
+    openebs.io/version: {{ .Values.release.version }}
+spec:
+  replicas: {{ .Values.webhook.replicas }}
+  strategy:
+    type: "Recreate"
+    rollingUpdate: null
+  selector:
+    matchLabels:
+      app: admission-webhook
+  template:
+    metadata:
+      labels:
+        app: admission-webhook
+        name: admission-webhook
+        release: {{ .Release.Name }}
+        openebs.io/version: {{ .Values.release.version }}
+        openebs.io/component-name: admission-webhook
+    spec:
+{{- if .Values.webhook.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.webhook.nodeSelector | indent 8 }}
+{{- end }}
+{{- if .Values.webhook.tolerations }}
+      tolerations:
+{{ toYaml .Values.webhook.tolerations | indent 8 }}
+{{- end }}
+{{- if .Values.webhook.affinity }}
+      affinity:
+{{ toYaml .Values.webhook.affinity | indent 8 }}
+{{- end }}
+      serviceAccountName: {{ template "openebs.serviceAccountName" . }}
+      containers:
+        - name: admission-webhook
+          image: "{{ .Values.webhook.image }}:{{ .Values.webhook.imageTag }}"
+          imagePullPolicy: Always 
+          args:
+            - -alsologtostderr
+            - -v=2
+            - 2>&1
+          env:
+            - name: OPENEBS_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          # Process name used for matching is limited to the 15 characters
+          # present in the pgrep output.
+          # So fullname can't be used here with pgrep (>15 chars).A regular expression
+          # Anchor `^` : matches any string that starts with `admission-serve`
+          # `.*`: matche any string that has `admission-serve` followed by zero or more char
+          # that matches the entire command name has to specified.
+          livenessProbe:
+            exec:
+              command:
+              - sh
+              - -c
+              - test `pgrep -c "^admission-serve.*"` = 1
+            initialDelaySeconds: {{ .Values.webhook.healthCheck.initialDelaySeconds }}
+            periodSeconds: {{ .Values.webhook.healthCheck.periodSeconds }}
+{{- end }}

--- a/stable/openebs/templates/deployment-local-provisioner.yaml
+++ b/stable/openebs/templates/deployment-local-provisioner.yaml
@@ -1,0 +1,99 @@
+{{- if .Values.localprovisioner.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "openebs.fullname" . }}-localpv-provisioner
+  labels:
+    app: {{ template "openebs.name" . }}
+    chart: {{ template "openebs.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: localpv-provisioner
+    openebs.io/component-name: openebs-localpv-provisioner
+    openebs.io/version: {{ .Values.release.version }}
+spec:
+  replicas: {{ .Values.localprovisioner.replicas }}
+  strategy:
+    type: "Recreate"
+    rollingUpdate: null
+  selector:
+    matchLabels:
+      app: {{ template "openebs.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "openebs.name" . }}
+        release: {{ .Release.Name }}
+        component: localpv-provisioner
+        name: openebs-localpv-provisioner
+        openebs.io/component-name: openebs-localpv-provisioner
+        openebs.io/version: {{ .Values.release.version }}
+    spec:
+      serviceAccountName: {{ template "openebs.serviceAccountName" . }}
+      containers:
+      - name: {{ template "openebs.name" . }}-localpv-provisioner
+        image: "{{ .Values.localprovisioner.image }}:{{ .Values.localprovisioner.imageTag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+        # OPENEBS_IO_K8S_MASTER enables openebs provisioner to connect to K8s
+        # based on this address. This is ignored if empty.
+        # This is supported for openebs provisioner version 0.5.2 onwards
+        #- name: OPENEBS_IO_K8S_MASTER
+        #  value: "http://10.128.0.12:8080"
+        # OPENEBS_IO_KUBE_CONFIG enables openebs provisioner to connect to K8s
+        # based on this config. This is ignored if empty.
+        # This is supported for openebs provisioner version 0.5.2 onwards
+        #- name: OPENEBS_IO_KUBE_CONFIG
+        #  value: "/home/ubuntu/.kube/config"
+        # OPENEBS_NAMESPACE is the namespace that this provisioner will
+        # lookup to find maya api service
+        - name: OPENEBS_NAMESPACE
+          value: "{{ .Release.Namespace }}"
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        # OPENEBS_SERVICE_ACCOUNT provides the service account of this pod as
+        # environment variable
+        - name: OPENEBS_SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        # OPENEBS_IO_BASE_PATH is the environment variable that provides the
+        # default base path on the node where host-path PVs will be provisioned.
+        - name: OPENEBS_IO_ENABLE_ANALYTICS
+          value: "{{ .Values.analytics.enabled }}"
+        - name: OPENEBS_IO_BASE_PATH
+          value: "{{ .Values.localprovisioner.basePath }}"
+        - name: OPENEBS_IO_HELPER_IMAGE
+          value: "{{ .Values.helper.image }}:{{ .Values.helper.imageTag }}"
+        - name: OPENEBS_IO_INSTALLER_TYPE
+          value: "charts-helm"
+        # Process name used for matching is limited to the 15 characters
+        # present in the pgrep output.
+        # So fullname can't be used here with pgrep (>15 chars).A regular expression
+        # that matches the entire command name has to specified.
+        # Anchor `^` : matches any string that starts with `provisioner-loc`
+        # `.*`: matches any string that has `provisioner-loc` followed by zero or more char
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - test `pgrep -c "^provisioner-loc.*"` = 1
+          initialDelaySeconds: {{ .Values.localprovisioner.healthCheck.initialDelaySeconds }}
+          periodSeconds: {{ .Values.localprovisioner.healthCheck.periodSeconds }}
+{{- if .Values.localprovisioner.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.localprovisioner.nodeSelector | indent 8 }}
+{{- end }}
+{{- if .Values.localprovisioner.tolerations }}
+      tolerations:
+{{ toYaml .Values.localprovisioner.tolerations | indent 8 }}
+{{- end }}
+{{- if .Values.localprovisioner.affinity }}
+      affinity:
+{{ toYaml .Values.localprovisioner.affinity | indent 8 }}
+{{- end }}
+{{- end }}

--- a/stable/openebs/templates/deployment-maya-apiserver.yaml
+++ b/stable/openebs/templates/deployment-maya-apiserver.yaml
@@ -1,0 +1,161 @@
+{{- if .Values.apiserver.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "openebs.fullname" . }}-apiserver
+  labels:
+    app: {{ template "openebs.name" . }}
+    chart: {{ template "openebs.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: apiserver
+    name: maya-apiserver
+    openebs.io/component-name: maya-apiserver
+    openebs.io/version: {{ .Values.release.version }}
+spec:
+  replicas: {{ .Values.apiserver.replicas }}
+  strategy:
+    type: "Recreate"
+    rollingUpdate: null
+  selector:
+    matchLabels:
+      app: {{ template "openebs.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "openebs.name" . }}
+        release: {{ .Release.Name }}
+        component: apiserver
+        name: maya-apiserver
+        openebs.io/component-name: maya-apiserver
+        openebs.io/version: {{ .Values.release.version }}
+    spec:
+      serviceAccountName: {{ template "openebs.serviceAccountName" . }}
+      containers:
+      - name: {{ template "openebs.name" . }}-apiserver
+        image: "{{ .Values.apiserver.image }}:{{ .Values.apiserver.imageTag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - containerPort: {{ .Values.apiserver.ports.internalPort }}
+        env:
+        # OPENEBS_IO_KUBE_CONFIG enables maya api service to connect to K8s
+        # based on this config. This is ignored if empty.
+        # This is supported for maya api server version 0.5.2 onwards
+        #- name: OPENEBS_IO_KUBE_CONFIG
+        #  value: "/home/ubuntu/.kube/config"
+        # OPENEBS_IO_K8S_MASTER enables maya api service to connect to K8s
+        # based on this address. This is ignored if empty.
+        # This is supported for maya api server version 0.5.2 onwards
+        #- name: OPENEBS_IO_K8S_MASTER
+        #  value: "http://172.28.128.3:8080"
+        # OPENEBS_NAMESPACE provides the namespace of this deployment as an
+        # environment variable
+        - name: OPENEBS_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        # OPENEBS_SERVICE_ACCOUNT provides the service account of this pod as
+        # environment variable
+        - name: OPENEBS_SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        # OPENEBS_MAYA_POD_NAME provides the name of this pod as
+        # environment variable
+        - name: OPENEBS_MAYA_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        # If OPENEBS_IO_CREATE_DEFAULT_STORAGE_CONFIG is false then OpenEBS default
+        # storageclass and storagepool will not be created.
+        - name: OPENEBS_IO_CREATE_DEFAULT_STORAGE_CONFIG
+          value: "{{ .Values.defaultStorageConfig.enabled }}"
+        # OPENEBS_IO_INSTALL_DEFAULT_CSTOR_SPARSE_POOL decides whether default cstor sparse pool should be
+        # configured as a part of openebs installation.
+        # If "true" a default cstor sparse pool will be configured, if "false" it will not be configured.
+        # This value takes effect only if OPENEBS_IO_CREATE_DEFAULT_STORAGE_CONFIG
+        # is set to true
+        - name: OPENEBS_IO_INSTALL_DEFAULT_CSTOR_SPARSE_POOL
+          value: "{{ .Values.apiserver.sparse.enabled }}"
+        # OPENEBS_IO_CSTOR_TARGET_DIR can be used to specify the hostpath
+        # to be used for saving the shared content between the side cars
+        # of cstor volume pod.
+        # The default path used is /var/openebs/sparse
+        - name: OPENEBS_IO_CSTOR_TARGET_DIR
+          value: "{{ .Values.ndm.sparse.path }}"
+        # OPENEBS_IO_CSTOR_POOL_SPARSE_DIR can be used to specify the hostpath
+        # to be used for saving the shared content between the side cars
+        # of cstor pool pod. This ENV is also used to indicate the location
+        # of the sparse devices.
+        # The default path used is /var/openebs/sparse
+        - name: OPENEBS_IO_CSTOR_POOL_SPARSE_DIR
+          value: "{{ .Values.ndm.sparse.path }}"
+        # OPENEBS_IO_JIVA_POOL_DIR can be used to specify the hostpath
+        # to be used for default Jiva StoragePool loaded by OpenEBS
+        # The default path used is /var/openebs
+        # This value takes effect only if OPENEBS_IO_CREATE_DEFAULT_STORAGE_CONFIG
+        # is set to true
+        - name: OPENEBS_IO_JIVA_POOL_DIR
+          value: "{{ .Values.jiva.defaultStoragePath }}"
+        # OPENEBS_IO_LOCALPV_HOSTPATH_DIR can be used to specify the hostpath
+        # to be used for default openebs-hostpath storageclass loaded by OpenEBS
+        # The default path used is /var/openebs/local
+        # This value takes effect only if OPENEBS_IO_CREATE_DEFAULT_STORAGE_CONFIG
+        # is set to true
+        - name: OPENEBS_IO_LOCALPV_HOSTPATH_DIR
+          value: "{{ .Values.localprovisioner.basePath }}"
+        # OPENEBS_IO_BASE_DIR used by the OpenEBS to store debug information and
+        # so forth that are generated in the course of running OpenEBS containers.
+        - name: OPENEBS_IO_BASE_DIR
+          value: "{{ .Values.varDirectoryPath.baseDir }}"
+        - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
+          value: "{{ .Values.jiva.image }}:{{ .Values.jiva.imageTag }}"
+        - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
+          value: "{{ .Values.jiva.image }}:{{ .Values.jiva.imageTag }}"
+        - name: OPENEBS_IO_JIVA_REPLICA_COUNT
+          value: "{{ .Values.jiva.replicas }}"
+        - name: OPENEBS_IO_CSTOR_TARGET_IMAGE
+          value: "{{ .Values.cstor.target.image }}:{{ .Values.cstor.target.imageTag }}"
+        - name: OPENEBS_IO_CSTOR_POOL_IMAGE
+          value: "{{ .Values.cstor.pool.image }}:{{ .Values.cstor.pool.imageTag }}"
+        - name: OPENEBS_IO_CSTOR_POOL_MGMT_IMAGE
+          value: "{{ .Values.cstor.poolMgmt.image }}:{{ .Values.cstor.poolMgmt.imageTag }}"
+        - name: OPENEBS_IO_CSTOR_VOLUME_MGMT_IMAGE
+          value: "{{ .Values.cstor.volumeMgmt.image }}:{{ .Values.cstor.volumeMgmt.imageTag }}"
+        - name: OPENEBS_IO_VOLUME_MONITOR_IMAGE
+          value: "{{ .Values.policies.monitoring.image }}:{{ .Values.policies.monitoring.imageTag }}"
+        - name: OPENEBS_IO_CSTOR_POOL_EXPORTER_IMAGE
+          value: "{{ .Values.policies.monitoring.image }}:{{ .Values.policies.monitoring.imageTag }}"
+        - name: OPENEBS_IO_HELPER_IMAGE
+          value: "{{ .Values.helper.image }}:{{ .Values.helper.imageTag }}"
+        # OPENEBS_IO_ENABLE_ANALYTICS if set to true sends anonymous usage
+        # events to Google Analytics
+        - name: OPENEBS_IO_ENABLE_ANALYTICS
+          value: "{{ .Values.analytics.enabled }}"
+        # OPENEBS_IO_ANALYTICS_PING_INTERVAL can be used to specify the duration (in hours)
+        # for periodic ping events sent to Google Analytics. Default is 24 hours.
+        - name: OPENEBS_IO_ANALYTICS_PING_INTERVAL
+          value: "{{ .Values.analytics.pingInterval }}"
+        - name: OPENEBS_IO_INSTALLER_TYPE
+          value: "charts-helm"
+        livenessProbe:
+          exec:
+            command:
+            - /usr/local/bin/mayactl
+            - version
+          initialDelaySeconds: {{ .Values.apiserver.healthCheck.initialDelaySeconds }}
+          periodSeconds: {{ .Values.apiserver.healthCheck.periodSeconds }}
+{{- if .Values.apiserver.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.apiserver.nodeSelector | indent 8 }}
+{{- end }}
+{{- if .Values.apiserver.tolerations }}
+      tolerations:
+{{ toYaml .Values.apiserver.tolerations | indent 8 }}
+{{- end }}
+{{- if .Values.apiserver.affinity }}
+      affinity:
+{{ toYaml .Values.apiserver.affinity | indent 8 }}
+{{- end }}
+{{- end }}

--- a/stable/openebs/templates/deployment-maya-provisioner.yaml
+++ b/stable/openebs/templates/deployment-maya-provisioner.yaml
@@ -1,0 +1,98 @@
+{{- if .Values.provisioner.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "openebs.fullname" . }}-provisioner
+  labels:
+    app: {{ template "openebs.name" . }}
+    chart: {{ template "openebs.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: provisioner
+    name: openebs-provisioner
+    openebs.io/component-name: openebs-provisioner
+    openebs.io/version: {{ .Values.release.version }}
+spec:
+  replicas: {{ .Values.provisioner.replicas }}
+  strategy:
+    type: "Recreate"
+    rollingUpdate: null
+  selector:
+    matchLabels:
+      app: {{ template "openebs.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "openebs.name" . }}
+        release: {{ .Release.Name }}
+        component: provisioner
+        name: openebs-provisioner
+        openebs.io/component-name: openebs-provisioner
+        openebs.io/version: {{ .Values.release.version }}
+    spec:
+      serviceAccountName: {{ template "openebs.serviceAccountName" . }}
+      containers:
+      - name: {{ template "openebs.name" . }}-provisioner
+        image: "{{ .Values.provisioner.image }}:{{ .Values.provisioner.imageTag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+        # OPENEBS_IO_K8S_MASTER enables openebs provisioner to connect to K8s
+        # based on this address. This is ignored if empty.
+        # This is supported for openebs provisioner version 0.5.2 onwards
+        #- name: OPENEBS_IO_K8S_MASTER
+        #  value: "http://10.128.0.12:8080"
+        # OPENEBS_IO_KUBE_CONFIG enables openebs provisioner to connect to K8s
+        # based on this config. This is ignored if empty.
+        # This is supported for openebs provisioner version 0.5.2 onwards
+        #- name: OPENEBS_IO_KUBE_CONFIG
+        #  value: "/home/ubuntu/.kube/config"
+        # OPENEBS_NAMESPACE is the namespace that this provisioner will
+        # lookup to find maya api service
+        - name: OPENEBS_NAMESPACE
+          value: "{{ .Release.Namespace }}"
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        # OPENEBS_MAYA_SERVICE_NAME provides the maya-apiserver K8s service name,
+        # that provisioner should forward the volume create/delete requests.
+        # If not present, "maya-apiserver-service" will be used for lookup.
+        # This is supported for openebs provisioner version 0.5.3-RC1 onwards
+        - name: OPENEBS_MAYA_SERVICE_NAME
+          value: "{{ template "openebs.fullname" . }}-apiservice"
+        # The following values will be set as annotations to the PV object.
+        # Refer : https://github.com/openebs/external-storage/pull/15
+        #- name: OPENEBS_MONITOR_URL
+        #  value: "{{ .Values.provisioner.monitorUrl }}"
+        #- name: OPENEBS_MONITOR_VOLKEY
+        #  value: "{{ .Values.provisioner.monitorVolumeKey }}"
+        #- name: MAYA_PORTAL_URL
+        #  value: "{{ .Values.provisioner.mayaPortalUrl }}"
+         # Process name used for matching is limited to the 15 characters
+         # present in the pgrep output.
+         # So fullname can't be used here with pgrep (>15 chars).A regular expression
+         # that matches the entire command name has to specified.
+         # Anchor `^` : matches any string that starts with `openebs-provis`
+         # `.*`: matches any string that has `openebs-provis` followed by zero or more char
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - test `pgrep -c "^openebs-provisi.*"` = 1
+          initialDelaySeconds: {{ .Values.provisioner.healthCheck.initialDelaySeconds }}
+          periodSeconds: {{ .Values.provisioner.healthCheck.periodSeconds }}
+{{- if .Values.provisioner.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.provisioner.nodeSelector | indent 8 }}
+{{- end }}
+{{- if .Values.provisioner.tolerations }}
+      tolerations:
+{{ toYaml .Values.provisioner.tolerations | indent 8 }}
+{{- end }}
+{{- if .Values.provisioner.affinity }}
+      affinity:
+{{ toYaml .Values.provisioner.affinity | indent 8 }}
+{{- end }}
+{{- end }}

--- a/stable/openebs/templates/deployment-maya-snapshot-operator.yaml
+++ b/stable/openebs/templates/deployment-maya-snapshot-operator.yaml
@@ -1,0 +1,131 @@
+{{- if .Values.snapshotOperator.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "openebs.fullname" . }}-snapshot-operator
+  labels:
+    app: {{ template "openebs.name" . }}
+    chart: {{ template "openebs.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: snapshot-operator
+    openebs.io/component-name: openebs-snapshot-operator
+    openebs.io/version: {{ .Values.release.version }}
+spec:
+  replicas: {{ .Values.snapshotOperator.replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "openebs.name" . }}
+      release: {{ .Release.Name }}
+  strategy:
+    type: "Recreate"
+    rollingUpdate: null
+  template:
+    metadata:
+      labels:
+        app: {{ template "openebs.name" . }}
+        release: {{ .Release.Name }}
+        component: snapshot-operator
+        name: openebs-snapshot-operator
+        openebs.io/version: {{ .Values.release.version }}
+        openebs.io/component-name: openebs-snapshot-operator
+    spec:
+      serviceAccountName: {{ template "openebs.serviceAccountName" . }}
+      containers:
+      - name: {{ template "openebs.name" . }}-snapshot-controller
+        image: "{{ .Values.snapshotOperator.controller.image }}:{{ .Values.snapshotOperator.controller.imageTag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+        # OPENEBS_IO_K8S_MASTER enables openebs snapshot controller to connect to K8s
+        # based on this address. This is ignored if empty.
+        # This is supported for openebs snapshot controller version 0.6-RC1 onwards
+        #- name: OPENEBS_IO_K8S_MASTER
+        #  value: "http://10.128.0.12:8080"
+        # OPENEBS_IO_KUBE_CONFIG enables openebs snapshot controller to connect to K8s
+        # based on this config. This is ignored if empty.
+        # This is supported for openebs snapshot controller version 0.6-RC1 onwards
+        #- name: OPENEBS_IO_KUBE_CONFIG
+        #  value: "/home/ubuntu/.kube/config"
+        # OPENEBS_NAMESPACE is the namespace that this snapshot controller will
+        # lookup to find maya api service
+        - name: OPENEBS_NAMESPACE
+          value: "{{ .Release.Namespace }}"
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        # OPENEBS_MAYA_SERVICE_NAME provides the maya-apiserver K8s service name,
+        # that snapshot controller should forward the volume snapshot requests.
+        # If not present, "maya-apiserver-service" will be used for lookup.
+        # This is supported for openebs snapshot controller version 0.6-RC1 onwards
+        - name: OPENEBS_MAYA_SERVICE_NAME
+          value: "{{ template "openebs.fullname" . }}-apiservice"
+         # Process name used for matching is limited to the 15 characters
+         # present in the pgrep output.
+         # So fullname can't be used here with pgrep (>15 chars).A regular expression
+         # that matches the entire command name has to specified.
+         # Anchor `^` : matches any string that starts with `snapshot-contro`
+         # `.*`: matches any string that has `snapshot-contro` followed by zero or more char
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - test `pgrep -c "^snapshot-contro.*"` = 1
+          initialDelaySeconds: {{ .Values.snapshotOperator.healthCheck.initialDelaySeconds }}
+          periodSeconds: {{ .Values.snapshotOperator.healthCheck.periodSeconds }}
+      - name: {{ template "openebs.name" . }}-snapshot-provisioner
+        image: "{{ .Values.snapshotOperator.provisioner.image }}:{{ .Values.snapshotOperator.provisioner.imageTag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+        # OPENEBS_IO_K8S_MASTER enables openebs snapshot provisioner to connect to K8s
+        # based on this address. This is ignored if empty.
+        # This is supported for openebs snapshot provisioner version 0.6-RC1 onwards
+        #- name: OPENEBS_IO_K8S_MASTER
+        #  value: "http://10.128.0.12:8080"
+        # OPENEBS_IO_KUBE_CONFIG enables openebs snapshot provisioner to connect to K8s
+        # based on this config. This is ignored if empty.
+        # This is supported for openebs snapshot provisioner version 0.6-RC1 onwards
+        #- name: OPENEBS_IO_KUBE_CONFIG
+        #  value: "/home/ubuntu/.kube/config"
+        # OPENEBS_NAMESPACE is the namespace that this snapshot provisioner will
+        # lookup to find maya api service
+        - name: OPENEBS_NAMESPACE
+          value: "{{ .Release.Namespace }}"
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        # OPENEBS_MAYA_SERVICE_NAME provides the maya-apiserver K8s service name,
+        # that snapshot provisioner should forward the volume snapshot PV requests.
+        # If not present, "maya-apiserver-service" will be used for lookup.
+        # This is supported for openebs snapshot provisioner version 0.6-RC1 onwards
+        - name: OPENEBS_MAYA_SERVICE_NAME
+          value: "{{ template "openebs.fullname" . }}-apiservice"
+         # Process name used for matching is limited to the 15 characters
+         # present in the pgrep output.
+         # So fullname can't be used here with pgrep (>15 chars).A regular expression
+         # that matches the entire command name has to specified.
+         # Anchor `^` : matches any string that starts with `snapshot-provis`
+         # `.*`: matches any string that has `snapshot-provis` followed by zero or more char
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - test `pgrep -c "^snapshot-provis.*"` = 1
+          initialDelaySeconds: {{ .Values.snapshotOperator.healthCheck.initialDelaySeconds }}
+          periodSeconds: {{ .Values.snapshotOperator.healthCheck.periodSeconds }}
+{{- if .Values.snapshotOperator.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.snapshotOperator.nodeSelector | indent 8 }}
+{{- end }}
+{{- if .Values.snapshotOperator.tolerations }}
+      tolerations:
+{{ toYaml .Values.snapshotOperator.tolerations | indent 8 }}
+{{- end }}
+{{- if .Values.snapshotOperator.affinity }}
+      affinity:
+{{ toYaml .Values.snapshotOperator.affinity | indent 8 }}
+{{- end }}
+{{- end }}

--- a/stable/openebs/templates/deployment-ndm-operator.yaml
+++ b/stable/openebs/templates/deployment-ndm-operator.yaml
@@ -1,0 +1,79 @@
+{{- if .Values.ndmOperator.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "openebs.fullname" . }}-ndm-operator
+  labels:
+    app: {{ template "openebs.name" . }}
+    chart: {{ template "openebs.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: ndm-operator
+    openebs.io/component-name: ndm-operator
+    openebs.io/version: {{ .Values.release.version }}
+    name: ndm-operator
+spec:
+  replicas: {{ .Values.ndmOperator.replicas }}
+  strategy:
+    type: "Recreate"
+    rollingUpdate: null
+  selector:
+    matchLabels:
+      app: {{ template "openebs.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "openebs.name" . }}
+        release: {{ .Release.Name }}
+        component: ndm-operator
+        name: ndm-operator
+        openebs.io/component-name: ndm-operator
+        openebs.io/version: {{ .Values.release.version }}
+    spec:
+      serviceAccountName: {{ template "openebs.serviceAccountName" . }}
+      containers:
+      - name: {{ template "openebs.fullname" . }}-ndm-operator
+        image: "{{ .Values.ndmOperator.image }}:{{ .Values.ndmOperator.imageTag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        readinessProbe:
+          exec:
+            command:
+            - stat
+            - /tmp/operator-sdk-ready
+          initialDelaySeconds: {{ .Values.ndmOperator.readinessCheck.initialDelaySeconds }}
+          periodSeconds: {{ .Values.ndmOperator.readinessCheck.periodSeconds }}
+          failureThreshold: {{ .Values.ndmOperator.readinessCheck.failureThreshold }}
+        env:
+        - name: WATCH_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: OPERATOR_NAME
+          value: "node-disk-operator"
+        - name: CLEANUP_JOB_IMAGE
+          value: "{{ .Values.helper.image }}:{{ .Values.helper.imageTag }}"
+        # Process name used for matching is limited to the 15 characters
+        # present in the pgrep output.
+        # So fullname can be used here with pgrep (cmd is < 15 chars).
+        livenessProbe:
+          exec:
+            command:
+            - pgrep
+            - "ndo"
+          initialDelaySeconds: {{ .Values.ndmOperator.healthCheck.initialDelaySeconds }}
+          periodSeconds: {{ .Values.ndmOperator.healthCheck.periodSeconds }}
+{{- if .Values.ndmOperator.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.ndmOperator.nodeSelector | indent 8 }}
+{{- end }}
+{{- if .Values.ndmOperator.tolerations }}
+      tolerations:
+{{ toYaml .Values.ndmOperator.tolerations | indent 8 }}
+{{- end }}
+{{- end }}

--- a/stable/openebs/templates/psp-clusterrole.yaml
+++ b/stable/openebs/templates/psp-clusterrole.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.rbac.create .Values.rbac.pspEnabled }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "openebs.fullname" . }}-psp
+  labels:
+    app: {{ template "openebs.name" . }}
+rules:
+- apiGroups: ['extensions']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - {{ template "openebs.fullname" . }}-psp
+{{- end }}

--- a/stable/openebs/templates/psp-clusterrolebinding.yaml
+++ b/stable/openebs/templates/psp-clusterrolebinding.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.rbac.create .Values.rbac.pspEnabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "openebs.fullname" . }}-psp
+  labels:
+    app: {{ template "openebs.name" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "openebs.fullname" . }}-psp
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "openebs.serviceAccountName" . }}
+    namespace: {{ $.Release.Namespace }}
+{{- end }}
+

--- a/stable/openebs/templates/psp.yaml
+++ b/stable/openebs/templates/psp.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.rbac.create .Values.rbac.pspEnabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "openebs.fullname" . }}-psp
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app: {{ template "openebs.name" . }}
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  allowedCapabilities: ['*']
+  volumes: ['*']
+  hostNetwork: true
+  hostPorts:
+  - min: 0
+    max: 65535
+  hostIPC: true
+  hostPID: true
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+{{- end }}

--- a/stable/openebs/templates/service-maya-apiserver.yaml
+++ b/stable/openebs/templates/service-maya-apiserver.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.apiserver.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "openebs.fullname" . }}-apiservice
+  labels:
+    app: {{ template "openebs.name" . }}
+    chart: {{ template "openebs.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    openebs.io/component-name: maya-apiserver-svc
+spec:
+  ports:
+  - name: api
+    port: {{ .Values.apiserver.ports.externalPort }}
+    targetPort: {{ .Values.apiserver.ports.internalPort }}
+    protocol: TCP
+  selector:
+    app: {{ template "openebs.name" . }}
+    release: {{ .Release.Name }}
+    component: apiserver
+  sessionAffinity: None
+{{- end }}

--- a/stable/openebs/templates/serviceaccount.yaml
+++ b/stable/openebs/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "openebs.serviceAccountName" . }}
+  labels:
+    app: {{ template "openebs.name" . }}
+    chart: {{ template "openebs.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- end }}

--- a/stable/openebs/values.yaml
+++ b/stable/openebs/values.yaml
@@ -1,0 +1,170 @@
+# Default values for openebs.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+  pspEnabled: false
+
+serviceAccount:
+  create: true
+  name:
+
+release:
+  # "openebs.io/version" label for control plane components
+  version: "1.9.0"
+
+image:
+  pullPolicy: IfNotPresent
+
+apiserver:
+  enabled: true
+  image: "quay.io/openebs/m-apiserver"
+  imageTag: "1.9.0"
+  replicas: 1
+  ports:
+    externalPort: 5656
+    internalPort: 5656
+  sparse:
+    enabled: "false"
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  healthCheck:
+    initialDelaySeconds: 30
+    periodSeconds: 60
+
+defaultStorageConfig:
+  enabled: "true"
+
+# Directory used by the OpenEBS to store debug information and so forth
+# that are generated in the course of running OpenEBS containers.
+varDirectoryPath:
+  baseDir: "/var/openebs"
+
+provisioner:
+  enabled: true
+  image: "quay.io/openebs/openebs-k8s-provisioner"
+  imageTag: "1.9.0"
+  replicas: 1
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  healthCheck:
+    initialDelaySeconds: 30
+    periodSeconds: 60
+
+localprovisioner:
+  enabled: true
+  image: "quay.io/openebs/provisioner-localpv"
+  imageTag: "1.9.0"
+  replicas: 1
+  basePath: "/var/openebs/local"
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  healthCheck:
+    initialDelaySeconds: 30
+    periodSeconds: 60
+
+snapshotOperator:
+  enabled: true
+  controller:
+    image: "quay.io/openebs/snapshot-controller"
+    imageTag: "1.9.0"
+  provisioner:
+    image: "quay.io/openebs/snapshot-provisioner"
+    imageTag: "1.9.0"
+  replicas: 1
+  upgradeStrategy: "Recreate"
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  healthCheck:
+    initialDelaySeconds: 30
+    periodSeconds: 60
+
+ndm:
+  enabled: true
+  image: "quay.io/openebs/node-disk-manager-amd64"
+  imageTag: "v0.4.9"
+  sparse:
+    path: "/var/openebs/sparse"
+    size: "10737418240"
+    count: "0"
+  filters:
+    excludeVendors: "CLOUDBYT,OpenEBS"
+    includePaths: ""
+    excludePaths: "loop,fd0,sr0,/dev/ram,/dev/dm-,/dev/md"
+  probes:
+    enableSeachest: false
+  nodeSelector: {}
+  tolerations: []
+  healthCheck:
+    initialDelaySeconds: 30
+    periodSeconds: 60
+
+ndmOperator:
+  enabled: true
+  image: "quay.io/openebs/node-disk-operator-amd64"
+  imageTag: "v0.4.9"
+  replicas: 1
+  upgradeStrategy: Recreate
+  nodeSelector: {}
+  tolerations: []
+  healthCheck:
+    initialDelaySeconds: 30
+    periodSeconds: 60
+  readinessCheck:
+    initialDelaySeconds: 4
+    periodSeconds: 10
+    failureThreshold: 1
+
+webhook:
+  enabled: true
+  image: "quay.io/openebs/admission-server"
+  imageTag: "1.9.0"
+  failurePolicy: Ignore
+  replicas: 1
+  healthCheck:
+    initialDelaySeconds: 30
+    periodSeconds: 60
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+jiva:
+  image: "quay.io/openebs/jiva"
+  imageTag: "1.9.0"
+  replicas: 3
+  defaultStoragePath: "/var/openebs"
+
+cstor:
+  pool:
+    image: "quay.io/openebs/cstor-pool"
+    imageTag: "1.9.0"
+  poolMgmt:
+    image: "quay.io/openebs/cstor-pool-mgmt"
+    imageTag: "1.9.0"
+  target:
+    image: "quay.io/openebs/cstor-istgt"
+    imageTag: "1.9.0"
+  volumeMgmt:
+    image: "quay.io/openebs/cstor-volume-mgmt"
+    imageTag: "1.9.0"
+
+helper:
+  image: "quay.io/openebs/linux-utils"
+  imageTag: "1.9.0"
+
+policies:
+  monitoring:
+    enabled: true
+    image: "quay.io/openebs/m-exporter"
+    imageTag: "1.9.0"
+
+analytics:
+  enabled: true
+  # Specify in hours the duration after which a ping event needs to be sent.
+  pingInterval: "24h"


### PR DESCRIPTION
Changes add stable 1.9.0 openebs helm charts with automated chart tests which deploys the kind based kubernetes cluster and deploy the charts

Runing tests results be cheked [here](https://github.com/prateekpandey14/charts-2/runs/611392363?check_suite_focus=true)