### PR TITLE
chore(ndm): add ndm charts

### DIFF
--- a/charts/ndm/.helmignore
+++ b/charts/ndm/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/ndm/Chart.yaml
+++ b/charts/ndm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: openebs-ndm
-description: Disk inventory and management in Kubernetes cluster
+description: Kubernetes Storage Device Management. Also used to maintain the inventory of block devices.
 version: 0.8.0
 appVersion: 0.8.0
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/openebs/icon/color/openebs-icon-color.png
@@ -18,4 +18,6 @@ maintainers:
     email: kiran.mova@mayadata.io
   - name: prateekpandey14
     email: prateek.pandey@mayadata.io
+  - name: akhilerm
+    email: akhil.mohan@mayadata.io
 tillerVersion: ">=2.10.0"

--- a/charts/ndm/Chart.yaml
+++ b/charts/ndm/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 name: openebs-ndm
 description: Kubernetes Storage Device Management. Also used to maintain the inventory of block devices.
 version: 0.8.0
@@ -14,10 +14,9 @@ keywords:
 sources:
   - https://github.com/openebs/node-disk-manager
 maintainers:
+  - name: akhilerm
+    email: akhil.mohan@mayadata.io
   - name: kmova
     email: kiran.mova@mayadata.io
   - name: prateekpandey14
     email: prateek.pandey@mayadata.io
-  - name: akhilerm
-    email: akhil.mohan@mayadata.io
-tillerVersion: ">=2.10.0"

--- a/charts/ndm/Chart.yaml
+++ b/charts/ndm/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+name: openebs-ndm
+description: Disk inventory and management in Kubernetes cluster
+version: 0.8.0
+appVersion: 0.8.0
+icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/openebs/icon/color/openebs-icon-color.png
+home: http://www.openebs.io/
+keywords:
+  - cloud-native-storage
+  - block-storage
+  - ndm
+  - disk-inventory
+  - storage
+sources:
+  - https://github.com/openebs/node-disk-manager
+maintainers:
+  - name: kmova
+    email: kiran.mova@mayadata.io
+  - name: prateekpandey14
+    email: prateek.pandey@mayadata.io
+tillerVersion: ">=2.10.0"

--- a/charts/ndm/crds/blockdevice.yaml
+++ b/charts/ndm/crds/blockdevice.yaml
@@ -1,0 +1,39 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: blockdevices.openebs.io
+spec:
+  additionalPrinterColumns:
+    - JSONPath: .spec.nodeAttributes.nodeName
+      name: NodeName
+      type: string
+    - JSONPath: .spec.path
+      name: Path
+      priority: 1
+      type: string
+    - JSONPath: .spec.filesystem.fsType
+      name: FSType
+      priority: 1
+      type: string
+    - JSONPath: .spec.capacity.storage
+      name: Size
+      type: string
+    - JSONPath: .status.claimState
+      name: ClaimState
+      type: string
+    - JSONPath: .status.state
+      name: Status
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+  group: openebs.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    kind: BlockDevice
+    listKind: BlockDeviceList
+    plural: blockdevices
+    singular: blockdevice
+    shortNames:
+      - bd

--- a/charts/ndm/crds/blockdeviceclaim.yaml
+++ b/charts/ndm/crds/blockdeviceclaim.yaml
@@ -1,0 +1,25 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: blockdeviceclaims.openebs.io
+spec:
+  additionalPrinterColumns:
+    - JSONPath: .spec.blockDeviceName
+      name: BlockDeviceName
+      type: string
+    - JSONPath: .status.phase
+      name: Phase
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+  group: openebs.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    kind: BlockDeviceClaim
+    listKind: BlockDeviceClaimList
+    plural: blockdeviceclaims
+    shortNames:
+      - bdc
+    singular: blockdeviceclaim

--- a/charts/ndm/templates/_helpers.tpl
+++ b/charts/ndm/templates/_helpers.tpl
@@ -1,0 +1,134 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ndm.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ndm.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified ndm daemonset app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "ndm.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "ndmOperator.name" -}}
+{{- default .Values.ndmOperator.name .Values.ndmOperator.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified ndm operator app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "ndmOperator.fullname" -}}
+{{- if .Values.ndmOperator.fullnameOverride }}
+{{- .Values.ndmOperator.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Values.ndmOperator.name .Values.ndmOperator.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "ndm.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "ndm.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Define meta labels for ndm components
+*/}}
+{{- define "ndm.common.metaLabels" -}}
+chart: {{ template "ndm.chart" . }}
+heritage: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Define version label for ndm components
+*/}}
+{{- define "ndm.common.versionLabels" -}}
+openebs.io/version: {{ .Values.release.version | quote }}
+{{- end -}}
+
+{{/*
+Create match labels for ndm daemonset component
+*/}}
+{{- define "ndm.matchLabels" -}}
+app: {{ template "ndm.name" . }}
+release: {{ .Release.Name }}
+component: {{ .Values.ndm.componentName | quote }}
+{{- end -}}
+
+{{/*
+Create component labels for ndm daemonset component
+*/}}
+{{- define "ndm.componentLabels" -}}
+openebs.io/component-name: {{ .Values.ndm.componentName | quote }}
+{{- end -}}
+
+
+{{/*
+Create labels for ndm daemonset component
+*/}}
+{{- define "ndm.labels" -}}
+{{ include "ndm.common.metaLabels" . }}
+{{ include "ndm.common.versionLabels" . }}
+{{ include "ndm.matchLabels" . }}
+{{ include "ndm.componentLabels" . }}
+{{- end -}}
+
+{{/*
+Create match labels for ndm operator deployment
+*/}}
+{{- define "ndmOperator.matchLabels" -}}
+app: {{ template "ndmOperator.name" . }}
+release: {{ .Release.Name }}
+component: {{ .Values.ndmOperator.name | quote }}
+{{- end -}}
+
+{{/*
+Create component labels for ndm daemonset component
+*/}}
+{{- define "ndmOperator.componentLabels" -}}
+openebs.io/component-name: {{ .Values.ndmOperator.name | quote }}
+{{- end -}}
+
+
+{{/*
+Create labels for ndm daemonset component
+*/}}
+{{- define "ndmOperator.labels" -}}
+{{ include "ndm.common.metaLabels" . }}
+{{ include "ndm.common.versionLabels" . }}
+{{ include "ndmOperator.matchLabels" . }}
+{{ include "ndmOperator.componentLabels" . }}
+{{- end -}}

