### PR TITLE
[stable/openebs] Add support to admission server to use hostNetwork

### DIFF
--- a/charts/openebs/Chart.yaml
+++ b/charts/openebs/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 1.12.1
+version: 1.12.2
 name: openebs
 appVersion: 1.12.0
 description: Containerized Storage for Containers

--- a/charts/openebs/README.md
+++ b/charts/openebs/README.md
@@ -75,6 +75,7 @@ The following table lists the configurable parameters of the OpenEBS chart and t
 | `webhook.image`                         | Image for admission server                    | `openebs/admission-server`                |
 | `webhook.imageTag`                      | Image Tag for admission server                | `1.12.0`                                  |
 | `webhook.replicas`                      | Number of admission server Replicas           | `1`                                       |
+| `webhook.hostNetwork`                   | Use hostNetwork in admission server           | `false`                                   |
 | `snapshotOperator.enabled`              | Enable Snapshot Provisioner                   | `true`                                    |
 | `snapshotOperator.provisioner.image`    | Image for Snapshot Provisioner                | `openebs/snapshot-provisioner`            |
 | `snapshotOperator.provisioner.imageTag` | Image Tag for Snapshot Provisioner            | `1.12.0`                                  |

--- a/charts/openebs/templates/deployment-admission-server.yaml
+++ b/charts/openebs/templates/deployment-admission-server.yaml
@@ -28,6 +28,9 @@ spec:
         openebs.io/version: {{ .Values.release.version }}
         openebs.io/component-name: admission-webhook
     spec:
+{{- if .Values.webhook.hostNetwork }}
+      hostNetwork: true
+{{- end }}
 {{- if .Values.webhook.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.webhook.nodeSelector | indent 8 }}

--- a/charts/openebs/values.yaml
+++ b/charts/openebs/values.yaml
@@ -137,6 +137,7 @@ webhook:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  hostNetwork: false
 
 jiva:
   image: "openebs/jiva"


### PR DESCRIPTION
#### Special notes for your reviewer:
This is added because in EKS there's some wierd network stuff that makes it necessary. See [this](https://docs.projectcalico.org/getting-started/kubernetes/managed-public-cloud/eks) the note at **Install EKS with Calico networking**. The extract is:

> Note: Calico networking cannot currently be installed on the EKS control plane nodes. As a result the control plane nodes will not be able to initiate network connections to Calico pods. (This is a general limitation of EKS’s custom networking support, not specific to Calico.) As a workaround, trusted pods that require control plane nodes to connect to them, such as those implementing admission controller webhooks, can include hostNetwork:true in their pod spec. See the Kuberentes API pod spec definition for more information on this setting.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. `[stable/openebs]`)
