### PR TITLE
fix(YAML): Remove extra image tag

### DIFF
--- a/docs/openebs-operator-1.9.0-aws.yaml
+++ b/docs/openebs-operator-1.9.0-aws.yaml
@@ -355,7 +355,7 @@ spec:
       serviceAccountName: openebs-maya-operator
       containers:
         - name: snapshot-controller
-          image: 117940112483.dkr.ecr.us-east-1.amazonaws.com/3ed4f202-6b8f-4bc9-adaa-20ce0807bba3/cg-1638419926/quay.io/openebs/snapshot-controller:1.9.0-latest-latest
+          image: 117940112483.dkr.ecr.us-east-1.amazonaws.com/3ed4f202-6b8f-4bc9-adaa-20ce0807bba3/cg-1638419926/quay.io/openebs/snapshot-controller:1.9.0-latest
           imagePullPolicy: IfNotPresent
           env:
           - name: OPENEBS_NAMESPACE
@@ -383,7 +383,7 @@ spec:
         #- name: OPENEBS_MAYA_SERVICE_NAME
         #  value: "maya-apiserver-apiservice"
         - name: snapshot-provisioner
-          image: 117940112483.dkr.ecr.us-east-1.amazonaws.com/3ed4f202-6b8f-4bc9-adaa-20ce0807bba3/cg-1638419926/quay.io/openebs/snapshot-provisioner:1.9.0-latest-latest
+          image: 117940112483.dkr.ecr.us-east-1.amazonaws.com/3ed4f202-6b8f-4bc9-adaa-20ce0807bba3/cg-1638419926/quay.io/openebs/snapshot-provisioner:1.9.0-latest
           imagePullPolicy: IfNotPresent
           env:
           - name: OPENEBS_NAMESPACE
@@ -487,7 +487,7 @@ spec:
       hostNetwork: true
       containers:
       - name: node-disk-manager
-        image: 117940112483.dkr.ecr.us-east-1.amazonaws.com/3ed4f202-6b8f-4bc9-adaa-20ce0807bba3/cg-1638419926/quay.io/openebs/node-disk-manager-amd64:1.9.0-latest-latest
+        image: 117940112483.dkr.ecr.us-east-1.amazonaws.com/3ed4f202-6b8f-4bc9-adaa-20ce0807bba3/cg-1638419926/quay.io/openebs/node-disk-manager-amd64:1.9.0-latest
         imagePullPolicy: Always
         securityContext:
           privileged: true
@@ -583,7 +583,7 @@ spec:
       serviceAccountName: openebs-maya-operator
       containers:
         - name: node-disk-operator
-          image: 117940112483.dkr.ecr.us-east-1.amazonaws.com/3ed4f202-6b8f-4bc9-adaa-20ce0807bba3/cg-1638419926/quay.io/openebs/node-disk-operator-amd64:1.9.0-latest-latest
+          image: 117940112483.dkr.ecr.us-east-1.amazonaws.com/3ed4f202-6b8f-4bc9-adaa-20ce0807bba3/cg-1638419926/quay.io/openebs/node-disk-operator-amd64:1.9.0-latest
           imagePullPolicy: Always
           readinessProbe:
             exec:


### PR DESCRIPTION
- Remove extra image tag for some of the OpenEBS components which makes the pods in ErrImagepull state for AWS 1.9 version

Signed-off-by: Ranjith R <ranjith.raveendran@mayadata.io>