--- a/charts/ndm/templates/_helpers.tpl
+++ b/charts/ndm/templates/_helpers.tpl
@@ -70,14 +70,9 @@ Define meta labels for ndm components
 {{- define "ndm.common.metaLabels" -}}
 chart: {{ template "ndm.chart" . }}
 heritage: {{ .Release.Service }}
-{{- end -}}
-
-{{/*
-Define version label for ndm components
-*/}}
-{{- define "ndm.common.versionLabels" -}}
 openebs.io/version: {{ .Values.release.version | quote }}
 {{- end -}}
+
 
 {{/*
 Create match labels for ndm daemonset component
@@ -101,7 +96,6 @@ Create labels for ndm daemonset component
 */}}
 {{- define "ndm.labels" -}}
 {{ include "ndm.common.metaLabels" . }}
-{{ include "ndm.common.versionLabels" . }}
 {{ include "ndm.matchLabels" . }}
 {{ include "ndm.componentLabels" . }}
 {{- end -}}
@@ -128,7 +122,6 @@ Create labels for ndm daemonset component
 */}}
 {{- define "ndmOperator.labels" -}}
 {{ include "ndm.common.metaLabels" . }}
-{{ include "ndm.common.versionLabels" . }}
 {{ include "ndmOperator.matchLabels" . }}
 {{ include "ndmOperator.componentLabels" . }}
 {{- end -}}

