### PR TITLE
fix(build): trim v from all image tags

### DIFF
--- a/scripts/release/buildscripts/push
+++ b/scripts/release/buildscripts/push
@@ -55,7 +55,11 @@ echo "Set the build/unique image tag as: ${BUILD_TAG}"
 
 function TagAndPushImage() {
   REPO="$1"
-  TAG="$2"
+  # Trim the `v` from the TAG if it exists
+  # Example: v1.10.0 maps to 1.10.0
+  # Example: 1.10.0 maps to 1.10.0
+  # Example: v1.10.0-custom maps to 1.10.0-custom
+  TAG="${2#v}"
 
   #Add an option to specify a custom TAG_SUFFIX 
   #via environment variable. Default is no tag.
@@ -87,7 +91,7 @@ then
     # Example: v1.10.0 maps to 1.10.0
     # Example: 1.10.0 maps to 1.10.0
     # Example: v1.10.0-custom maps to 1.10.0-custom
-    TagAndPushImage "${DIMAGE}" "${TRAVIS_TAG#v}"
+    TagAndPushImage "${DIMAGE}" "${TRAVIS_TAG}"
     TagAndPushImage "${DIMAGE}" "latest"
   fi;
 else
@@ -108,7 +112,7 @@ then
     # When github is tagged with a release, then Travis will
     # set the release tag in env TRAVIS_TAG
     # Trim the `v` from the TRAVIS_TAG if it exists
-    TagAndPushImage "quay.io/${DIMAGE}" "${TRAVIS_TAG#v}"
+    TagAndPushImage "quay.io/${DIMAGE}" "${TRAVIS_TAG}"
     TagAndPushImage "quay.io/${DIMAGE}" "latest"
   fi;
 else

--- a/scripts/release/buildscripts/push
+++ b/scripts/release/buildscripts/push
@@ -84,13 +84,6 @@ then
 
   if [ ! -z "${TRAVIS_TAG}" ] ;
   then
-    # Push with different tags if tagged as a release
-    # When github is tagged with a release, then Travis will
-    # set the release tag in env TRAVIS_TAG
-    # Trim the `v` from the TRAVIS_TAG if it exists
-    # Example: v1.10.0 maps to 1.10.0
-    # Example: 1.10.0 maps to 1.10.0
-    # Example: v1.10.0-custom maps to 1.10.0-custom
     TagAndPushImage "${DIMAGE}" "${TRAVIS_TAG}"
     TagAndPushImage "${DIMAGE}" "latest"
   fi;
@@ -108,10 +101,6 @@ then
 
   if [ ! -z "${TRAVIS_TAG}" ] ;
   then
-    # Push with different tags if tagged as a release
-    # When github is tagged with a release, then Travis will
-    # set the release tag in env TRAVIS_TAG
-    # Trim the `v` from the TRAVIS_TAG if it exists
     TagAndPushImage "quay.io/${DIMAGE}" "${TRAVIS_TAG}"
     TagAndPushImage "quay.io/${DIMAGE}" "latest"
   fi;


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

#### Special notes for your reviewer:
This PR fixes the push script for builds in openebs to remove the leading v from the image tags.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/openebs]`)
