### PR TITLE
[arm-operator] fix: m-apiserver image now points to arm64 repo

### DIFF
--- a/docs/openebs-operator-arm-dev.yaml
+++ b/docs/openebs-operator-arm-dev.yaml
@@ -106,7 +106,7 @@ spec:
       containers:
       - name: maya-apiserver
         imagePullPolicy: IfNotPresent
-        image: quay.io/openebs/m-apiserver:1.10.0
+        image: quay.io/openebs/m-apiserver-arm64:1.10.0
         ports:
         - containerPort: 5656
         env:


### PR DESCRIPTION
Signed-off-by: Nick Pappas <nick@radicand.org>

#### Special notes for your reviewer:

The current version of the ARM operator contains a reference to the standard/amd64 version of m-apiserver. This PR corrects the reference to point to the arm64 image.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [-] Chart Version bumped
- [-] Variables are documented in the README.md
- [-] Title of the PR starts with chart name (e.g. `[stable/openebs]`)
