### PR TITLE
[stable/openebs] Add rbd to exclusions

### DIFF
--- a/charts/openebs/Chart.yaml
+++ b/charts/openebs/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 1.10.2
+version: 1.11.0
 name: openebs
 appVersion: 1.10.0
 description: Containerized Storage for Containers

--- a/charts/openebs/Chart.yaml
+++ b/charts/openebs/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 1.11.0
+version: 1.10.3
 name: openebs
 appVersion: 1.10.0
 description: Containerized Storage for Containers

--- a/charts/openebs/values.yaml
+++ b/charts/openebs/values.yaml
@@ -100,7 +100,7 @@ ndm:
     excludeVendors: "CLOUDBYT,OpenEBS"
     enablePathFilter: true
     includePaths: ""
-    excludePaths: "loop,fd0,sr0,/dev/ram,/dev/dm-,/dev/md,/dev/rbd-"
+    excludePaths: "loop,fd0,sr0,/dev/ram,/dev/dm-,/dev/md,/dev/rbd"
   probes:
     enableSeachest: false
   nodeSelector: {}

--- a/charts/openebs/values.yaml
+++ b/charts/openebs/values.yaml
@@ -100,7 +100,7 @@ ndm:
     excludeVendors: "CLOUDBYT,OpenEBS"
     enablePathFilter: true
     includePaths: ""
-    excludePaths: "loop,fd0,sr0,/dev/ram,/dev/dm-,/dev/md"
+    excludePaths: "loop,fd0,sr0,/dev/ram,/dev/dm-,/dev/md,/dev/rbd-"
   probes:
     enableSeachest: false
   nodeSelector: {}


### PR DESCRIPTION
For cluster operators who also run ceph within the cluster, this will stop /dev/rbd[0-9]+ devices being accidentally added as a block device

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/openebs]`)