--- a/charts/ndm/templates/_helpers.tpl
+++ b/charts/ndm/templates/_helpers.tpl
@@ -2,14 +2,14 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "ndm.name" -}}
+{{- define "openebs-ndm.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "ndm.chart" -}}
+{{- define "openebs-ndm.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
@@ -18,7 +18,7 @@ Create a default fully qualified ndm daemonset app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "ndm.fullname" -}}
+{{- define "openebs-ndm.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -31,7 +31,7 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 {{- end }}
 
-{{- define "ndmOperator.name" -}}
+{{- define "openebs-ndm.operator.name" -}}
 {{- default .Values.ndmOperator.name .Values.ndmOperator.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
@@ -40,7 +40,7 @@ Create a default fully qualified ndm operator app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "ndmOperator.fullname" -}}
+{{- define "openebs-ndm.operator.fullname" -}}
 {{- if .Values.ndmOperator.fullnameOverride }}
 {{- .Values.ndmOperator.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -56,9 +56,9 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create the name of the service account to use
 */}}
-{{- define "ndm.serviceAccountName" -}}
+{{- define "openebs-ndm.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "ndm.fullname" .) .Values.serviceAccount.name }}
+{{- default (include "openebs-ndm.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
@@ -67,8 +67,8 @@ Create the name of the service account to use
 {{/*
 Define meta labels for ndm components
 */}}
-{{- define "ndm.common.metaLabels" -}}
-chart: {{ template "ndm.chart" . }}
+{{- define "openebs-ndm.common.metaLabels" -}}
+chart: {{ template "openebs-ndm.chart" . }}
 heritage: {{ .Release.Service }}
 openebs.io/version: {{ .Values.release.version | quote }}
 {{- end -}}
@@ -77,8 +77,8 @@ openebs.io/version: {{ .Values.release.version | quote }}
 {{/*
 Create match labels for ndm daemonset component
 */}}
-{{- define "ndm.matchLabels" -}}
-app: {{ template "ndm.name" . }}
+{{- define "openebs-ndm.matchLabels" -}}
+app: {{ template "openebs-ndm.name" . }}
 release: {{ .Release.Name }}
 component: {{ .Values.ndm.componentName | quote }}
 {{- end -}}
@@ -86,7 +86,7 @@ component: {{ .Values.ndm.componentName | quote }}
 {{/*
 Create component labels for ndm daemonset component
 */}}
-{{- define "ndm.componentLabels" -}}
+{{- define "openebs-ndm.componentLabels" -}}
 openebs.io/component-name: {{ .Values.ndm.componentName | quote }}
 {{- end -}}
 
@@ -94,34 +94,34 @@ openebs.io/component-name: {{ .Values.ndm.componentName | quote }}
 {{/*
 Create labels for ndm daemonset component
 */}}
-{{- define "ndm.labels" -}}
-{{ include "ndm.common.metaLabels" . }}
-{{ include "ndm.matchLabels" . }}
-{{ include "ndm.componentLabels" . }}
+{{- define "openebs-ndm.labels" -}}
+{{ include "openebs-ndm.common.metaLabels" . }}
+{{ include "openebs-ndm.matchLabels" . }}
+{{ include "openebs-ndm.componentLabels" . }}
 {{- end -}}
 
 {{/*
 Create match labels for ndm operator deployment
 */}}
-{{- define "ndmOperator.matchLabels" -}}
-app: {{ template "ndmOperator.name" . }}
+{{- define "openebs-ndm.operator.matchLabels" -}}
+app: {{ template "openebs-ndm.operator.name" . }}
 release: {{ .Release.Name }}
 component: {{ .Values.ndmOperator.name | quote }}
 {{- end -}}
 
 {{/*
-Create component labels for ndm daemonset component
+Create component labels for ndm operator component
 */}}
-{{- define "ndmOperator.componentLabels" -}}
+{{- define "openebs-ndm.operator.componentLabels" -}}
 openebs.io/component-name: {{ .Values.ndmOperator.name | quote }}
 {{- end -}}
 
 
 {{/*
-Create labels for ndm daemonset component
+Create labels for ndm operator component
 */}}
-{{- define "ndmOperator.labels" -}}
-{{ include "ndm.common.metaLabels" . }}
-{{ include "ndmOperator.matchLabels" . }}
-{{ include "ndmOperator.componentLabels" . }}
+{{- define "openebs-ndm.operator.labels" -}}
+{{ include "openebs-ndm.common.metaLabels" . }}
+{{ include "openebs-ndm.operator.matchLabels" . }}
+{{ include "openebs-ndm.operator.componentLabels" . }}
 {{- end -}}

--- a/charts/ndm/templates/configmap.yaml
+++ b/charts/ndm/templates/configmap.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "ndm.fullname" . }}-config
+data:
+  # node-disk-manager-config contains config of available probes and filters.
+  # Probes and Filters will initialize with default values if config for that
+  # filter or probe are not present in configmap
+
+  # udev-probe is default or primary probe it should be enabled to run ndm
+  # filterconfigs contains configs of filters. To provide a group of include
+  # and exclude values add it as , separated string
+  node-disk-manager.config: |
+    probeconfigs:
+      - key: udev-probe
+        name: udev probe
+        state: {{ .Values.ndm.probes.enableUdevProbe }}
+      - key: seachest-probe
+        name: seachest probe
+        state: {{ .Values.ndm.probes.enableSeachest }}
+      - key: smart-probe
+        name: smart probe
+        state: {{ .Values.ndm.probes.enableSmartProbe }}
+    filterconfigs:
+      - key: os-disk-exclude-filter
+        name: os disk exclude filter
+        state: {{ .Values.ndm.filters.enableOsDiskExcludeFilter }}
+        exclude: "/,/etc/hosts,/boot"
+      - key: vendor-filter
+        name: vendor filter
+        state: {{ .Values.ndm.filters.enableVendorFilter }}
+        include: ""
+        exclude: "{{ .Values.ndm.filters.excludeVendors }}"
+      - key: path-filter
+        name: path filter
+        state: {{ .Values.ndm.filters.enablePathFilter }}
+        include: "{{ .Values.ndm.filters.includePaths }}"
+        exclude: "{{ .Values.ndm.filters.excludePaths }}"

--- a/charts/ndm/templates/configmap.yaml
+++ b/charts/ndm/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "ndm.fullname" . }}-config
+  name: {{ include "openebs-ndm.fullname" . }}-config
 data:
   # node-disk-manager-config contains config of available probes and filters.
   # Probes and Filters will initialize with default values if config for that

--- a/charts/ndm/templates/daemonset.yaml
+++ b/charts/ndm/templates/daemonset.yaml
@@ -1,0 +1,161 @@
+{{- if .Values.ndm.enabled }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ template "ndm.fullname" . }}
+  {{- if .Values.ndm.annotations }}
+  annotations:
+  {{ toYaml .Values.ndm.annotations | indent 4 }}
+  {{- end }}
+  labels:
+    {{- include "ndm.labels" . | nindent 4 }}
+spec:
+  updateStrategy:
+{{ toYaml .Values.ndm.updateStrategy | indent 4 }}
+  selector:
+    matchLabels:
+      {{- include "ndm.matchLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- if .Values.ndm.podAnnotations }}
+      annotations:
+      {{ toYaml .Values.ndm.podAnnotations | indent 8 }}
+      {{- end }}
+      labels:
+        {{- include "ndm.labels" . | nindent 8 }}
+        {{- if .Values.ndm.podLabels}}
+        {{ toYaml .Values.ndm.podLabels | nindent 8 }}
+        {{- end}}
+    spec:
+      serviceAccountName: {{ template "ndm.serviceAccountName" . }}
+      hostNetwork: true
+{{- if .Values.featureGates.enabled }}
+{{- if .Values.featureGates.APIService.enabled }}
+      hostPID: true
+{{- end}}
+{{- end}}
+      containers:
+      - name: {{ template "ndm.name" . }}
+        image: "{{ .Values.ndm.image.registry }}{{ .Values.ndm.image.repository }}:{{ .Values.ndm.image.tag }}"
+        args:
+          - -v=4
+{{- if .Values.featureGates.enabled }}
+{{- if .Values.featureGates.GPTBasedUUID.enabled }}
+          - --feature-gates={{ .Values.featureGates.GPTBasedUUID.featureGateFlag }}
+{{- end}}
+{{- if .Values.featureGates.APIService.enabled }}
+          - --feature-gates={{ .Values.featureGates.APIService.featureGateFlag }}
+{{- end}}
+{{- end}}
+        imagePullPolicy: {{ .Values.ndm.image.pullPolicy }}
+        securityContext:
+          privileged: true
+        env:
+        # namespace in which NDM is installed will be passed to NDM Daemonset
+        # as environment variable
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        # pass hostname as env variable using downward API to the NDM container
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+{{- if .Values.ndm.sparse }}
+{{- if .Values.ndm.sparse.path }}
+        # specify the directory where the sparse files need to be created.
+        # if not specified, then sparse files will not be created.
+        - name: SPARSE_FILE_DIR
+          value: "{{ .Values.ndm.sparse.path }}"
+{{- end }}
+{{- if .Values.ndm.sparse.size }}
+        # Size(bytes) of the sparse file to be created.
+        - name: SPARSE_FILE_SIZE
+          value: "{{ .Values.ndm.sparse.size }}"
+{{- end }}
+{{- if .Values.ndm.sparse.count }}
+        # Specify the number of sparse files to be created
+        - name: SPARSE_FILE_COUNT
+          value: "{{ .Values.ndm.sparse.count }}"
+{{- end }}
+{{- end }}
+        # Process name used for matching is limited to the 15 characters
+        # present in the pgrep output.
+        # So fullname can be used here with pgrep (cmd is < 15 chars).
+        livenessProbe:
+          exec:
+            command:
+            - pgrep
+            - "ndm"
+          initialDelaySeconds: {{ .Values.ndm.healthCheck.initialDelaySeconds }}
+          periodSeconds: {{ .Values.ndm.healthCheck.periodSeconds }}
+        volumeMounts:
+        - name: config
+          mountPath: /host/node-disk-manager.config
+          subPath: node-disk-manager.config
+          readOnly: true
+        - name: udev
+          mountPath: /run/udev
+        - name: procmount
+          mountPath: /host/proc
+          readOnly: true
+        - name: devmount
+          mountPath: /dev
+        - name: basepath
+          mountPath: /var/openebs/ndm
+{{- if .Values.ndm.sparse }}
+{{- if .Values.ndm.sparse.path }}
+        - name: sparsepath
+          mountPath: {{ .Values.ndm.sparse.path }}
+{{- end }}
+{{- end }}
+      volumes:
+      - name: config
+        configMap:
+          name: {{ include "ndm.fullname" . }}-config
+      - name: udev
+        hostPath:
+          path: /run/udev
+          type: Directory
+      # mount /proc (to access mount file of process 1 of host) inside container
+      # to read mount-point of disks and partitions
+      - name: procmount
+        hostPath:
+          path: /proc
+          type: Directory
+      - name: devmount
+      # the /dev directory is mounted so that we have access to the devices that
+      # are connected at runtime of the pod.
+        hostPath:
+          path: /dev
+          type: Directory
+      - name: basepath
+        hostPath:
+          path: "{{ .Values.varDirectoryPath.baseDir }}/ndm"
+          type: DirectoryOrCreate
+{{- if .Values.ndm.sparse }}
+{{- if .Values.ndm.sparse.path }}
+      - name: sparsepath
+        hostPath:
+          path: {{ .Values.ndm.sparse.path }}
+{{- end }}
+{{- end }}
+      # By default the node-disk-manager will be run on all kubernetes nodes
+      # If you would like to limit this to only some nodes, say the nodes
+      # that have storage attached, you could label those node and use
+      # nodeSelector.
+      #
+      # e.g. label the storage nodes with - "openebs.io/nodegroup"="storage-node"
+      # kubectl label node <node-name> "openebs.io/nodegroup"="storage-node"
+      #nodeSelector:
+      #  "openebs.io/nodegroup": "storage-node"
+{{- if .Values.ndm.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.ndm.nodeSelector | indent 8 }}
+{{- end }}
+{{- if .Values.ndm.tolerations }}
+      tolerations:
+{{ toYaml .Values.ndm.tolerations | indent 8 }}
+{{- end }}
+{{- end }}

--- a/charts/ndm/templates/daemonset.yaml
+++ b/charts/ndm/templates/daemonset.yaml
@@ -2,19 +2,19 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: {{ template "ndm.fullname" . }}
+  name: {{ template "openebs-ndm.fullname" . }}
   {{- if .Values.ndm.annotations }}
   annotations:
   {{ toYaml .Values.ndm.annotations | indent 4 }}
   {{- end }}
   labels:
-    {{- include "ndm.labels" . | nindent 4 }}
+    {{- include "openebs-ndm.labels" . | nindent 4 }}
 spec:
   updateStrategy:
 {{ toYaml .Values.ndm.updateStrategy | indent 4 }}
   selector:
     matchLabels:
-      {{- include "ndm.matchLabels" . | nindent 6 }}
+      {{- include "openebs-ndm.matchLabels" . | nindent 6 }}
   template:
     metadata:
       {{- if .Values.ndm.podAnnotations }}
@@ -22,12 +22,12 @@ spec:
       {{ toYaml .Values.ndm.podAnnotations | indent 8 }}
       {{- end }}
       labels:
-        {{- include "ndm.labels" . | nindent 8 }}
+        {{- include "openebs-ndm.labels" . | nindent 8 }}
         {{- if .Values.ndm.podLabels}}
         {{ toYaml .Values.ndm.podLabels | nindent 8 }}
         {{- end}}
     spec:
-      serviceAccountName: {{ template "ndm.serviceAccountName" . }}
+      serviceAccountName: {{ template "openebs-ndm.serviceAccountName" . }}
       hostNetwork: true
 {{- if .Values.featureGates.enabled }}
 {{- if .Values.featureGates.APIService.enabled }}
@@ -35,7 +35,7 @@ spec:
 {{- end}}
 {{- end}}
       containers:
-      - name: {{ template "ndm.name" . }}
+      - name: {{ template "openebs-ndm.name" . }}
         image: "{{ .Values.ndm.image.registry }}{{ .Values.ndm.image.repository }}:{{ .Values.ndm.image.tag }}"
         args:
           - -v=4
@@ -45,6 +45,7 @@ spec:
 {{- end}}
 {{- if .Values.featureGates.APIService.enabled }}
           - --feature-gates={{ .Values.featureGates.APIService.featureGateFlag }}
+          - --api-service-address={{ .Values.featureGates.APIService.address }}
 {{- end}}
 {{- end}}
         imagePullPolicy: {{ .Values.ndm.image.pullPolicy }}
@@ -113,7 +114,7 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: {{ include "ndm.fullname" . }}-config
+          name: {{ include "openebs-ndm.fullname" . }}-config
       - name: udev
         hostPath:
           path: /run/udev

--- a/charts/ndm/templates/deployment.yaml
+++ b/charts/ndm/templates/deployment.yaml
@@ -55,7 +55,7 @@ spec:
         - name: OPERATOR_NAME
           value: "node-disk-operator"
         - name: CLEANUP_JOB_IMAGE
-          value: "{{ .Values.cleanupUtil.image.registry }}{{ .Values.cleanupUtil.image.repository }}:{{ .Values.cleanupUtil.image.tag }}"
+          value: "{{ .Values.helperPod.image.registry }}{{ .Values.helperPod.image.repository }}:{{ .Values.helperPod.image.tag }}"
         # OPENEBS_IO_INSTALL_CRD environment variable is used to enable/disable CRD installation
         # from NDM Operator. By default the CRDs will be installed
         - name: OPENEBS_IO_INSTALL_CRD

--- a/charts/ndm/templates/deployment.yaml
+++ b/charts/ndm/templates/deployment.yaml
@@ -1,0 +1,81 @@
+{{- if .Values.ndmOperator.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "ndmOperator.fullname" . }}
+  {{- if .Values.ndmOperator.annotations }}
+  annotations:
+  {{ toYaml .Values.ndmOperator.annotations | indent 4 }}
+  {{- end }}
+  labels:
+    {{- include "ndmOperator.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.ndmOperator.replicas }}
+  strategy:
+    type: "Recreate"
+    rollingUpdate: null
+  selector:
+    matchLabels:
+      {{- include "ndmOperator.matchLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "ndmOperator.labels" . | nindent 8 }}
+        {{- if .Values.ndmOperator.podLabels}}
+        {{ toYaml .Values.ndmOperator.podLabels | nindent 8 }}
+        {{- end}}
+    spec:
+      serviceAccountName: {{ template "ndm.serviceAccountName" . }}
+      containers:
+      - name: {{ template "ndmOperator.fullname" . }}
+        image: "{{ .Values.ndmOperator.image.registry }}{{ .Values.ndmOperator.image.repository }}:{{ .Values.ndmOperator.image.tag }}"
+        imagePullPolicy: {{ .Values.ndmOperator.image.pullPolicy }}
+        readinessProbe:
+          exec:
+            command:
+            - stat
+            - /tmp/operator-sdk-ready
+          initialDelaySeconds: {{ .Values.ndmOperator.readinessCheck.initialDelaySeconds }}
+          periodSeconds: {{ .Values.ndmOperator.readinessCheck.periodSeconds }}
+          failureThreshold: {{ .Values.ndmOperator.readinessCheck.failureThreshold }}
+        env:
+        - name: WATCH_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: OPERATOR_NAME
+          value: "node-disk-operator"
+        - name: CLEANUP_JOB_IMAGE
+          value: "{{ .Values.cleanupUtil.image.registry }}{{ .Values.cleanupUtil.image.repository }}:{{ .Values.cleanupUtil.image.tag }}"
+        # OPENEBS_IO_INSTALL_CRD environment variable is used to enable/disable CRD installation
+        # from NDM Operator. By default the CRDs will be installed
+        - name: OPENEBS_IO_INSTALL_CRD
+          value: "{{ .Values.crd.enableInstall }}"
+        # Process name used for matching is limited to the 15 characters
+        # present in the pgrep output.
+        # So fullname can be used here with pgrep (cmd is < 15 chars).
+        livenessProbe:
+          exec:
+            command:
+            - pgrep
+            - "ndo"
+          initialDelaySeconds: {{ .Values.ndmOperator.healthCheck.initialDelaySeconds }}
+          periodSeconds: {{ .Values.ndmOperator.healthCheck.periodSeconds }}
+{{- if .Values.ndmOperator.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.ndmOperator.nodeSelector | indent 8 }}
+{{- end }}
+{{- if .Values.ndmOperator.tolerations }}
+      tolerations:
+{{ toYaml .Values.ndmOperator.tolerations | indent 8 }}
+{{- end }}
+{{- end }}

--- a/charts/ndm/templates/deployment.yaml
+++ b/charts/ndm/templates/deployment.yaml
@@ -3,13 +3,13 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "ndmOperator.fullname" . }}
+  name: {{ template "openebs-ndm.operator.fullname" . }}
   {{- if .Values.ndmOperator.annotations }}
   annotations:
   {{ toYaml .Values.ndmOperator.annotations | indent 4 }}
   {{- end }}
   labels:
-    {{- include "ndmOperator.labels" . | nindent 4 }}
+    {{- include "openebs-ndm.operator.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.ndmOperator.replicas }}
   strategy:
@@ -17,18 +17,18 @@ spec:
     rollingUpdate: null
   selector:
     matchLabels:
-      {{- include "ndmOperator.matchLabels" . | nindent 6 }}
+      {{- include "openebs-ndm.operator.matchLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "ndmOperator.labels" . | nindent 8 }}
+        {{- include "openebs-ndm.operator.labels" . | nindent 8 }}
         {{- if .Values.ndmOperator.podLabels}}
         {{ toYaml .Values.ndmOperator.podLabels | nindent 8 }}
         {{- end}}
     spec:
-      serviceAccountName: {{ template "ndm.serviceAccountName" . }}
+      serviceAccountName: {{ template "openebs-ndm.serviceAccountName" . }}
       containers:
-      - name: {{ template "ndmOperator.fullname" . }}
+      - name: {{ template "openebs-ndm.operator.fullname" . }}
         image: "{{ .Values.ndmOperator.image.registry }}{{ .Values.ndmOperator.image.repository }}:{{ .Values.ndmOperator.image.tag }}"
         imagePullPolicy: {{ .Values.ndmOperator.image.pullPolicy }}
         readinessProbe:

--- a/charts/ndm/templates/rbac.yaml
+++ b/charts/ndm/templates/rbac.yaml
@@ -2,13 +2,13 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "ndm.serviceAccountName" . }}
+  name: {{ include "openebs-ndm.serviceAccountName" . }}
 {{- end }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: {{ include "ndm.fullname" . }}
+  name: {{ include "openebs-ndm.fullname" . }}
 rules:
   - apiGroups: ["*"]
     resources: ["nodes", "pods", "events", "configmaps", "jobs"]
@@ -29,16 +29,16 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: {{ include "ndm.fullname" . }}
+  name: {{ include "openebs-ndm.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "ndm.serviceAccountName" . }}
+    name: {{ include "openebs-ndm.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
   - kind: User
     name: system:serviceaccount:default:default
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
-  name: {{ include "ndm.fullname" . }}
+  name: {{ include "openebs-ndm.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
 ---

--- a/charts/ndm/templates/rbac.yaml
+++ b/charts/ndm/templates/rbac.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "ndm.serviceAccountName" . }}
+{{- end }}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: {{ include "ndm.fullname" . }}
+rules:
+  - apiGroups: ["*"]
+    resources: ["nodes", "pods", "events", "configmaps", "jobs"]
+    verbs:
+      - '*'
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs:
+      - '*'
+  - apiGroups:
+      - openebs.io
+    resources:
+      - blockdevices
+      - blockdeviceclaims
+    verbs:
+      - '*'
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: {{ include "ndm.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "ndm.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+  - kind: User
+    name: system:serviceaccount:default:default
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: {{ include "ndm.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+---

--- a/charts/ndm/values.yaml
+++ b/charts/ndm/values.yaml
@@ -84,6 +84,7 @@ featureGates:
   APIService:
     enabled: true
     featureGateFlag: "APIService"
+    address: "0.0.0.0:9115"
 
 # Directory used by the OpenEBS to store debug information and so forth
 # that are generated in the course of running OpenEBS containers.

--- a/charts/ndm/values.yaml
+++ b/charts/ndm/values.yaml
@@ -1,0 +1,98 @@
+# Default values for ndm.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+release:
+  version: "0.8.0"
+ndm:
+  componentName: ndm
+  enabled: true
+  image:
+    # Make sure that registry name end with a '/'.
+    # For example : quay.io/ is a correct value here and quay.io is incorrect
+    registry:
+    repository: openebs/node-disk-manager
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: 0.8.0
+  sparse:
+    path: "/var/openebs/sparse"
+    size: "10737418240"
+    count: "0"
+  updateStrategy:
+    type: RollingUpdate
+  annotations: {}
+  podAnnotations: {}
+  ## Labels to be added to ndm daemonset pods
+  podLabels:
+    name: openebs-ndm
+  nodeSelector: {}
+  tolerations: []
+  filters:
+    enableOsDiskExcludeFilter: true
+    enableVendorFilter: true
+    excludeVendors: "CLOUDBYT,OpenEBS"
+    enablePathFilter: true
+    includePaths: ""
+    excludePaths: "loop,fd0,sr0,/dev/ram,/dev/dm-,/dev/md,/dev/rbd"
+  probes:
+    enableSeachest: true
+    enableUdevProbe: true
+    enableSmartProbe: true
+  healthCheck:
+    initialDelaySeconds: 30
+    periodSeconds: 60
+
+ndmOperator:
+  name: openebs-ndm-operator
+  enabled: true
+  image:
+    registry:
+    repository: openebs/node-disk-operator
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: 0.8.0
+  annotations: {}
+  podAnnotations: {}
+  nodeSelector: {}
+  tolerations: []
+  healthCheck:
+    initialDelaySeconds: 30
+    periodSeconds: 60
+  readinessCheck:
+    initialDelaySeconds: 4
+    periodSeconds: 10
+    failureThreshold: 1
+  replicas: 1
+  upgradeStrategy: Recreate
+
+cleanupUtil:
+  image:
+    registry:
+    repository: openebs/linux-utils
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: 2.0.0
+
+crd:
+  enableInstall: true
+
+featureGates:
+  enabled: true
+  GPTBasedUUID:
+    enabled: true
+    featureGateFlag: "GPTBasedUUID"
+  APIService:
+    enabled: true
+    featureGateFlag: "APIService"
+
+# Directory used by the OpenEBS to store debug information and so forth
+# that are generated in the course of running OpenEBS containers.
+varDirectoryPath:
+  baseDir: "/var/openebs"
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: openebs-ndm

--- a/charts/ndm/values.yaml
+++ b/charts/ndm/values.yaml
@@ -65,9 +65,9 @@ ndmOperator:
   replicas: 1
   upgradeStrategy: Recreate
 
-cleanupUtil:
+helperPod:
   image:
-    registry:
+    registry: ""
     repository: openebs/linux-utils
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.


### PR DESCRIPTION
This PR adds helm charts for standalone NDM installation.

NDM  component will have its own service account and RBAC. So following Kubernetes resource are 
created for NDM that is not shared with other OpenEBS components:
1. ClusterRole: ( Default name is `openebs-ndm`)
2. ClusterRoleBinding: ( Default name is `openebs-ndm`)
3. ServiceAccount : ( Default name is `openebs-ndm`)

NDM Daemonset default name : `openebs-ndm`
NDM deployment default name: `openebs-ndm-operator`
NDM configmap default name:  `openebs-ndm-config`

Signed-off-by: Ashutosh Kumar <ashutosh.kumar@mayadata.io>

#### Special notes for your reviewer:
- Currently, for this chart, the namespace where NDM needs to be deployed needs to be created prior.
(Need some discussion and should be fixed in this PR)

- There has been a change in match label selectors for the NDM pods. See following for the comparison 

**Older Helm Chart Based NDM Daemon Set:** 

```
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: {{ template "openebs.fullname" . }}-ndm
  labels:
    app: {{ template "openebs.name" . }}
    chart: {{ template "openebs.chart" . }}
    release: {{ .Release.Name }}
    heritage: {{ .Release.Service }}
    component: ndm
    openebs.io/component-name: ndm
    openebs.io/version: {{ .Values.release.version }}
spec:
  updateStrategy:
    type: "RollingUpdate"
  selector:
    matchLabels:
      app: {{ template "openebs.name" . }}
      release: {{ .Release.Name }}
      component: ndm
  template:
    metadata:
      labels:
        app: {{ template "openebs.name" . }}
        release: {{ .Release.Name }}
        component: ndm
        openebs.io/component-name: ndm
        name: openebs-ndm
        openebs.io/version: {{ .Values.release.version }}
```

**Current Helm Chart Based NDM Daemon Set:** 

```
apiVersion: apps/v1
kind: DaemonSet
metadata:
  annotations:
    deprecated.daemonset.template.generation: "1"
    meta.helm.sh/release-name: pascal
    meta.helm.sh/release-namespace: openebs
  creationTimestamp: "2020-08-26T15:28:33Z"
  generation: 1
  labels:
    app: openebs-ndm
    app.kubernetes.io/managed-by: Helm
    chart: openebs-ndm-0.8.0
    component: ndm
    heritage: Helm
    openebs.io/component-name: ndm
    openebs.io/version: 0.8.0
    release: pascal
spec:
  selector:
    matchLabels:
      app: openebs-ndm
      component: ndm
      release: pascal
  template:
    metadata:
      creationTimestamp: null
      labels:
        app: openebs-ndm
        chart: openebs-ndm-0.8.0
        component: ndm
        heritage: Helm
        name: openebs-ndm
        openebs.io/component-name: ndm
        openebs.io/version: 0.8.0
        release: pascal
```

**Older Helm Chart Based NDM Operator:** 

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: {{ template "openebs.fullname" . }}-ndm-operator
  labels:
    app: {{ template "openebs.name" . }}
    chart: {{ template "openebs.chart" . }}
    release: {{ .Release.Name }}
    heritage: {{ .Release.Service }}
    component: ndm-operator
    openebs.io/component-name: ndm-operator
    openebs.io/version: {{ .Values.release.version }}
    name: ndm-operator
spec:
  replicas: {{ .Values.ndmOperator.replicas }}
  strategy:
    type: "Recreate"
    rollingUpdate: null
  selector:
    matchLabels:
      app: {{ template "openebs.name" . }}
      release: {{ .Release.Name }}
  template:
    metadata:
      labels:
        app: {{ template "openebs.name" . }}
        release: {{ .Release.Name }}
        component: ndm-operator
        name: ndm-operator
        openebs.io/component-name: ndm-operator
        openebs.io/version: {{ .Values.release.version }}
```

**Current Helm Chart Based NDM operator:**

```
apiVersion: apps/v1
kind: Deployment
metadata:
  annotations:
    deployment.kubernetes.io/revision: "1"
    meta.helm.sh/release-name: pascal
    meta.helm.sh/release-namespace: openebs
  creationTimestamp: "2020-08-26T15:28:33Z"
  generation: 1
  labels:
    app: openebs-ndm-operator
    app.kubernetes.io/managed-by: Helm
    chart: openebs-ndm-0.8.0
    component: openebs-ndm-operator
    heritage: Helm
    openebs.io/component-name: openebs-ndm-operator
    openebs.io/version: 0.8.0
    release: pascal
spec:
  replicas: 1
  selector:
    matchLabels:
      app: openebs-ndm-operator
      component: openebs-ndm-operator
      release: pascal
  strategy:
    type: Recreate
  template:
    metadata:
      creationTimestamp: null
      labels:
        app: openebs-ndm-operator
        chart: openebs-ndm-0.8.0
        component: openebs-ndm-operator
        heritage: Helm
        openebs.io/component-name: openebs-ndm-operator
        openebs.io/version: 0.8.0
        release: pascal

``` 

**Notable Changes As Part of Best Practice:**
- The labels of ndm daemonset and ndm operator yaml comes from `helper.tpl`. This is more maintainable and less error prone.
- Clean up on image values is segregated in Values.yaml file.

#### Outputs ( Installing NDM ) 
```bash
$ kubectl create ns openebs
namespace/openebs created

$ kubectl get ns
NAME              STATUS   AGE
default           Active   97d
kube-node-lease   Active   97d
kube-public       Active   97d
kube-system       Active   97d
openebs           Active   7s

$ helm install pascal ./ndm
NAME: pascal
LAST DEPLOYED: Wed Aug 26 20:58:33 2020
NAMESPACE: openebs
STATUS: deployed
REVISION: 1
TEST SUITE: None
# Service Account
$ kubectl get sa -n openebs --show-labels
NAME          SECRETS   AGE    LABELS
default       1         8h     <none>
openebs-ndm   1         2m5s   app.kubernetes.io/managed-by=Helm

# Cluster Role
$ kubectl get clusterrole pascal-openebs-ndm --show-labels
NAME                 CREATED AT             LABELS
pascal-openebs-ndm   2020-08-26T15:28:33Z   app.kubernetes.io/managed-by=Helm

# Cluster Role Binding
$ kubectl get clusterrolebinding pascal-openebs-ndm --show-labels
NAME                 ROLE                             AGE     LABELS
pascal-openebs-ndm   ClusterRole/pascal-openebs-ndm   3m31s   app.kubernetes.io/managed-by=Helm

# CRDs
$ kubectl get crd
NAME                           CREATED AT
blockdeviceclaims.openebs.io   2020-08-26T14:59:29Z
blockdevices.openebs.io        2020-08-26T14:59:29Z

# NDM Daemonset
$ kubectl get ds -n openebs --show-labels
NAME                 DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE   LABELS
pascal-openebs-ndm   3         3         3       3            3           <none>          87s   app.kubernetes.io/managed-by=Helm,app=openebs-ndm,chart=openebs-ndm-0.8.0,component=ndm,heritage=Helm,openebs.io/component-name=ndm,openebs.io/version=0.8.0,release=pascal

# NDM operator
$ kubectl get deploy -n openebs --show-labels
NAME                          READY   UP-TO-DATE   AVAILABLE   AGE     LABELS
pascal-openebs-ndm-operator   1/1     1            1           6m14s   app.kubernetes.io/managed-by=Helm,app=openebs-ndm-operator,chart=openebs-ndm-0.8.0,component=openebs-ndm-operator,heritage=Helm,openebs.io/component-name=openebs-ndm-operator,openebs.io/version=0.8.0,release=pascal

# NDM Pods 
k8s@master1-ashutosh:~/go_projects/src/openebs/charts/charts$ kubectl get pod -n openebs --show-labels
NAME                                          READY   STATUS    RESTARTS   AGE   LABELS
pascal-openebs-ndm-dkxcf                      1/1     Running   0          7m    app=openebs-ndm,chart=openebs-ndm-0.8.0,component=ndm,controller-revision-hash=86589c47bc,heritage=Helm,name=openebs-ndm,openebs.io/component-name=ndm,openebs.io/version=0.8.0,pod-template-generation=1,release=pascal

pascal-openebs-ndm-gpg7v                      1/1     Running   0          7m    app=openebs-ndm,chart=openebs-ndm-0.8.0,component=ndm,controller-revision-hash=86589c47bc,heritage=Helm,name=openebs-ndm,openebs.io/component-name=ndm,openebs.io/version=0.8.0,pod-template-generation=1,release=pascal

pascal-openebs-ndm-operator-db6df758d-5wv7m   1/1     Running   0          7m    app=openebs-ndm-operator,chart=openebs-ndm-0.8.0,component=openebs-ndm-operator,heritage=Helm,openebs.io/component-name=openebs-ndm-operator,openebs.io/version=0.8.0,pod-template-hash=db6df758d,release=pascal

pascal-openebs-ndm-pk58h                      1/1     Running   0          7m    app=openebs-ndm,chart=openebs-ndm-0.8.0,component=ndm,controller-revision-hash=86589c47bc,heritage=Helm,name=openebs-ndm,openebs.io/component-name=ndm,openebs.io/version=0.8.0,pod-template-generation=1,release=pascal
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/openebs]`)
