### PR TITLE
chore(operator, yaml): add cstor operator 2.0.0

### DIFF
--- a/2.0.0/cstor-operator-2.0.0-RC1.yaml
+++ b/2.0.0/cstor-operator-2.0.0-RC1.yaml
@@ -742,7 +742,7 @@ metadata:
   labels:
     name: openebs-cstor-csi-controller
     openebs.io/component-name: openebs-cstor-csi-controller
-    openebs.io/version: dev
+    openebs.io/version: 2.0.0-RC1
 spec:
   selector:
     matchLabels:
@@ -759,7 +759,7 @@ spec:
         role: openebs-cstor-csi
         name: openebs-cstor-csi-controller
         openebs.io/component-name: openebs-cstor-csi-controller
-        openebs.io/version: dev
+        openebs.io/version: 2.0.0-RC1
     spec:
       priorityClassName: system-cluster-critical
       serviceAccount: openebs-cstor-csi-controller-sa
@@ -1003,7 +1003,7 @@ metadata:
     app: openebs-cstor-csi-node
     name: openebs-cstor-csi-node
     openebs.io/component-name: openebs-cstor-csi-node
-    openebs.io/version: dev
+    openebs.io/version: 2.0.0-RC1
 spec:
   selector:
     matchLabels:
@@ -1018,7 +1018,7 @@ spec:
         role: openebs-cstor-csi
         name: openebs-cstor-csi-node
         openebs.io/component-name: openebs-cstor-csi-node
-        openebs.io/version: dev
+        openebs.io/version: 2.0.0-RC1
     spec:
       priorityClassName: system-node-critical
       serviceAccount: openebs-cstor-csi-node-sa

--- a/2.0.0/cstor-operator-2.0.0-RC1.yaml
+++ b/2.0.0/cstor-operator-2.0.0-RC1.yaml
@@ -1,0 +1,3924 @@
+# Create the OpenEBS namespace
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openebs
+---
+# Create Maya Service Account
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openebs-maya-operator
+  namespace: openebs
+---
+# Define Role that allows operations on K8s pods/deployments
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: openebs-cstor-operator
+rules:
+- apiGroups: ["*"]
+  resources: ["nodes", "nodes/proxy"]
+  verbs: ["*"]
+- apiGroups: ["*"]
+  resources: ["namespaces", "services", "pods", "deployments", "deployments/finalizers", "replicationcontrollers", "replicasets", "events", "endpoints", "configmaps", "secrets", "jobs", "cronjobs"]
+  verbs: ["*"]
+- apiGroups: ["*"]
+  resources: ["statefulsets", "daemonsets"]
+  verbs: ["*"]
+- apiGroups: ["*"]
+  resources: ["resourcequotas", "limitranges"]
+  verbs: ["list", "watch"]
+- apiGroups: ["*"]
+  resources: ["certificatesigningrequests"]
+  verbs: ["list", "watch"]
+- apiGroups: ["*"]
+  resources: ["storageclasses", "persistentvolumeclaims", "persistentvolumes"]
+  verbs: ["*"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: [ "get", "list", "create", "update", "delete", "patch"]
+- apiGroups: ["openebs.io"]
+  resources: ["*"]
+  verbs: ["*" ]
+- apiGroups: ["cstor.openebs.io"]
+  resources: ["*"]
+  verbs: ["*" ]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "watch", "list", "delete", "update", "create"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
+  verbs: ["get", "create", "list", "delete", "update", "patch"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+- apiGroups: ["*"]
+  resources: ["upgradetasks"]
+  verbs: ["*"]
+- apiGroups: ["*"]
+  resources: ["poddisruptionbudgets"]
+  verbs: ["get", "list", "create", "delete", "watch"]
+---
+# Bind the Service Account with the Role Privileges.
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: openebs-cstor-operator
+subjects:
+- kind: ServiceAccount
+  name: openebs-maya-operator
+  namespace: openebs
+roleRef:
+  kind: ClusterRole
+  name: openebs-cstor-operator
+  apiGroup: rbac.authorization.k8s.io
+---
+# Define Role that allows operations required for migration of snapshots
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: openebs-cstor-migration
+rules:
+- apiGroups: ["snapshot.storage.k8s.io"]
+  resources: ["volumesnapshotclasses"]
+  verbs: ["get", "list"]
+- apiGroups: ["snapshot.storage.k8s.io"]
+  resources: ["volumesnapshotcontents"]
+  verbs: ["create", "get", "list"]
+- apiGroups: ["snapshot.storage.k8s.io"]
+  resources: ["volumesnapshots"]
+  verbs: ["create", "get", "list"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: openebs-cstor-migration
+subjects:
+- kind: ServiceAccount
+  name: openebs-maya-operator
+  namespace: openebs
+roleRef:
+  kind: ClusterRole
+  name: openebs-cstor-migration
+  apiGroup: rbac.authorization.k8s.io
+---
+# This manifest deploys the OpenEBS CStor and CSI control plane components,
+# with associated CRs & RBAC rules. This manifest has been verified
+# only with different linux flavours and linux distros
+#
+# For supporting a differnet OS other than the above,
+# 1) Get the list of shared object files required for iscsiadm binary in that OS version.
+# 2) Check which files are already present in the cstor-csi-driver container present in csi node pod.
+# 3) Mount the required missing files inside the container.
+#
+####################################################
+###########                             ############
+###########  CSI Node and Driver CRDs   ############
+###########                             ############
+####################################################
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: csinodeinfos.csi.storage.k8s.io
+spec:
+  group: csi.storage.k8s.io
+  names:
+    kind: CSINodeInfo
+    plural: csinodeinfos
+  scope: Cluster
+  validation:
+    openAPIV3Schema:
+      properties:
+        csiDrivers:
+          description: List of CSI drivers running on the node and their properties.
+          items:
+            properties:
+              driver:
+                description: The CSI driver that this object refers to.
+                type: string
+              nodeID:
+                description: The node from the driver point of view.
+                type: string
+              topologyKeys:
+                description: List of keys supported by the driver.
+                items:
+                  type: string
+                type: array
+          type: array
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cstorvolumeattachments.cstor.openebs.io
+spec:
+  group: cstor.openebs.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: cstorvolumeattachments
+    singular: cstorvolumeattachment
+    kind: CStorVolumeAttachment
+    shortNames:
+    - cstorvolumeattachment
+    - cva
+---
+##############################################
+###########                       ############
+###########   Snapshot CRDs       ############
+###########                       ############
+##############################################
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: volumesnapshotclasses.snapshot.storage.k8s.io
+spec:
+  group: snapshot.storage.k8s.io
+  names:
+    kind: VolumeSnapshotClass
+    listKind: VolumeSnapshotClassList
+    plural: volumesnapshotclasses
+    singular: volumesnapshotclass
+  scope: Cluster
+# this field is supported in kubernetes 1.15+
+# https://v1-15.docs.kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/
+#preserveUnknownFields: false
+  validation:
+    openAPIV3Schema:
+      description: VolumeSnapshotClass specifies parameters that a underlying storage
+        system uses when creating a volume snapshot. A specific VolumeSnapshotClass
+        is used by specifying its name in a VolumeSnapshot object. VolumeSnapshotClasses
+        are non-namespaced
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        deletionPolicy:
+          description: deletionPolicy determines whether a VolumeSnapshotContent created
+            through the VolumeSnapshotClass should be deleted when its bound VolumeSnapshot
+            is deleted. Supported values are "Retain" and "Delete". "Retain" means
+            that the VolumeSnapshotContent and its physical snapshot on underlying
+            storage system are kept. "Delete" means that the VolumeSnapshotContent
+            and its physical snapshot on underlying storage system are deleted. Required.
+          enum:
+          - Delete
+          - Retain
+          type: string
+        driver:
+          description: driver is the name of the storage driver that handles this
+            VolumeSnapshotClass. Required.
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        parameters:
+          additionalProperties:
+            type: string
+          description: parameters is a key-value map with storage driver specific
+            parameters for creating snapshots. These values are opaque to Kubernetes.
+          type: object
+      required:
+      - deletionPolicy
+      - driver
+      type: object
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: volumesnapshotcontents.snapshot.storage.k8s.io
+spec:
+  group: snapshot.storage.k8s.io
+  names:
+    kind: VolumeSnapshotContent
+    listKind: VolumeSnapshotContentList
+    plural: volumesnapshotcontents
+    singular: volumesnapshotcontent
+  scope: Cluster
+  subresources:
+    status: {}
+# this field is supported in kubernetes 1.15+
+# https://v1-15.docs.kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/
+#preserveUnknownFields: false
+  validation:
+    openAPIV3Schema:
+      description: VolumeSnapshotContent represents the actual "on-disk" snapshot
+        object in the underlying storage system
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        spec:
+          description: spec defines properties of a VolumeSnapshotContent created
+            by the underlying storage system. Required.
+          properties:
+            deletionPolicy:
+              description: deletionPolicy determines whether this VolumeSnapshotContent
+                and its physical snapshot on the underlying storage system should
+                be deleted when its bound VolumeSnapshot is deleted. Supported values
+                are "Retain" and "Delete". "Retain" means that the VolumeSnapshotContent
+                and its physical snapshot on underlying storage system are kept. "Delete"
+                means that the VolumeSnapshotContent and its physical snapshot on
+                underlying storage system are deleted. In dynamic snapshot creation
+                case, this field will be filled in with the "DeletionPolicy" field
+                defined in the VolumeSnapshotClass the VolumeSnapshot refers to. For
+                pre-existing snapshots, users MUST specify this field when creating
+                the VolumeSnapshotContent object. Required.
+              enum:
+              - Delete
+              - Retain
+              type: string
+            driver:
+              description: driver is the name of the CSI driver used to create the
+                physical snapshot on the underlying storage system. This MUST be the
+                same as the name returned by the CSI GetPluginName() call for that
+                driver. Required.
+              type: string
+            source:
+              description: source specifies from where a snapshot will be created.
+                This field is immutable after creation. Required.
+              properties:
+                snapshotHandle:
+                  description: snapshotHandle specifies the CSI "snapshot_id" of a
+                    pre-existing snapshot on the underlying storage system. This field
+                    is immutable.
+                  type: string
+                volumeHandle:
+                  description: volumeHandle specifies the CSI "volume_id" of the volume
+                    from which a snapshot should be dynamically taken from. This field
+                    is immutable.
+                  type: string
+              type: object
+            volumeSnapshotClassName:
+              description: name of the VolumeSnapshotClass to which this snapshot
+                belongs.
+              type: string
+            volumeSnapshotRef:
+              description: volumeSnapshotRef specifies the VolumeSnapshot object to
+                which this VolumeSnapshotContent object is bound. VolumeSnapshot.Spec.VolumeSnapshotContentName
+                field must reference to this VolumeSnapshotContent's name for the
+                bidirectional binding to be valid. For a pre-existing VolumeSnapshotContent
+                object, name and namespace of the VolumeSnapshot object MUST be provided
+                for binding to happen. This field is immutable after creation. Required.
+              properties:
+                apiVersion:
+                  description: API version of the referent.
+                  type: string
+                fieldPath:
+                  description: 'If referring to a piece of an object instead of an
+                    entire object, this string should contain a valid JSON/Go field
+                    access statement, such as desiredState.manifest.containers[2].
+                    For example, if the object reference is to a container within
+                    a pod, this would take on a value like: "spec.containers{name}"
+                    (where "name" refers to the name of the container that triggered
+                    the event) or if no container name is specified "spec.containers[2]"
+                    (container with index 2 in this pod). This syntax is chosen only
+                    to have some well-defined way of referencing a part of an object.
+                    TODO: this design is not final and this field is subject to change
+                    in the future.'
+                  type: string
+                kind:
+                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+                resourceVersion:
+                  description: 'Specific resourceVersion to which this reference is
+                    made, if any. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                  type: string
+                uid:
+                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                  type: string
+              type: object
+          required:
+          - deletionPolicy
+          - driver
+          - source
+          - volumeSnapshotRef
+          type: object
+        status:
+          description: status represents the current information of a snapshot.
+          properties:
+            creationTime:
+              description: creationTime is the timestamp when the point-in-time snapshot
+                is taken by the underlying storage system. In dynamic snapshot creation
+                case, this field will be filled in with the "creation_time" value
+                returned from CSI "CreateSnapshotRequest" gRPC call. For a pre-existing
+                snapshot, this field will be filled with the "creation_time" value
+                returned from the CSI "ListSnapshots" gRPC call if the driver supports
+                it. If not specified, it indicates the creation time is unknown. The
+                format of this field is a Unix nanoseconds time encoded as an int64.
+                On Unix, the command `date +%s%N` returns the current time in nanoseconds
+                since 1970-01-01 00:00:00 UTC.
+              format: int64
+              type: integer
+            error:
+              description: error is the latest observed error during snapshot creation,
+                if any.
+              properties:
+                message:
+                  description: 'message is a string detailing the encountered error
+                    during snapshot creation if specified. NOTE: message may be logged,
+                    and it should not contain sensitive information.'
+                  type: string
+                time:
+                  description: time is the timestamp when the error was encountered.
+                  format: date-time
+                  type: string
+              type: object
+            readyToUse:
+              description: readyToUse indicates if a snapshot is ready to be used
+                to restore a volume. In dynamic snapshot creation case, this field
+                will be filled in with the "ready_to_use" value returned from CSI
+                "CreateSnapshotRequest" gRPC call. For a pre-existing snapshot, this
+                field will be filled with the "ready_to_use" value returned from the
+                CSI "ListSnapshots" gRPC call if the driver supports it, otherwise,
+                this field will be set to "True". If not specified, it means the readiness
+                of a snapshot is unknown.
+              type: boolean
+            restoreSize:
+              description: restoreSize represents the complete size of the snapshot
+                in bytes. In dynamic snapshot creation case, this field will be filled
+                in with the "size_bytes" value returned from CSI "CreateSnapshotRequest"
+                gRPC call. For a pre-existing snapshot, this field will be filled
+                with the "size_bytes" value returned from the CSI "ListSnapshots"
+                gRPC call if the driver supports it. When restoring a volume from
+                this snapshot, the size of the volume MUST NOT be smaller than the
+                restoreSize if it is specified, otherwise the restoration will fail.
+                If not specified, it indicates that the size is unknown.
+              format: int64
+              minimum: 0
+              type: integer
+            snapshotHandle:
+              description: snapshotHandle is the CSI "snapshot_id" of a snapshot on
+                the underlying storage system. If not specified, it indicates that
+                dynamic snapshot creation has either failed or it is still in progress.
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: volumesnapshots.snapshot.storage.k8s.io
+spec:
+  group: snapshot.storage.k8s.io
+  names:
+    kind: VolumeSnapshot
+    listKind: VolumeSnapshotList
+    plural: volumesnapshots
+    singular: volumesnapshot
+  scope: Namespaced
+  subresources:
+    status: {}
+# this field is supported in kubernetes 1.15+
+# https://v1-15.docs.kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/
+#preserveUnknownFields: false
+  validation:
+    openAPIV3Schema:
+      description: VolumeSnapshot is a user's request for either creating a point-in-time
+        snapshot of a persistent volume, or binding to a pre-existing snapshot.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        spec:
+          description: 'spec defines the desired characteristics of a snapshot requested
+            by a user. More info: https://kubernetes.io/docs/concepts/storage/volume-snapshots#volumesnapshots
+            Required.'
+          properties:
+            source:
+              description: source specifies where a snapshot will be created from.
+                This field is immutable after creation. Required.
+              properties:
+                persistentVolumeClaimName:
+                  description: persistentVolumeClaimName specifies the name of the
+                    PersistentVolumeClaim object in the same namespace as the VolumeSnapshot
+                    object where the snapshot should be dynamically taken from. This
+                    field is immutable.
+                  type: string
+                volumeSnapshotContentName:
+                  description: volumeSnapshotContentName specifies the name of a pre-existing
+                    VolumeSnapshotContent object. This field is immutable.
+                  type: string
+              type: object
+            volumeSnapshotClassName:
+              description: 'volumeSnapshotClassName is the name of the VolumeSnapshotClass
+                requested by the VolumeSnapshot. If not specified, the default snapshot
+                class will be used if one exists. If not specified, and there is no
+                default snapshot class, dynamic snapshot creation will fail. Empty
+                string is not allowed for this field. TODO(xiangqian): a webhook validation
+                on empty string. More info: https://kubernetes.io/docs/concepts/storage/volume-snapshot-classes'
+              type: string
+          required:
+          - source
+          type: object
+        status:
+          description: 'status represents the current information of a snapshot. NOTE:
+            status can be modified by sources other than system controllers, and must
+            not be depended upon for accuracy. Controllers should only use information
+            from the VolumeSnapshotContent object after verifying that the binding
+            is accurate and complete.'
+          properties:
+            boundVolumeSnapshotContentName:
+              description: 'boundVolumeSnapshotContentName represents the name of
+                the VolumeSnapshotContent object to which the VolumeSnapshot object
+                is bound. If not specified, it indicates that the VolumeSnapshot object
+                has not been successfully bound to a VolumeSnapshotContent object
+                yet. NOTE: Specified boundVolumeSnapshotContentName alone does not
+                mean binding       is valid. Controllers MUST always verify bidirectional
+                binding between       VolumeSnapshot and VolumeSnapshotContent to
+                avoid possible security issues.'
+              type: string
+            creationTime:
+              description: creationTime is the timestamp when the point-in-time snapshot
+                is taken by the underlying storage system. In dynamic snapshot creation
+                case, this field will be filled in with the "creation_time" value
+                returned from CSI "CreateSnapshotRequest" gRPC call. For a pre-existing
+                snapshot, this field will be filled with the "creation_time" value
+                returned from the CSI "ListSnapshots" gRPC call if the driver supports
+                it. If not specified, it indicates that the creation time of the snapshot
+                is unknown.
+              format: date-time
+              type: string
+            error:
+              description: error is the last observed error during snapshot creation,
+                if any. This field could be helpful to upper level controllers(i.e.,
+                application controller) to decide whether they should continue on
+                waiting for the snapshot to be created based on the type of error
+                reported.
+              properties:
+                message:
+                  description: 'message is a string detailing the encountered error
+                    during snapshot creation if specified. NOTE: message may be logged,
+                    and it should not contain sensitive information.'
+                  type: string
+                time:
+                  description: time is the timestamp when the error was encountered.
+                  format: date-time
+                  type: string
+              type: object
+            readyToUse:
+              description: readyToUse indicates if a snapshot is ready to be used
+                to restore a volume. In dynamic snapshot creation case, this field
+                will be filled in with the "ready_to_use" value returned from CSI
+                "CreateSnapshotRequest" gRPC call. For a pre-existing snapshot, this
+                field will be filled with the "ready_to_use" value returned from the
+                CSI "ListSnapshots" gRPC call if the driver supports it, otherwise,
+                this field will be set to "True". If not specified, it means the readiness
+                of a snapshot is unknown.
+              type: boolean
+            restoreSize:
+              description: restoreSize represents the complete size of the snapshot
+                in bytes. In dynamic snapshot creation case, this field will be filled
+                in with the "size_bytes" value returned from CSI "CreateSnapshotRequest"
+                gRPC call. For a pre-existing snapshot, this field will be filled
+                with the "size_bytes" value returned from the CSI "ListSnapshots"
+                gRPC call if the driver supports it. When restoring a volume from
+                this snapshot, the size of the volume MUST NOT be smaller than the
+                restoreSize if it is specified, otherwise the restoration will fail.
+                If not specified, it indicates that the size is unknown.
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+
+apiVersion: storage.k8s.io/v1beta1
+kind: CSIDriver
+metadata:
+  name: cstor.csi.openebs.io
+spec:
+  # Supports persistent inline volumes.
+  volumeLifecycleModes:
+  - Persistent
+  # To determine at runtime which mode a volume uses, pod info and its
+  # "csi.storage.k8s.io/ephemeral" entry are needed.
+  podInfoOnMount: true
+  attachRequired: true
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-csi-snapshotter-binding
+subjects:
+  - kind: ServiceAccount
+    name: openebs-cstor-csi-controller-sa
+    namespace: openebs
+roleRef:
+  kind: ClusterRole
+  name: openebs-cstor-csi-snapshotter-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-csi-snapshotter-role
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents/status"]
+    verbs: ["update"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots/status"]
+    verbs: ["update"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["create", "list", "watch", "delete", "get", "update"]
+
+---
+##############################################
+###########                       ############
+###########   Controller plugin   ############
+###########                       ############
+##############################################
+
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: openebs-cstor-csi-controller-sa
+  namespace: openebs
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-csi-provisioner-role
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes", "services"]
+    verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses", "csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["get", "list"]
+
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["*"]
+  - apiGroups: ["*"]
+    resources: ["cstorvolumeattachments", "cstorvolumes","cstorvolumeconfigs"]
+    verbs: ["*"]
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-csi-provisioner-binding
+subjects:
+  - kind: ServiceAccount
+    name: openebs-cstor-csi-controller-sa
+    namespace: openebs
+roleRef:
+  kind: ClusterRole
+  name: openebs-cstor-csi-provisioner-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: openebs-cstor-csi-controller
+  namespace: openebs
+  labels:
+    name: openebs-cstor-csi-controller
+    openebs.io/component-name: openebs-cstor-csi-controller
+    openebs.io/version: dev
+spec:
+  selector:
+    matchLabels:
+      app: openebs-cstor-csi-controller
+      role: openebs-cstor-csi
+      name: openebs-cstor-csi-controller
+      openebs.io/component-name: openebs-cstor-csi-controller
+  serviceName: "openebs-csi"
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: openebs-cstor-csi-controller
+        role: openebs-cstor-csi
+        name: openebs-cstor-csi-controller
+        openebs.io/component-name: openebs-cstor-csi-controller
+        openebs.io/version: dev
+    spec:
+      priorityClassName: system-cluster-critical
+      serviceAccount: openebs-cstor-csi-controller-sa
+      containers:
+        - name: csi-resizer
+          image: quay.io/k8scsi/csi-resizer:v0.4.0
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+            - "--leader-election"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: csi-snapshotter
+          image: quay.io/k8scsi/csi-snapshotter:v2.0.1
+          args:
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: snapshot-controller
+          image: quay.io/k8scsi/snapshot-controller:v2.0.1
+          args:
+            - "--v=5"
+            - "--leader-election=false"
+          imagePullPolicy: IfNotPresent
+        - name: csi-provisioner
+          image: quay.io/k8scsi/csi-provisioner:v1.6.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--provisioner=cstor.csi.openebs.io"
+            - "--csi-address=$(ADDRESS)"
+            - "--v=5"
+            - "--feature-gates=Topology=true"
+            - "--extra-create-metadata=true"
+          env:
+            - name: MY_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: csi-attacher
+          image: quay.io/k8scsi/csi-attacher:v2.0.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: csi-cluster-driver-registrar
+          image: quay.io/k8scsi/csi-cluster-driver-registrar:v1.0.1
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--v=5"
+            - "--driver-requires-attachment=true"
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: cstor-csi-plugin
+          image: openebs/cstor-csi-driver:2.0.0-RC1
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: OPENEBS_CONTROLLER_DRIVER
+              value: controller
+            - name: OPENEBS_CSI_ENDPOINT
+              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+            - name: OPENEBS_CSI_API_URL
+              value: https://openebs.io
+              # OpenEBS namespace where the openebs cstor operator components
+              # has been installed
+            - name: OPENEBS_NAMESPACE
+              value: openebs
+          args :
+            - "--endpoint=$(OPENEBS_CSI_ENDPOINT)"
+            - "--url=$(OPENEBS_CSI_API_URL)"
+            - "--plugin=$(OPENEBS_CONTROLLER_DRIVER)"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+      volumes:
+        - name: socket-dir
+          emptyDir: {}
+---
+
+############################## CSI- Attacher #######################
+# Attacher must be able to work with PVs, nodes and VolumeAttachments
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-csi-attacher-role
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csinodeinfos"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments", "csinodes"]
+    verbs: ["get", "list", "watch", "update"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-csi-attacher-binding
+subjects:
+  - kind: ServiceAccount
+    name: openebs-cstor-csi-controller-sa
+    namespace: openebs
+roleRef:
+  kind: ClusterRole
+  name: openebs-cstor-csi-attacher-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-csi-cluster-registrar-role
+rules:
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csidrivers"]
+    verbs: ["create", "delete"]
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-csi-cluster-registrar-binding
+subjects:
+  - kind: ServiceAccount
+    name: openebs-cstor-csi-controller-sa
+    namespace: openebs
+roleRef:
+  kind: ClusterRole
+  name: openebs-cstor-csi-cluster-registrar-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+########################################
+###########                 ############
+###########   Node plugin   ############
+###########                 ############
+########################################
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openebs-cstor-csi-node-sa
+  namespace: openebs
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-csi-registrar-role
+rules:
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes", "nodes", "services"]
+    verbs: ["get", "list", "patch"]
+  - apiGroups: ["*"]
+    resources: ["cstorvolumeattachments", "cstorvolumes","cstorvolumeconfigs"]
+    verbs: ["get", "list", "watch", "create", "update", "delete", "patch"]
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-csi-registrar-binding
+subjects:
+  - kind: ServiceAccount
+    name: openebs-cstor-csi-node-sa
+    namespace: openebs
+roleRef:
+  kind: ClusterRole
+  name: openebs-cstor-csi-registrar-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: openebs-cstor-csi-iscsiadm
+  namespace: openebs
+data:
+  iscsiadm: |
+    #!/bin/sh
+    if [ -x /host/sbin/iscsiadm ]; then
+      chroot /host /sbin/iscsiadm "$@"
+    elif [ -x /host/usr/local/sbin/iscsiadm ]; then
+      chroot /host /usr/local/sbin/iscsiadm "$@"
+    elif [ -x /host/bin/iscsiadm ]; then
+      chroot /host /bin/iscsiadm "$@"
+    elif [ -x /host/usr/local/bin/iscsiadm ]; then
+      chroot /host /usr/local/bin/iscsiadm "$@"
+    else
+      chroot /host iscsiadm "$@"
+    fi
+
+---
+
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: openebs-cstor-csi-node
+  namespace: openebs
+  labels:
+    app: openebs-cstor-csi-node
+    name: openebs-cstor-csi-node
+    openebs.io/component-name: openebs-cstor-csi-node
+    openebs.io/version: dev
+spec:
+  selector:
+    matchLabels:
+      app: openebs-cstor-csi-node
+      role: openebs-cstor-csi
+      name: openebs-cstor-csi-node
+      openebs.io/component-name: openebs-cstor-csi-node
+  template:
+    metadata:
+      labels:
+        app: openebs-cstor-csi-node
+        role: openebs-cstor-csi
+        name: openebs-cstor-csi-node
+        openebs.io/component-name: openebs-cstor-csi-node
+        openebs.io/version: dev
+    spec:
+      priorityClassName: system-node-critical
+      serviceAccount: openebs-cstor-csi-node-sa
+      hostNetwork: true
+      containers:
+        - name: csi-node-driver-registrar
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.0.1
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+            - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "rm -rf /registration/cstor.csi.openebs.io /registration/cstor.csi.openebs.io-reg.sock"]
+          env:
+            - name: ADDRESS
+              value: /plugin/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: /var/lib/kubelet/plugins/cstor.csi.openebs.io/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: NODE_DRIVER
+              value: openebs-cstor-csi
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /plugin
+            - name: registration-dir
+              mountPath: /registration
+        - name: cstor-csi-plugin
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["CAP_MKNOD", "CAP_SYS_ADMIN", "SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+          image: openebs/cstor-csi-driver:2.0.0-RC1
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--nodeid=$(OPENEBS_NODE_ID)"
+            - "--endpoint=$(OPENEBS_CSI_ENDPOINT)"
+            - "--url=$(OPENEBS_CSI_API_URL)"
+            - "--plugin=$(OPENEBS_NODE_DRIVER)"
+          env:
+            - name: OPENEBS_NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: OPENEBS_CSI_ENDPOINT
+              value: unix:///plugin/csi.sock
+            - name: OPENEBS_NODE_DRIVER
+              value: node
+            - name: OPENEBS_CSI_API_URL
+              value: https://openebs.io
+              # OpenEBS namespace where the openebs cstor operator components
+              # has been installed
+            - name: OPENEBS_NAMESPACE
+              value: openebs
+              # Enable/Disable auto-remount feature, when volumes
+              # recovers form the read-only state
+            - name: REMOUNT
+              value: "false"
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /plugin
+            - name: device-dir
+              mountPath: /dev
+            - name: pods-mount-dir
+              mountPath: /var/lib/kubelet/
+              # needed so that any mounts setup inside this container are
+              # propagated back to the host machine.
+              mountPropagation: "Bidirectional"
+            - name: host-root
+              mountPath: /host
+              mountPropagation: "HostToContainer"
+            - name: chroot-iscsiadm
+              mountPath: /sbin/iscsiadm
+              subPath: iscsiadm
+      volumes:
+        - name: device-dir
+          hostPath:
+            path: /dev
+            type: Directory
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry/
+            type: DirectoryOrCreate
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/cstor.csi.openebs.io/
+            type: DirectoryOrCreate
+        - name: pods-mount-dir
+          hostPath:
+            path: /var/lib/kubelet/
+            type: Directory
+        - name: chroot-iscsiadm
+          configMap:
+            defaultMode: 0555
+            name: openebs-cstor-csi-iscsiadm
+        - name: host-root
+          hostPath:
+            path: /
+            type: Directory
+---
+###########################################################################
+####                                                                   ####
+####                     CStor-Operator yaml                           ####
+####                                                                   ####
+###########################################################################
+#
+#
+###########################################################################
+#                                                                       ###
+#                        CStorPoolCluster CRD                           ###
+#                                                                       ###
+###########################################################################
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  name: cstorpoolclusters.cstor.openebs.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.healthyInstances
+    description: The number of healthy cStorPoolInstances
+    name: HealthyInstances
+    type: integer
+  - JSONPath: .status.provisionedInstances
+    description: The number of provisioned cStorPoolInstances
+    name: ProvisionedInstances
+    type: integer
+  - JSONPath: .status.desiredInstances
+    description: The number of desired cStorPoolInstances
+    name: DesiredInstances
+    type: integer
+  - JSONPath: .metadata.creationTimestamp
+    description: Age of CStorPoolCluster
+    name: Age
+    type: date
+  group: cstor.openebs.io
+  names:
+    kind: CStorPoolCluster
+    listKind: CStorPoolClusterList
+    plural: cstorpoolclusters
+    shortNames:
+    - cspc
+    singular: cstorpoolcluster
+  preserveUnknownFields: false
+  scope: Namespaced
+  subresources: {}
+  validation:
+    openAPIV3Schema:
+      description: CStorPoolCluster describes a CStorPoolCluster custom resource.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: CStorPoolClusterSpec is the spec for a CStorPoolClusterSpec
+            resource
+          properties:
+            auxResources:
+              description: AuxResources are the compute resources required by the
+                cstor-pool pod side car containers.
+              nullable: true
+              properties:
+                limits:
+                  additionalProperties:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: 'Limits describes the maximum amount of compute resources
+                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+                requests:
+                  additionalProperties:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: 'Requests describes the minimum amount of compute resources
+                    required. If Requests is omitted for a container, it defaults
+                    to Limits if that is explicitly specified, otherwise to an implementation-defined
+                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+              type: object
+            pools:
+              description: Pools is the spec for pools for various nodes where it
+                should be created.
+              items:
+                description: PoolSpec is the spec for pool on node where it should
+                  be created.
+                properties:
+                  dataRaidGroups:
+                    description: DataRaidGroups is the raid group configuration for
+                      the given pool.
+                    items:
+                      description: RaidGroup contains the details of a raid group
+                        for the pool
+                      properties:
+                        blockDevices:
+                          items:
+                            description: CStorPoolInstanceBlockDevice contains the
+                              details of block devices that constitutes a raid group.
+                            properties:
+                              blockDeviceName:
+                                description: BlockDeviceName is the name of the block
+                                  device.
+                                type: string
+                              capacity:
+                                description: Capacity is the capacity of the block
+                                  device. It is system generated
+                                format: int64
+                                type: integer
+                              devLink:
+                                description: DevLink is the dev link for block devices
+                                type: string
+                            required:
+                            - blockDeviceName
+                            type: object
+                          type: array
+                      required:
+                      - blockDevices
+                      type: object
+                    type: array
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: NodeSelector is the labels that will be used to select
+                      a node for pool provisioning. Required field
+                    type: object
+                  poolConfig:
+                    description: PoolConfig is the default pool config that applies
+                      to the pool on node.
+                    properties:
+                      auxResources:
+                        description: AuxResources are the compute resources required
+                          by the cstor-pool pod side car containers.
+                        nullable: true
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                        type: object
+                      compression:
+                        description: 'Compression to enable compression Optional --
+                          defaults to off Possible values : lz, off'
+                        type: string
+                      dataRaidGroupType:
+                        description: DataRaidGroupType is the  raid type.
+                        type: string
+                      priorityClassName:
+                        description: PriorityClassName if specified applies to this
+                          pool pod If left empty, DefaultPriorityClassName is applied.
+                          (See CStorPoolClusterSpec.DefaultPriorityClassName) If both
+                          are empty, not priority class is applied.
+                        nullable: true
+                        type: string
+                      resources:
+                        description: Resources are the compute resources required
+                          by the cstor-pool container.
+                        nullable: true
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                        type: object
+                      roThresholdLimit:
+                        description: 'ROThresholdLimit is threshold(percentage base)
+                          limit for pool read only mode. If ROThresholdLimit(%) amount
+                          of pool storage is reached then pool will set to readonly.
+                          NOTE: 1. If ROThresholdLimit is set to 100 then entire    pool
+                          storage will be used by default it will be set to 85%. 2.
+                          ROThresholdLimit value will be 0 <= ROThresholdLimit <=
+                          100.'
+                        nullable: true
+                        type: integer
+                      thickProvision:
+                        description: ThickProvision to enable thick provisioning Optional
+                          -- defaults to false
+                        type: boolean
+                      tolerations:
+                        description: Tolerations, if specified, the pool pod's tolerations.
+                        items:
+                          description: The pod this Toleration is attached to tolerates
+                            any taint that matches the triple <key,value,effect> using
+                            the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match.
+                                Empty means match all taint effects. When specified,
+                                allowed values are NoSchedule, PreferNoSchedule and
+                                NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration
+                                applies to. Empty means match all taint keys. If the
+                                key is empty, operator must be Exists; this combination
+                                means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship
+                                to the value. Valid operators are Exists and Equal.
+                                Defaults to Equal. Exists is equivalent to wildcard
+                                for value, so that a pod can tolerate all taints of
+                                a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period
+                                of time the toleration (which must be of effect NoExecute,
+                                otherwise this field is ignored) tolerates the taint.
+                                By default, it is not set, which means tolerate the
+                                taint forever (do not evict). Zero and negative values
+                                will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration
+                                matches to. If the operator is Exists, the value should
+                                be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        nullable: true
+                        type: array
+                      writeCacheGroupType:
+                        description: WriteCacheGroupType is the write cache raid type.
+                        type: string
+                    required:
+                    - dataRaidGroupType
+                    type: object
+                  writeCacheRaidGroups:
+                    description: WriteCacheRaidGroups is the write cache raid group.
+                    items:
+                      description: RaidGroup contains the details of a raid group
+                        for the pool
+                      properties:
+                        blockDevices:
+                          items:
+                            description: CStorPoolInstanceBlockDevice contains the
+                              details of block devices that constitutes a raid group.
+                            properties:
+                              blockDeviceName:
+                                description: BlockDeviceName is the name of the block
+                                  device.
+                                type: string
+                              capacity:
+                                description: Capacity is the capacity of the block
+                                  device. It is system generated
+                                format: int64
+                                type: integer
+                              devLink:
+                                description: DevLink is the dev link for block devices
+                                type: string
+                            required:
+                            - blockDeviceName
+                            type: object
+                          type: array
+                      required:
+                      - blockDevices
+                      type: object
+                    nullable: true
+                    type: array
+                required:
+                - dataRaidGroups
+                - nodeSelector
+                type: object
+              type: array
+            priorityClassName:
+              description: DefaultPriorityClassName if specified applies to all the
+                pool pods in the pool spec if the priorityClass at the pool level
+                is not specified.
+              type: string
+            resources:
+              description: DefaultResources are the compute resources required by
+                the cstor-pool container. If the resources at PoolConfig is not specified,
+                this is written to CSPI PoolConfig.
+              nullable: true
+              properties:
+                limits:
+                  additionalProperties:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: 'Limits describes the maximum amount of compute resources
+                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+                requests:
+                  additionalProperties:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: 'Requests describes the minimum amount of compute resources
+                    required. If Requests is omitted for a container, it defaults
+                    to Limits if that is explicitly specified, otherwise to an implementation-defined
+                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+              type: object
+            tolerations:
+              description: Tolerations, if specified, are the pool pod's tolerations
+                If tolerations at PoolConfig is empty, this is written to CSPI PoolConfig.
+              items:
+                description: The pod this Toleration is attached to tolerates any
+                  taint that matches the triple <key,value,effect> using the matching
+                  operator <operator>.
+                properties:
+                  effect:
+                    description: Effect indicates the taint effect to match. Empty
+                      means match all taint effects. When specified, allowed values
+                      are NoSchedule, PreferNoSchedule and NoExecute.
+                    type: string
+                  key:
+                    description: Key is the taint key that the toleration applies
+                      to. Empty means match all taint keys. If the key is empty, operator
+                      must be Exists; this combination means to match all values and
+                      all keys.
+                    type: string
+                  operator:
+                    description: Operator represents a key's relationship to the value.
+                      Valid operators are Exists and Equal. Defaults to Equal. Exists
+                      is equivalent to wildcard for value, so that a pod can tolerate
+                      all taints of a particular category.
+                    type: string
+                  tolerationSeconds:
+                    description: TolerationSeconds represents the period of time the
+                      toleration (which must be of effect NoExecute, otherwise this
+                      field is ignored) tolerates the taint. By default, it is not
+                      set, which means tolerate the taint forever (do not evict).
+                      Zero and negative values will be treated as 0 (evict immediately)
+                      by the system.
+                    format: int64
+                    type: integer
+                  value:
+                    description: Value is the taint value the toleration matches to.
+                      If the operator is Exists, the value should be empty, otherwise
+                      just a regular string.
+                    type: string
+                type: object
+              nullable: true
+              type: array
+          type: object
+        status:
+          description: CStorPoolClusterStatus represents the latest available observations
+            of a CSPC's current state.
+          properties:
+            conditions:
+              description: Current state of CSPC.
+              items:
+                description: CStorPoolClusterCondition describes the state of a CSPC
+                  at a certain point.
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    description: The last time this condition was updated.
+                    format: date-time
+                    type: string
+                  message:
+                    description: A human readable message indicating details about
+                      the transition.
+                    type: string
+                  reason:
+                    description: The reason for the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of CSPC condition.
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              nullable: true
+              type: array
+            desiredInstances:
+              description: DesiredInstances is the number of CSPI(s) that should be
+                provisioned.
+              format: int32
+              nullable: true
+              type: integer
+            healthyInstances:
+              description: HealthyInstances is the number of CSPI(s) that are healthy.
+              format: int32
+              nullable: true
+              type: integer
+            provisionedInstances:
+              description: ProvisionedInstances is the the number of CSPI present
+                at the current state.
+              format: int32
+              nullable: true
+              type: integer
+          type: object
+        versionDetails:
+          description: VersionDetails provides the details for upgrade
+          properties:
+            autoUpgrade:
+              description: If AutoUpgrade is set to true then the resource is upgraded
+                automatically without any manual steps
+              type: boolean
+            desired:
+              description: Desired is the version that we want to upgrade or the control
+                plane version
+              type: string
+            status:
+              description: Status gives the status of reconciliation triggered when
+                the desired and current version are not same
+              properties:
+                current:
+                  description: Current is the version of resource
+                  type: string
+                dependentsUpgraded:
+                  description: DependentsUpgraded gives the details whether all children
+                    of a resource are upgraded to desired version or not
+                  type: boolean
+                lastUpdateTime:
+                  description: LastUpdateTime is the time the status was last  updated
+                  format: date-time
+                  nullable: true
+                  type: string
+                message:
+                  description: Message is a human readable message if some error occurs
+                  type: string
+                reason:
+                  description: Reason is the actual reason for the error state
+                  type: string
+                state:
+                  description: State is the state of reconciliation
+                  type: string
+              type: object
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+################################################################################
+###                                                                         ####
+###                       CStorPoolInstance CRD                             ####
+###                                                                         ####
+################################################################################
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  name: cstorpoolinstances.cstor.openebs.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.hostName
+    description: Host name where cstorpool instances scheduled
+    name: HostName
+    type: string
+  - JSONPath: .status.capacity.used
+    description: The amount of storage space within the pool that has been physically
+      allocated
+    name: Allocated
+    type: string
+  - JSONPath: .status.capacity.free
+    description: The amount of usable free space available in the pool
+    name: Free
+    type: string
+  - JSONPath: .status.capacity.total
+    description: Total amount of usable space in pool
+    name: Capacity
+    type: string
+  - JSONPath: .status.readOnly
+    description: Identifies the pool read only mode
+    name: ReadOnly
+    type: boolean
+  - JSONPath: .status.provisionedReplicas
+    description: Represents no.of replicas present in the pool
+    name: ProvisionedReplicas
+    type: integer
+  - JSONPath: .status.healthyReplicas
+    description: Represents no.of healthy replicas present in the pool
+    name: HealthyReplicas
+    type: integer
+  - JSONPath: .spec.poolConfig.dataRaidGroupType
+    description: Represents the type of the storage pool
+    name: Type
+    type: string
+  - JSONPath: .status.phase
+    description: Identifies the current health of the pool
+    name: Status
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: Age of CStorPoolInstance
+    name: Age
+    type: date
+  group: cstor.openebs.io
+  names:
+    kind: CStorPoolInstance
+    listKind: CStorPoolInstanceList
+    plural: cstorpoolinstances
+    shortNames:
+    - cspi
+    singular: cstorpoolinstance
+  preserveUnknownFields: false
+  scope: Namespaced
+  subresources: {}
+  validation:
+    openAPIV3Schema:
+      description: CStorPoolInstance describes a cstor pool instance resource.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: Spec is the specification of the cstorpoolinstance resource.
+          properties:
+            dataRaidGroups:
+              description: DataRaidGroups is the raid group configuration for the
+                given pool.
+              items:
+                description: RaidGroup contains the details of a raid group for the
+                  pool
+                properties:
+                  blockDevices:
+                    items:
+                      description: CStorPoolInstanceBlockDevice contains the details
+                        of block devices that constitutes a raid group.
+                      properties:
+                        blockDeviceName:
+                          description: BlockDeviceName is the name of the block device.
+                          type: string
+                        capacity:
+                          description: Capacity is the capacity of the block device.
+                            It is system generated
+                          format: int64
+                          type: integer
+                        devLink:
+                          description: DevLink is the dev link for block devices
+                          type: string
+                      required:
+                      - blockDeviceName
+                      type: object
+                    type: array
+                required:
+                - blockDevices
+                type: object
+              type: array
+            hostName:
+              description: HostName is the name of kubernetes node where the pool
+                should be created.
+              type: string
+            nodeSelector:
+              additionalProperties:
+                type: string
+              description: NodeSelector is the labels that will be used to select
+                a node for pool provisioning. Required field
+              type: object
+            poolConfig:
+              description: PoolConfig is the default pool config that applies to the
+                pool on node.
+              properties:
+                auxResources:
+                  description: AuxResources are the compute resources required by
+                    the cstor-pool pod side car containers.
+                  nullable: true
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                  type: object
+                compression:
+                  description: 'Compression to enable compression Optional -- defaults
+                    to off Possible values : lz, off'
+                  type: string
+                dataRaidGroupType:
+                  description: DataRaidGroupType is the  raid type.
+                  type: string
+                priorityClassName:
+                  description: PriorityClassName if specified applies to this pool
+                    pod If left empty, DefaultPriorityClassName is applied. (See CStorPoolClusterSpec.DefaultPriorityClassName)
+                    If both are empty, not priority class is applied.
+                  nullable: true
+                  type: string
+                resources:
+                  description: Resources are the compute resources required by the
+                    cstor-pool container.
+                  nullable: true
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                  type: object
+                roThresholdLimit:
+                  description: 'ROThresholdLimit is threshold(percentage base) limit
+                    for pool read only mode. If ROThresholdLimit(%) amount of pool
+                    storage is reached then pool will set to readonly. NOTE: 1. If
+                    ROThresholdLimit is set to 100 then entire    pool storage will
+                    be used by default it will be set to 85%. 2. ROThresholdLimit
+                    value will be 0 <= ROThresholdLimit <= 100.'
+                  nullable: true
+                  type: integer
+                thickProvision:
+                  description: ThickProvision to enable thick provisioning Optional
+                    -- defaults to false
+                  type: boolean
+                tolerations:
+                  description: Tolerations, if specified, the pool pod's tolerations.
+                  items:
+                    description: The pod this Toleration is attached to tolerates
+                      any taint that matches the triple <key,value,effect> using the
+                      matching operator <operator>.
+                    properties:
+                      effect:
+                        description: Effect indicates the taint effect to match. Empty
+                          means match all taint effects. When specified, allowed values
+                          are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                      key:
+                        description: Key is the taint key that the toleration applies
+                          to. Empty means match all taint keys. If the key is empty,
+                          operator must be Exists; this combination means to match
+                          all values and all keys.
+                        type: string
+                      operator:
+                        description: Operator represents a key's relationship to the
+                          value. Valid operators are Exists and Equal. Defaults to
+                          Equal. Exists is equivalent to wildcard for value, so that
+                          a pod can tolerate all taints of a particular category.
+                        type: string
+                      tolerationSeconds:
+                        description: TolerationSeconds represents the period of time
+                          the toleration (which must be of effect NoExecute, otherwise
+                          this field is ignored) tolerates the taint. By default,
+                          it is not set, which means tolerate the taint forever (do
+                          not evict). Zero and negative values will be treated as
+                          0 (evict immediately) by the system.
+                        format: int64
+                        type: integer
+                      value:
+                        description: Value is the taint value the toleration matches
+                          to. If the operator is Exists, the value should be empty,
+                          otherwise just a regular string.
+                        type: string
+                    type: object
+                  nullable: true
+                  type: array
+                writeCacheGroupType:
+                  description: WriteCacheGroupType is the write cache raid type.
+                  type: string
+              required:
+              - dataRaidGroupType
+              type: object
+            writeCacheRaidGroups:
+              description: WriteCacheRaidGroups is the write cache raid group.
+              items:
+                description: RaidGroup contains the details of a raid group for the
+                  pool
+                properties:
+                  blockDevices:
+                    items:
+                      description: CStorPoolInstanceBlockDevice contains the details
+                        of block devices that constitutes a raid group.
+                      properties:
+                        blockDeviceName:
+                          description: BlockDeviceName is the name of the block device.
+                          type: string
+                        capacity:
+                          description: Capacity is the capacity of the block device.
+                            It is system generated
+                          format: int64
+                          type: integer
+                        devLink:
+                          description: DevLink is the dev link for block devices
+                          type: string
+                      required:
+                      - blockDeviceName
+                      type: object
+                    type: array
+                required:
+                - blockDevices
+                type: object
+              nullable: true
+              type: array
+          required:
+          - dataRaidGroups
+          - nodeSelector
+          type: object
+        status:
+          description: Status is the possible statuses of the cstorpoolinstance resource.
+          properties:
+            capacity:
+              description: Capacity describes the capacity details of a cstor pool
+              properties:
+                free:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  description: Amount of usable space in the pool after excluding
+                    metadata and raid parity
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                total:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  description: Sum of usable capacity in all the data raidgroups
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                used:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  description: Amount of physical data (and its metadata) written
+                    to pool after applying compression, etc..,
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                zfs:
+                  description: ZFSCapacityAttributes contains advanced information
+                    about pool capacity details
+                  properties:
+                    logicalUsed:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: LogicalUsed is the amount of space that is "logically"
+                        consumed by this pool and all its descendents. The logical
+                        space ignores the effect of the compression and copies properties,
+                        giving a quantity closer to the amount of data that applications
+                        see. However, it does include space consumed by metadata.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  required:
+                  - logicalUsed
+                  type: object
+              required:
+              - free
+              - total
+              - used
+              - zfs
+              type: object
+            conditions:
+              description: Current state of CSPI with details.
+              items:
+                description: CSPIConditionType describes the state of a CSPI at a
+                  certain point.
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    description: The last time this condition was updated.
+                    format: date-time
+                    type: string
+                  message:
+                    description: A human readable message indicating details about
+                      the transition.
+                    type: string
+                  reason:
+                    description: The reason for the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of CSPC condition.
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+            healthyReplicas:
+              description: HealthyReplicas describes the total count of healthy Volume
+                Replicas in the cstor pool
+              format: int32
+              type: integer
+            phase:
+              description: ' The phase of a CStorPool is a simple, high-level summary
+                of the pool state on the  node.'
+              type: string
+            provisionedReplicas:
+              description: ProvisionedReplicas describes the total count of Volume
+                Replicas present in the cstor pool
+              format: int32
+              type: integer
+            readOnly:
+              description: ReadOnly if pool is readOnly or not
+              type: boolean
+          type: object
+        versionDetails:
+          description: VersionDetails is the openebs version.
+          properties:
+            autoUpgrade:
+              description: If AutoUpgrade is set to true then the resource is upgraded
+                automatically without any manual steps
+              type: boolean
+            desired:
+              description: Desired is the version that we want to upgrade or the control
+                plane version
+              type: string
+            status:
+              description: Status gives the status of reconciliation triggered when
+                the desired and current version are not same
+              properties:
+                current:
+                  description: Current is the version of resource
+                  type: string
+                dependentsUpgraded:
+                  description: DependentsUpgraded gives the details whether all children
+                    of a resource are upgraded to desired version or not
+                  type: boolean
+                lastUpdateTime:
+                  description: LastUpdateTime is the time the status was last  updated
+                  format: date-time
+                  nullable: true
+                  type: string
+                message:
+                  description: Message is a human readable message if some error occurs
+                  type: string
+                reason:
+                  description: Reason is the actual reason for the error state
+                  type: string
+                state:
+                  description: State is the state of reconciliation
+                  type: string
+              type: object
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+#########################################################################
+####                                                                #####
+####                         CStorVolumeConfig CRD                  #####
+####                                                                #####
+#########################################################################
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  name: cstorvolumeconfigs.cstor.openebs.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.capacity.storage
+    description: Identifies the volume capacity
+    name: Capacity
+    type: string
+  - JSONPath: .status.phase
+    description: Identifies the volume provisioning status
+    name: Status
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: Age of CStorVolumeReplica
+    name: Age
+    type: date
+  group: cstor.openebs.io
+  names:
+    kind: CStorVolumeConfig
+    listKind: CStorVolumeConfigList
+    plural: cstorvolumeconfigs
+    shortNames:
+    - cvc
+    singular: cstorvolumeconfig
+  preserveUnknownFields: false
+  scope: Namespaced
+  subresources: {}
+  validation:
+    openAPIV3Schema:
+      description: CStorVolumeConfig describes a cstor volume config resource created
+        as custom resource. CStorVolumeConfig is a request for creating cstor volume
+        related resources like deployment, svc etc.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        publish:
+          description: Publish contains info related to attachment of a volume to
+            a node. i.e. NodeId etc.
+          properties:
+            nodeId:
+              description: NodeID contains publish info related to attachment of a
+                volume to a node.
+              type: string
+          type: object
+        spec:
+          description: Spec defines a specification of a cstor volume config required
+            to provisione cstor volume resources
+          properties:
+            capacity:
+              additionalProperties:
+                anyOf:
+                - type: integer
+                - type: string
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+              description: Capacity represents the actual resources of the underlying
+                cstor volume.
+              type: object
+            cstorVolumeRef:
+              description: CStorVolumeRef has the information about where CstorVolumeClaim
+                is created from.
+              properties:
+                apiVersion:
+                  description: API version of the referent.
+                  type: string
+                fieldPath:
+                  description: 'If referring to a piece of an object instead of an
+                    entire object, this string should contain a valid JSON/Go field
+                    access statement, such as desiredState.manifest.containers[2].
+                    For example, if the object reference is to a container within
+                    a pod, this would take on a value like: "spec.containers{name}"
+                    (where "name" refers to the name of the container that triggered
+                    the event) or if no container name is specified "spec.containers[2]"
+                    (container with index 2 in this pod). This syntax is chosen only
+                    to have some well-defined way of referencing a part of an object.
+                    TODO: this design is not final and this field is subject to change
+                    in the future.'
+                  type: string
+                kind:
+                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+                resourceVersion:
+                  description: 'Specific resourceVersion to which this reference is
+                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                  type: string
+                uid:
+                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                  type: string
+              type: object
+            cstorVolumeSource:
+              description: CStorVolumeSource contains the source volumeName@snapShotname
+                combaination.  This will be filled only if it is a clone creation.
+              type: string
+            policy:
+              description: Policy contains volume specific required policies target
+                and replicas
+              properties:
+                provision:
+                  description: replicaAffinity is set to true then volume replica
+                    resources need to be distributed across the pool instances
+                  properties:
+                    blockSize:
+                      description: BlockSize is the logical block size in multiple
+                        of 512 bytes BlockSize specifies the block size of the volume.
+                        The blocksize cannot be changed once the volume has been written,
+                        so it should be set at volume creation time. The default blocksize
+                        for volumes is 4 Kbytes. Any power of 2 from 512 bytes to
+                        128 Kbytes is valid.
+                      format: int32
+                      type: integer
+                    replicaAffinity:
+                      description: replicaAffinity is set to true then volume replica
+                        resources need to be distributed across the cstor pool instances
+                        based on the given topology
+                      type: boolean
+                  required:
+                  - replicaAffinity
+                  type: object
+                replica:
+                  description: ReplicaSpec represents configuration related to replicas
+                    resources
+                  properties:
+                    compression:
+                      description: The zle compression algorithm compresses runs of
+                        zeros.
+                      type: string
+                    zvolWorkers:
+                      description: IOWorkers represents number of threads that executes
+                        client IOs
+                      type: string
+                  type: object
+                replicaPoolInfo:
+                  description: 'ReplicaPoolInfo holds the pool information of volume
+                    replicas. Ex: If volume is provisioned on which CStor pool volume
+                    replicas exist'
+                  items:
+                    description: ReplicaPoolInfo represents the pool information of
+                      volume replica
+                    properties:
+                      poolName:
+                        description: PoolName represents the pool name where volume
+                          replica exists
+                        type: string
+                    required:
+                    - poolName
+                    type: object
+                  type: array
+                target:
+                  description: TargetSpec represents configuration related to cstor
+                    target and its resources
+                  properties:
+                    affinity:
+                      description: PodAffinity if specified, are the target pod's
+                        affinities
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          description: The scheduler will prefer to schedule pods
+                            to nodes that satisfy the affinity expressions specified
+                            by this field, but it may choose a node that violates
+                            one or more of the expressions. The node that is most
+                            preferred is the one with the greatest sum of weights,
+                            i.e. for each node that meets all of the scheduling requirements
+                            (resource request, requiredDuringScheduling affinity expressions,
+                            etc.), compute a sum by iterating through the elements
+                            of this field and adding "weight" to the sum if the node
+                            has pods which matches the corresponding podAffinityTerm;
+                            the node(s) with the highest sum are the most preferred.
+                          items:
+                            description: The weights of all of the matched WeightedPodAffinityTerm
+                              fields are added per-node to find the most preferred
+                              node(s)
+                            properties:
+                              podAffinityTerm:
+                                description: Required. A pod affinity term, associated
+                                  with the corresponding weight.
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies which namespaces
+                                      the labelSelector applies to (matches against);
+                                      null or empty list means "this pod's namespace"
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified
+                                      namespaces, where co-located is defined as running
+                                      on a node whose value of the label with key
+                                      topologyKey matches that of any node on which
+                                      any of the selected pods is running. Empty topologyKey
+                                      is not allowed.
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              weight:
+                                description: weight associated with matching the corresponding
+                                  podAffinityTerm, in the range 1-100.
+                                format: int32
+                                type: integer
+                            required:
+                            - podAffinityTerm
+                            - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          description: If the affinity requirements specified by this
+                            field are not met at scheduling time, the pod will not
+                            be scheduled onto the node. If the affinity requirements
+                            specified by this field cease to be met at some point
+                            during pod execution (e.g. due to a pod label update),
+                            the system may or may not try to eventually evict the
+                            pod from its node. When there are multiple elements, the
+                            lists of nodes corresponding to each podAffinityTerm are
+                            intersected, i.e. all terms must be satisfied.
+                          items:
+                            description: Defines a set of pods (namely those matching
+                              the labelSelector relative to the given namespace(s))
+                              that this pod should be co-located (affinity) or not
+                              co-located (anti-affinity) with, where co-located is
+                              defined as running on a node whose value of the label
+                              with key <topologyKey> matches that of any node on which
+                              a pod of the set of pods is running
+                            properties:
+                              labelSelector:
+                                description: A label query over a set of resources,
+                                  in this case pods.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaces:
+                                description: namespaces specifies which namespaces
+                                  the labelSelector applies to (matches against);
+                                  null or empty list means "this pod's namespace"
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods
+                                  matching the labelSelector in the specified namespaces,
+                                  where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches
+                                  that of any node on which any of the selected pods
+                                  is running. Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          type: array
+                      type: object
+                    auxResources:
+                      description: AuxResources are the compute resources required
+                        by the cstor-target pod side car containers.
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                      type: object
+                    luWorkers:
+                      description: IOWorkers sets the number of threads that are working
+                        on above queue
+                      format: int64
+                      type: integer
+                    monitor:
+                      description: Monitor enables or disables the target exporter
+                        sidecar
+                      type: boolean
+                    nodeSelector:
+                      additionalProperties:
+                        type: string
+                      description: NodeSelector is the labels that will be used to
+                        select a node for target pod scheduleing Required field
+                      type: object
+                    priorityClassName:
+                      description: PriorityClassName if specified applies to this
+                        target pod If left empty, no priority class is applied.
+                      type: string
+                    queueDepth:
+                      description: QueueDepth sets the queue size at iSCSI target
+                        which limits the ongoing IO count from client
+                      type: string
+                    replicationFactor:
+                      description: ReplicationFactor represents maximum number of
+                        replicas that are allowed to connect to the target
+                      format: int64
+                      type: integer
+                    resources:
+                      description: Resources are the compute resources required by
+                        the cstor-target container.
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                      type: object
+                    tolerations:
+                      description: Tolerations, if specified, are the target pod's
+                        tolerations
+                      items:
+                        description: The pod this Toleration is attached to tolerates
+                          any taint that matches the triple <key,value,effect> using
+                          the matching operator <operator>.
+                        properties:
+                          effect:
+                            description: Effect indicates the taint effect to match.
+                              Empty means match all taint effects. When specified,
+                              allowed values are NoSchedule, PreferNoSchedule and
+                              NoExecute.
+                            type: string
+                          key:
+                            description: Key is the taint key that the toleration
+                              applies to. Empty means match all taint keys. If the
+                              key is empty, operator must be Exists; this combination
+                              means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: Operator represents a key's relationship
+                              to the value. Valid operators are Exists and Equal.
+                              Defaults to Equal. Exists is equivalent to wildcard
+                              for value, so that a pod can tolerate all taints of
+                              a particular category.
+                            type: string
+                          tolerationSeconds:
+                            description: TolerationSeconds represents the period of
+                              time the toleration (which must be of effect NoExecute,
+                              otherwise this field is ignored) tolerates the taint.
+                              By default, it is not set, which means tolerate the
+                              taint forever (do not evict). Zero and negative values
+                              will be treated as 0 (evict immediately) by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: Value is the taint value the toleration matches
+                              to. If the operator is Exists, the value should be empty,
+                              otherwise just a regular string.
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+              type: object
+            provision:
+              description: Provision represents the initial volume configuration for
+                the underlying cstor volume based on the persistent volume request
+                by user. Provision properties are immutable
+              properties:
+                capacity:
+                  additionalProperties:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Capacity represents initial capacity of volume replica
+                    required during volume clone operations to maintain some metadata
+                    info related to child resources like snapshot, cloned volumes.
+                  type: object
+                replicaCount:
+                  description: ReplicaCount represents initial cstor volume replica
+                    count, its will not be updated later on based on scale up/down
+                    operations, only readonly operations and validations.
+                  type: integer
+              required:
+              - capacity
+              - replicaCount
+              type: object
+          required:
+          - capacity
+          - policy
+          - provision
+          type: object
+        status:
+          description: Status represents the current information/status for the cstor
+            volume config, populated by the controller.
+          properties:
+            capacity:
+              additionalProperties:
+                anyOf:
+                - type: integer
+                - type: string
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+              description: Capacity the actual resources of the underlying volume.
+              type: object
+            condition:
+              items:
+                description: CStorVolumeConfigCondition contains details about state
+                  of cstor volume
+                properties:
+                  lastProbeTime:
+                    description: Last time we probed the condition.
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Reason is a brief CamelCase string that describes
+                      any failure
+                    type: string
+                  type:
+                    description: Current Condition of cstor volume config. If underlying
+                      persistent volume is being resized then the Condition will be
+                      set to 'ResizeStarted' etc
+                    type: string
+                required:
+                - message
+                - reason
+                - type
+                type: object
+              type: array
+            phase:
+              description: Phase represents the current phase of CStorVolumeConfig.
+              type: string
+            poolInfo:
+              description: PoolInfo represents current pool names where volume replicas
+                exists
+              items:
+                type: string
+              type: array
+          type: object
+        versionDetails:
+          description: VersionDetails provides the details for upgrade
+          properties:
+            autoUpgrade:
+              description: If AutoUpgrade is set to true then the resource is upgraded
+                automatically without any manual steps
+              type: boolean
+            desired:
+              description: Desired is the version that we want to upgrade or the control
+                plane version
+              type: string
+            status:
+              description: Status gives the status of reconciliation triggered when
+                the desired and current version are not same
+              properties:
+                current:
+                  description: Current is the version of resource
+                  type: string
+                dependentsUpgraded:
+                  description: DependentsUpgraded gives the details whether all children
+                    of a resource are upgraded to desired version or not
+                  type: boolean
+                lastUpdateTime:
+                  description: LastUpdateTime is the time the status was last  updated
+                  format: date-time
+                  nullable: true
+                  type: string
+                message:
+                  description: Message is a human readable message if some error occurs
+                  type: string
+                reason:
+                  description: Reason is the actual reason for the error state
+                  type: string
+                state:
+                  description: State is the state of reconciliation
+                  type: string
+              type: object
+          type: object
+      required:
+      - spec
+      - status
+      - versionDetails
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+################################################################
+####                                                       #####
+####                  CStorVolumePolicies                  #####
+####                                                       #####
+################################################################
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  name: cstorvolumepolicies.cstor.openebs.io
+spec:
+  group: cstor.openebs.io
+  names:
+    kind: CStorVolumePolicy
+    listKind: CStorVolumePolicyList
+    plural: cstorvolumepolicies
+    shortNames:
+    - cvp
+    singular: cstorvolumepolicy
+  preserveUnknownFields: false
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: CStorVolumePolicy describes a configuration required for cstor
+        volume resources
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: Spec defines a configuration info of a cstor volume required
+            to provisione cstor volume resources
+          properties:
+            provision:
+              description: replicaAffinity is set to true then volume replica resources
+                need to be distributed across the pool instances
+              properties:
+                blockSize:
+                  description: BlockSize is the logical block size in multiple of
+                    512 bytes BlockSize specifies the block size of the volume. The
+                    blocksize cannot be changed once the volume has been written,
+                    so it should be set at volume creation time. The default blocksize
+                    for volumes is 4 Kbytes. Any power of 2 from 512 bytes to 128
+                    Kbytes is valid.
+                  format: int32
+                  type: integer
+                replicaAffinity:
+                  description: replicaAffinity is set to true then volume replica
+                    resources need to be distributed across the cstor pool instances
+                    based on the given topology
+                  type: boolean
+              required:
+              - replicaAffinity
+              type: object
+            replica:
+              description: ReplicaSpec represents configuration related to replicas
+                resources
+              properties:
+                compression:
+                  description: The zle compression algorithm compresses runs of zeros.
+                  type: string
+                zvolWorkers:
+                  description: IOWorkers represents number of threads that executes
+                    client IOs
+                  type: string
+              type: object
+            replicaPoolInfo:
+              description: 'ReplicaPoolInfo holds the pool information of volume replicas.
+                Ex: If volume is provisioned on which CStor pool volume replicas exist'
+              items:
+                description: ReplicaPoolInfo represents the pool information of volume
+                  replica
+                properties:
+                  poolName:
+                    description: PoolName represents the pool name where volume replica
+                      exists
+                    type: string
+                required:
+                - poolName
+                type: object
+              type: array
+            target:
+              description: TargetSpec represents configuration related to cstor target
+                and its resources
+              properties:
+                affinity:
+                  description: PodAffinity if specified, are the target pod's affinities
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the affinity expressions specified by this field,
+                        but it may choose a node that violates one or more of the
+                        expressions. The node that is most preferred is the one with
+                        the greatest sum of weights, i.e. for each node that meets
+                        all of the scheduling requirements (resource request, requiredDuringScheduling
+                        affinity expressions, etc.), compute a sum by iterating through
+                        the elements of this field and adding "weight" to the sum
+                        if the node has pods which matches the corresponding podAffinityTerm;
+                        the node(s) with the highest sum are the most preferred.
+                      items:
+                        description: The weights of all of the matched WeightedPodAffinityTerm
+                          fields are added per-node to find the most preferred node(s)
+                        properties:
+                          podAffinityTerm:
+                            description: Required. A pod affinity term, associated
+                              with the corresponding weight.
+                            properties:
+                              labelSelector:
+                                description: A label query over a set of resources,
+                                  in this case pods.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaces:
+                                description: namespaces specifies which namespaces
+                                  the labelSelector applies to (matches against);
+                                  null or empty list means "this pod's namespace"
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods
+                                  matching the labelSelector in the specified namespaces,
+                                  where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches
+                                  that of any node on which any of the selected pods
+                                  is running. Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          weight:
+                            description: weight associated with matching the corresponding
+                              podAffinityTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                        - podAffinityTerm
+                        - weight
+                        type: object
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: If the affinity requirements specified by this
+                        field are not met at scheduling time, the pod will not be
+                        scheduled onto the node. If the affinity requirements specified
+                        by this field cease to be met at some point during pod execution
+                        (e.g. due to a pod label update), the system may or may not
+                        try to eventually evict the pod from its node. When there
+                        are multiple elements, the lists of nodes corresponding to
+                        each podAffinityTerm are intersected, i.e. all terms must
+                        be satisfied.
+                      items:
+                        description: Defines a set of pods (namely those matching
+                          the labelSelector relative to the given namespace(s)) that
+                          this pod should be co-located (affinity) or not co-located
+                          (anti-affinity) with, where co-located is defined as running
+                          on a node whose value of the label with key <topologyKey>
+                          matches that of any node on which a pod of the set of pods
+                          is running
+                        properties:
+                          labelSelector:
+                            description: A label query over a set of resources, in
+                              this case pods.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          namespaces:
+                            description: namespaces specifies which namespaces the
+                              labelSelector applies to (matches against); null or
+                              empty list means "this pod's namespace"
+                            items:
+                              type: string
+                            type: array
+                          topologyKey:
+                            description: This pod should be co-located (affinity)
+                              or not co-located (anti-affinity) with the pods matching
+                              the labelSelector in the specified namespaces, where
+                              co-located is defined as running on a node whose value
+                              of the label with key topologyKey matches that of any
+                              node on which any of the selected pods is running. Empty
+                              topologyKey is not allowed.
+                            type: string
+                        required:
+                        - topologyKey
+                        type: object
+                      type: array
+                  type: object
+                auxResources:
+                  description: AuxResources are the compute resources required by
+                    the cstor-target pod side car containers.
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                  type: object
+                luWorkers:
+                  description: IOWorkers sets the number of threads that are working
+                    on above queue
+                  format: int64
+                  type: integer
+                monitor:
+                  description: Monitor enables or disables the target exporter sidecar
+                  type: boolean
+                nodeSelector:
+                  additionalProperties:
+                    type: string
+                  description: NodeSelector is the labels that will be used to select
+                    a node for target pod scheduleing Required field
+                  type: object
+                priorityClassName:
+                  description: PriorityClassName if specified applies to this target
+                    pod If left empty, no priority class is applied.
+                  type: string
+                queueDepth:
+                  description: QueueDepth sets the queue size at iSCSI target which
+                    limits the ongoing IO count from client
+                  type: string
+                replicationFactor:
+                  description: ReplicationFactor represents maximum number of replicas
+                    that are allowed to connect to the target
+                  format: int64
+                  type: integer
+                resources:
+                  description: Resources are the compute resources required by the
+                    cstor-target container.
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                  type: object
+                tolerations:
+                  description: Tolerations, if specified, are the target pod's tolerations
+                  items:
+                    description: The pod this Toleration is attached to tolerates
+                      any taint that matches the triple <key,value,effect> using the
+                      matching operator <operator>.
+                    properties:
+                      effect:
+                        description: Effect indicates the taint effect to match. Empty
+                          means match all taint effects. When specified, allowed values
+                          are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                      key:
+                        description: Key is the taint key that the toleration applies
+                          to. Empty means match all taint keys. If the key is empty,
+                          operator must be Exists; this combination means to match
+                          all values and all keys.
+                        type: string
+                      operator:
+                        description: Operator represents a key's relationship to the
+                          value. Valid operators are Exists and Equal. Defaults to
+                          Equal. Exists is equivalent to wildcard for value, so that
+                          a pod can tolerate all taints of a particular category.
+                        type: string
+                      tolerationSeconds:
+                        description: TolerationSeconds represents the period of time
+                          the toleration (which must be of effect NoExecute, otherwise
+                          this field is ignored) tolerates the taint. By default,
+                          it is not set, which means tolerate the taint forever (do
+                          not evict). Zero and negative values will be treated as
+                          0 (evict immediately) by the system.
+                        format: int64
+                        type: integer
+                      value:
+                        description: Value is the taint value the toleration matches
+                          to. If the operator is Exists, the value should be empty,
+                          otherwise just a regular string.
+                        type: string
+                    type: object
+                  type: array
+              type: object
+          type: object
+        status:
+          description: CStorVolumePolicyStatus is for handling status of CstorVolumePolicy
+          properties:
+            phase:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+#############################################################################################
+###                                                                                    ######
+###                    CStorVolumeReplicas CRD                                         ######
+###                                                                                    ######
+#############################################################################################
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  name: cstorvolumereplicas.cstor.openebs.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.capacity.total
+    description: The amount of disk space consumed by a dataset and all its descendents
+    name: Allocated
+    type: string
+  - JSONPath: .status.capacity.used
+    description: The amount of space that is logically consumed by this dataset
+    name: Used
+    type: string
+  - JSONPath: .status.phase
+    description: Identifies the current state of the replicas
+    name: Status
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: Age of CStorVolumeReplica
+    name: Age
+    type: date
+  group: cstor.openebs.io
+  names:
+    kind: CStorVolumeReplica
+    listKind: CStorVolumeReplicaList
+    plural: cstorvolumereplicas
+    shortNames:
+    - cvr
+    singular: cstorvolumereplica
+  preserveUnknownFields: false
+  scope: Namespaced
+  subresources: {}
+  validation:
+    openAPIV3Schema:
+      description: CStorVolumeReplica describes a cstor volume resource created as
+        custom resource
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: CStorVolumeReplicaSpec is the spec for a CStorVolumeReplica
+            resource
+          properties:
+            blockSize:
+              description: BlockSize is the logical block size in multiple of 512
+                bytes BlockSize specifies the block size of the volume. The blocksize
+                cannot be changed once the volume has been written, so it should be
+                set at volume creation time. The default blocksize for volumes is
+                4 Kbytes. Any power of 2 from 512 bytes to 128 Kbytes is valid.
+              format: int32
+              type: integer
+            capacity:
+              description: Represents the actual capacity of the underlying volume
+              type: string
+            compression:
+              description: 'Controls the compression algorithm used for this volumes
+                examples: on|off|gzip|gzip-N|lz4|lzjb|zle'
+              type: string
+            replicaid:
+              description: ReplicaID is unique number to identify the replica
+              type: string
+            targetIP:
+              description: TargetIP represents iscsi target IP through which replica
+                cummunicates IO workloads and other volume operations like snapshot
+                and resize requests
+              type: string
+            zvolWorkers:
+              description: ZvolWorkers represents number of threads that executes
+                client IOs
+              type: string
+          type: object
+        status:
+          description: CStorVolumeReplicaStatus is for handling status of cvr.
+          properties:
+            capacity:
+              description: CStorVolumeCapacityDetails represents capacity info of
+                replica
+              properties:
+                total:
+                  description: The amount of space consumed by this volume replica
+                    and all its descendents
+                  type: string
+                used:
+                  description: The amount of space that is "logically" accessible
+                    by this dataset. The logical space ignores the effect of the compression
+                    and copies properties, giving a quantity closer to the amount
+                    of data that applications see.  However, it does include space
+                    consumed by metadata
+                  type: string
+              required:
+              - total
+              - used
+              type: object
+            lastTransitionTime:
+              description: LastTransitionTime refers to the time when the phase changes
+              format: date-time
+              nullable: true
+              type: string
+            lastUpdateTime:
+              description: The last updated time
+              format: date-time
+              nullable: true
+              type: string
+            message:
+              description: A human readable message indicating details about the transition.
+              type: string
+            pendingSnapshots:
+              additionalProperties:
+                description: CStorSnapshotInfo represents the snapshot information
+                  related to particular snapshot
+                properties:
+                  logicalReferenced:
+                    description: LogicalReferenced describes the amount of space that
+                      is "logically" accessable by this snapshot. This logical space
+                      ignores the effect of the compression and copies properties,
+                      giving a quantity closer to the amount of data that application
+                      see. It also includes space consumed by metadata.
+                    format: int64
+                    type: integer
+                required:
+                - logicalReferenced
+                type: object
+              description: PendingSnapshots contains list of pending snapshots that
+                are not yet available on this replica
+              type: object
+            phase:
+              description: CStorVolumeReplicaPhase is to holds different phases of
+                replica
+              type: string
+            snapshots:
+              additionalProperties:
+                description: CStorSnapshotInfo represents the snapshot information
+                  related to particular snapshot
+                properties:
+                  logicalReferenced:
+                    description: LogicalReferenced describes the amount of space that
+                      is "logically" accessable by this snapshot. This logical space
+                      ignores the effect of the compression and copies properties,
+                      giving a quantity closer to the amount of data that application
+                      see. It also includes space consumed by metadata.
+                    format: int64
+                    type: integer
+                required:
+                - logicalReferenced
+                type: object
+              description: Snapshots contains list of snapshots, and their properties,
+                created on CVR
+              type: object
+          type: object
+        versionDetails:
+          description: VersionDetails provides the details for upgrade
+          properties:
+            autoUpgrade:
+              description: If AutoUpgrade is set to true then the resource is upgraded
+                automatically without any manual steps
+              type: boolean
+            desired:
+              description: Desired is the version that we want to upgrade or the control
+                plane version
+              type: string
+            status:
+              description: Status gives the status of reconciliation triggered when
+                the desired and current version are not same
+              properties:
+                current:
+                  description: Current is the version of resource
+                  type: string
+                dependentsUpgraded:
+                  description: DependentsUpgraded gives the details whether all children
+                    of a resource are upgraded to desired version or not
+                  type: boolean
+                lastUpdateTime:
+                  description: LastUpdateTime is the time the status was last  updated
+                  format: date-time
+                  nullable: true
+                  type: string
+                message:
+                  description: Message is a human readable message if some error occurs
+                  type: string
+                reason:
+                  description: Reason is the actual reason for the error state
+                  type: string
+                state:
+                  description: State is the state of reconciliation
+                  type: string
+              type: object
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+###############################################################################
+####                                                                       ####
+####               CStorVolume CRD                                         ####
+####                                                                       ####
+###############################################################################
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  name: cstorvolumes.cstor.openebs.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.capacity
+    description: Current volume capacity
+    name: Capacity
+    type: string
+  - JSONPath: .status.phase
+    description: Identifies the current health of the volume
+    name: Status
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: Age of CStorVolume
+    name: Age
+    type: date
+  group: cstor.openebs.io
+  names:
+    kind: CStorVolume
+    listKind: CStorVolumeList
+    plural: cstorvolumes
+    shortNames:
+    - cv
+    singular: cstorvolume
+  preserveUnknownFields: false
+  scope: Namespaced
+  subresources: {}
+  validation:
+    openAPIV3Schema:
+      description: CStorVolume describes a cstor volume resource created as custom
+        resource
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: CStorVolumeSpec is the spec for a CStorVolume resource
+          properties:
+            capacity:
+              anyOf:
+              - type: integer
+              - type: string
+              description: Capacity represents the desired size of the underlying
+                volume.
+              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+              x-kubernetes-int-or-string: true
+            consistencyFactor:
+              description: ConsistencyFactor is minimum number of volume replicas
+                i.e. `RF/2 + 1` has to be connected to the target for write operations.
+                Basically more then 50% of replica has to be connected to target.
+              type: integer
+            desiredReplicationFactor:
+              description: DesiredReplicationFactor represents maximum number of replicas
+                that are allowed to connect to the target. Required for scale operations
+              type: integer
+            iqn:
+              description: Target iSCSI Qualified Name.combination of nodeBase
+              type: string
+            replicaDetails:
+              description: ReplicaDetails refers to the trusty replica information
+              properties:
+                knownReplicas:
+                  additionalProperties:
+                    type: string
+                  description: KnownReplicas represents the replicas that target can
+                    trust to read data
+                  type: object
+              type: object
+            replicationFactor:
+              description: ReplicationFactor represents number of volume replica created
+                during volume provisioning connect to the target
+              type: integer
+            targetIP:
+              description: TargetIP IP of the iSCSI target service
+              type: string
+            targetPort:
+              description: iSCSI Target Port typically TCP ports 3260
+              type: string
+            targetPortal:
+              description: iSCSI Target Portal. The Portal is combination of IP:port
+                (typically TCP ports 3260)
+              type: string
+          type: object
+        status:
+          description: CStorVolumeStatus is for handling status of cvr.
+          properties:
+            capacity:
+              anyOf:
+              - type: integer
+              - type: string
+              description: Represents the actual capacity of the underlying volume.
+              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+              x-kubernetes-int-or-string: true
+            conditions:
+              description: Current Condition of cstorvolume. If underlying persistent
+                volume is being resized then the Condition will be set to 'ResizePending'.
+              items:
+                description: CStorVolumeCondition contains details about state of
+                  cstorvolume
+                properties:
+                  lastProbeTime:
+                    description: Last time we probed the condition.
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, this should be a short, machine understandable
+                      string that gives the reason for condition's last transition.
+                      If it reports "ResizePending" that means the underlying cstorvolume
+                      is being resized.
+                    type: string
+                  status:
+                    description: ConditionStatus states in which state condition is
+                      present
+                    type: string
+                  type:
+                    description: CStorVolumeConditionType is a valid value of CStorVolumeCondition.Type
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+            lastTransitionTime:
+              description: LastTransitionTime refers to the time when the phase changes
+              format: date-time
+              nullable: true
+              type: string
+            lastUpdateTime:
+              description: LastUpdateTime refers to the time when last status updated
+                due to any operations
+              format: date-time
+              nullable: true
+              type: string
+            message:
+              description: A human-readable message indicating details about why the
+                volume is in this state.
+              type: string
+            phase:
+              description: CStorVolumePhase is to hold result of action.
+              type: string
+            replicaDetails:
+              description: ReplicaDetails refers to the trusty replica information
+              properties:
+                knownReplicas:
+                  additionalProperties:
+                    type: string
+                  description: KnownReplicas represents the replicas that target can
+                    trust to read data
+                  type: object
+              type: object
+            replicaStatuses:
+              items:
+                description: ReplicaStatus stores the status of replicas
+                properties:
+                  checkpointedIOSeq:
+                    description: Represents IO number of replica persisted on the
+                      disk
+                    type: string
+                  inflightRead:
+                    description: Ongoing reads I/O from target to replica
+                    type: string
+                  inflightSync:
+                    description: Ongoing sync I/O from target to replica
+                    type: string
+                  inflightWrite:
+                    description: ongoing writes I/O from target to replica
+                    type: string
+                  mode:
+                    description: Mode represents replica status i.e. Healthy, Degraded
+                    type: string
+                  quorum:
+                    description: 'Quorum indicates wheather data wrtitten to the replica
+                      is lost or exists. "0" means: data has been lost( might be ephimeral
+                      case) and will recostruct data from other Healthy replicas in
+                      a write-only mode 1 means: written data is exists on replica'
+                    type: string
+                  replicaId:
+                    description: ID is replica unique identifier
+                    type: string
+                  upTime:
+                    description: time since the replica connected to target
+                    type: integer
+                required:
+                - checkpointedIOSeq
+                - inflightRead
+                - inflightSync
+                - inflightWrite
+                - mode
+                - quorum
+                - replicaId
+                - upTime
+                type: object
+              type: array
+          type: object
+        versionDetails:
+          description: VersionDetails provides the details for upgrade
+          properties:
+            autoUpgrade:
+              description: If AutoUpgrade is set to true then the resource is upgraded
+                automatically without any manual steps
+              type: boolean
+            desired:
+              description: Desired is the version that we want to upgrade or the control
+                plane version
+              type: string
+            status:
+              description: Status gives the status of reconciliation triggered when
+                the desired and current version are not same
+              properties:
+                current:
+                  description: Current is the version of resource
+                  type: string
+                dependentsUpgraded:
+                  description: DependentsUpgraded gives the details whether all children
+                    of a resource are upgraded to desired version or not
+                  type: boolean
+                lastUpdateTime:
+                  description: LastUpdateTime is the time the status was last  updated
+                  format: date-time
+                  nullable: true
+                  type: string
+                message:
+                  description: Message is a human readable message if some error occurs
+                  type: string
+                reason:
+                  description: Reason is the actual reason for the error state
+                  type: string
+                state:
+                  description: State is the state of reconciliation
+                  type: string
+              type: object
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+############################################################
+####                                                    ####
+####                   CStorBackup CRD                  ####
+####                                                    ####
+############################################################
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cstorbackups.openebs.io
+spec:
+  group: openebs.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: cstorbackups
+    singular: cstorbackup
+    kind: CStorBackup
+    shortNames:
+    - cbkp
+    - cbkps
+    - cbackups
+    - cbackup
+  additionalPrinterColumns:
+    - JSONPath: .spec.volumeName
+      name: volume
+      description: volume on which backup performed
+      type: string
+    - JSONPath: .spec.backupName
+      name: backup/schedule
+      description: Backup/schedule name
+      type: string
+    - JSONPath: .status
+      name: Status
+      description: Backup status
+      type: string
+---
+############################################################
+####                                                    ####
+####             CStorCompletedBackup CRD               ####
+####                                                    ####
+############################################################
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cstorcompletedbackups.openebs.io
+spec:
+  group: openebs.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: cstorcompletedbackups
+    singular: cstorcompletedbackup
+    kind: CStorCompletedBackup
+    shortNames:
+    - cbkpc
+    - cbackupcompleted
+  additionalPrinterColumns:
+    - JSONPath: .spec.volumeName
+      name: volume
+      description: volume on which backup performed
+      type: string
+    - JSONPath: .spec.backupName
+      name: backup/schedule
+      description: Backup/schedule name
+      type: string
+    - JSONPath: .spec.prevSnapName
+      name: lastSnap
+      description: Last successful backup snapshot
+      type: string
+---
+############################################################
+####                                                    ####
+####             CStorRestore CRD                       ####
+####                                                    ####
+############################################################
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cstorrestores.openebs.io
+spec:
+  group: openebs.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: cstorrestores
+    singular: cstorrestore
+    kind: CStorRestore
+    shortNames:
+    - crst
+    - crsts
+    - crestores
+    - crestore
+  additionalPrinterColumns:
+    - JSONPath: .spec.restoreName
+      name: backup
+      description: backup name which is  restored
+      type: string
+    - JSONPath: .spec.volumeName
+      name: volume
+      description: volume on which restore performed
+      type: string
+    - JSONPath: .status
+      name: Status
+      description: Restore status
+      type: string
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cspc-operator
+  namespace: openebs
+  labels:
+    name: cspc-operator
+    openebs.io/component-name: cspc-operator
+    openebs.io/version: 2.0.0-RC1
+spec:
+  selector:
+    matchLabels:
+      name: cspc-operator
+      openebs.io/component-name: cspc-operator
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        name: cspc-operator
+        openebs.io/component-name: cspc-operator
+        openebs.io/version: 2.0.0-RC1
+    spec:
+      serviceAccountName: openebs-maya-operator
+      containers:
+      - name: cspc-operator
+        imagePullPolicy: IfNotPresent
+        image: openebs/cspc-operator-amd64:2.0.0-RC1
+        env:
+        - name: OPENEBS_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OPENEBS_SERVICEACCOUNT_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: CSPC_OPERATOR_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        # OPENEBS_IO_BASE_DIR is used to configure base directory for openebs on host path.
+        # Where OpenEBS can store required files. Default base path will be /var/openebs
+        # - name: OPENEBS_IO_BASE_DIR
+        #   value: "/var/openebs"
+        # OPENEBS_IO_CSTOR_POOL_SPARSE_DIR can be used to specify the hostpath
+        # to be used for saving the shared content between the side cars
+        # of cstor pool pod. This ENV is also used to indicate the location
+        # of the sparse devices.
+        # The default path used is /var/openebs/sparse
+        #- name: OPENEBS_IO_CSTOR_POOL_SPARSE_DIR
+        #  value: "/var/openebs/sparse"
+        - name: OPENEBS_IO_CSPI_MGMT_IMAGE
+          value: "openebs/cstor-pool-manager-amd64:2.0.0-RC1"
+        - name: OPENEBS_IO_CSTOR_POOL_IMAGE
+          value: "openebs/cstor-pool:2.0.0-RC1"
+        - name:  OPENEBS_IO_CSTOR_POOL_EXPORTER_IMAGE
+          value: "openebs/m-exporter:2.0.0-RC1"
+        - name: RESYNC_INTERVAL
+          value: "30"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cvc-operator
+  namespace: openebs
+  labels:
+    name: cvc-operator
+    openebs.io/component-name: cvc-operator
+    openebs.io/version: 2.0.0-RC1
+spec:
+  selector:
+    matchLabels:
+      name: cvc-operator
+      openebs.io/component-name: cvc-operator
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        name: cvc-operator
+        openebs.io/component-name: cvc-operator
+        openebs.io/version: 2.0.0-RC1
+    spec:
+      serviceAccountName: openebs-maya-operator
+      containers:
+      - name: cvc-operator
+        imagePullPolicy: IfNotPresent
+        image: openebs/cvc-operator-amd64:2.0.0-RC1
+        env:
+        # OPENEBS_IO_BASE_DIR is used to configure base directory for openebs on host path.
+        # Where OpenEBS can store required files. Default base path will be /var/openebs
+        # - name: OPENEBS_IO_BASE_DIR
+        #   value: "/var/openebs"
+        # OPENEBS_IO_CSTOR_TARGET_DIR can be used to specify the hostpath
+        # that to be used for saving the core dump of cstor volume pod.
+        # The default path used is /var/openebs/sparse
+        #- name: OPENEBS_IO_CSTOR_TARGET_DIR
+        #  value: "/var/openebs/sparse"
+        - name: OPENEBS_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OPENEBS_SERVICEACCOUNT_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: OPENEBS_IO_CSTOR_TARGET_IMAGE
+          value: "openebs/cstor-istgt:2.0.0-RC1"
+        - name:  OPENEBS_IO_CSTOR_VOLUME_MGMT_IMAGE
+          value: "openebs/cstor-volume-manager-amd64:2.0.0-RC1"
+        - name:  OPENEBS_IO_VOLUME_MONITOR_IMAGE
+          value: "openebs/m-exporter:2.0.0-RC1"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cvc-operator-service
+  namespace: openebs
+  labels:
+    openebs.io/component-name: cvc-operator-svc
+spec:
+  ports:
+  - name: api
+    port: 5757
+    protocol: TCP
+    targetPort: 5757
+  selector:
+    name: cvc-operator
+  sessionAffinity: None
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openebs-cstor-admission-server
+  namespace: openebs
+  labels:
+    app: cstor-admission-webhook
+    openebs.io/component-name: cstor-admission-webhook
+    openebs.io/version: 2.0.0-RC1
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+    rollingUpdate: null
+  selector:
+    matchLabels:
+      app: cstor-admission-webhook
+  template:
+    metadata:
+      labels:
+        app: cstor-admission-webhook
+        openebs.io/component-name: cstor-admission-webhook
+        openebs.io/version: 2.0.0-RC1
+    spec:
+      serviceAccountName: openebs-maya-operator
+      containers:
+        - name: admission-webhook
+          image: openebs/cstor-webhook-amd64:2.0.0-RC1
+          imagePullPolicy: IfNotPresent
+          args:
+            - -alsologtostderr
+            - -v=2
+            - 2>&1
+          env:
+            - name: OPENEBS_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ADMISSION_WEBHOOK_NAME
+              value: "openebs-cstor-admission-server"
+            - name: ADMISSION_WEBHOOK_FAILURE_POLICY
+              value: "Fail"

--- a/2.0.0/cstor-operator-2.0.0-RC2.yaml
+++ b/2.0.0/cstor-operator-2.0.0-RC2.yaml
@@ -1650,6 +1650,7 @@ spec:
     description: The amount of storage space within the pool that has been physically
       allocated
     name: Allocated
+    priority: 1
     type: string
   - JSONPath: .status.capacity.free
     description: The amount of usable free space available in the pool
@@ -1674,6 +1675,7 @@ spec:
   - JSONPath: .spec.poolConfig.dataRaidGroupType
     description: Represents the type of the storage pool
     name: Type
+    priority: 1
     type: string
   - JSONPath: .status.phase
     description: Identifies the current health of the pool
@@ -2025,6 +2027,10 @@ spec:
             readOnly:
               description: ReadOnly if pool is readOnly or not
               type: boolean
+          required:
+          - healthyReplicas
+          - provisionedReplicas
+          - readOnly
           type: object
         versionDetails:
           description: VersionDetails is the openebs version.
@@ -2078,6 +2084,7 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+
 ---
 #########################################################################
 ####                                                                #####

--- a/2.0.0/cstor-operator-2.0.0-RC2.yaml
+++ b/2.0.0/cstor-operator-2.0.0-RC2.yaml
@@ -1,0 +1,3924 @@
+# Create the OpenEBS namespace
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openebs
+---
+# Create Maya Service Account
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openebs-maya-operator
+  namespace: openebs
+---
+# Define Role that allows operations on K8s pods/deployments
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: openebs-cstor-operator
+rules:
+- apiGroups: ["*"]
+  resources: ["nodes", "nodes/proxy"]
+  verbs: ["*"]
+- apiGroups: ["*"]
+  resources: ["namespaces", "services", "pods", "deployments", "deployments/finalizers", "replicationcontrollers", "replicasets", "events", "endpoints", "configmaps", "secrets", "jobs", "cronjobs"]
+  verbs: ["*"]
+- apiGroups: ["*"]
+  resources: ["statefulsets", "daemonsets"]
+  verbs: ["*"]
+- apiGroups: ["*"]
+  resources: ["resourcequotas", "limitranges"]
+  verbs: ["list", "watch"]
+- apiGroups: ["*"]
+  resources: ["certificatesigningrequests"]
+  verbs: ["list", "watch"]
+- apiGroups: ["*"]
+  resources: ["storageclasses", "persistentvolumeclaims", "persistentvolumes"]
+  verbs: ["*"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: [ "get", "list", "create", "update", "delete", "patch"]
+- apiGroups: ["openebs.io"]
+  resources: ["*"]
+  verbs: ["*" ]
+- apiGroups: ["cstor.openebs.io"]
+  resources: ["*"]
+  verbs: ["*" ]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "watch", "list", "delete", "update", "create"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
+  verbs: ["get", "create", "list", "delete", "update", "patch"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+- apiGroups: ["*"]
+  resources: ["upgradetasks"]
+  verbs: ["*"]
+- apiGroups: ["*"]
+  resources: ["poddisruptionbudgets"]
+  verbs: ["get", "list", "create", "delete", "watch"]
+---
+# Bind the Service Account with the Role Privileges.
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: openebs-cstor-operator
+subjects:
+- kind: ServiceAccount
+  name: openebs-maya-operator
+  namespace: openebs
+roleRef:
+  kind: ClusterRole
+  name: openebs-cstor-operator
+  apiGroup: rbac.authorization.k8s.io
+---
+# Define Role that allows operations required for migration of snapshots
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: openebs-cstor-migration
+rules:
+- apiGroups: ["snapshot.storage.k8s.io"]
+  resources: ["volumesnapshotclasses"]
+  verbs: ["get", "list"]
+- apiGroups: ["snapshot.storage.k8s.io"]
+  resources: ["volumesnapshotcontents"]
+  verbs: ["create", "get", "list"]
+- apiGroups: ["snapshot.storage.k8s.io"]
+  resources: ["volumesnapshots"]
+  verbs: ["create", "get", "list"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: openebs-cstor-migration
+subjects:
+- kind: ServiceAccount
+  name: openebs-maya-operator
+  namespace: openebs
+roleRef:
+  kind: ClusterRole
+  name: openebs-cstor-migration
+  apiGroup: rbac.authorization.k8s.io
+---
+# This manifest deploys the OpenEBS CStor and CSI control plane components,
+# with associated CRs & RBAC rules. This manifest has been verified
+# only with different linux flavours and linux distros
+#
+# For supporting a differnet OS other than the above,
+# 1) Get the list of shared object files required for iscsiadm binary in that OS version.
+# 2) Check which files are already present in the cstor-csi-driver container present in csi node pod.
+# 3) Mount the required missing files inside the container.
+#
+####################################################
+###########                             ############
+###########  CSI Node and Driver CRDs   ############
+###########                             ############
+####################################################
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: csinodeinfos.csi.storage.k8s.io
+spec:
+  group: csi.storage.k8s.io
+  names:
+    kind: CSINodeInfo
+    plural: csinodeinfos
+  scope: Cluster
+  validation:
+    openAPIV3Schema:
+      properties:
+        csiDrivers:
+          description: List of CSI drivers running on the node and their properties.
+          items:
+            properties:
+              driver:
+                description: The CSI driver that this object refers to.
+                type: string
+              nodeID:
+                description: The node from the driver point of view.
+                type: string
+              topologyKeys:
+                description: List of keys supported by the driver.
+                items:
+                  type: string
+                type: array
+          type: array
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cstorvolumeattachments.cstor.openebs.io
+spec:
+  group: cstor.openebs.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: cstorvolumeattachments
+    singular: cstorvolumeattachment
+    kind: CStorVolumeAttachment
+    shortNames:
+    - cstorvolumeattachment
+    - cva
+---
+##############################################
+###########                       ############
+###########   Snapshot CRDs       ############
+###########                       ############
+##############################################
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: volumesnapshotclasses.snapshot.storage.k8s.io
+spec:
+  group: snapshot.storage.k8s.io
+  names:
+    kind: VolumeSnapshotClass
+    listKind: VolumeSnapshotClassList
+    plural: volumesnapshotclasses
+    singular: volumesnapshotclass
+  scope: Cluster
+# this field is supported in kubernetes 1.15+
+# https://v1-15.docs.kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/
+#preserveUnknownFields: false
+  validation:
+    openAPIV3Schema:
+      description: VolumeSnapshotClass specifies parameters that a underlying storage
+        system uses when creating a volume snapshot. A specific VolumeSnapshotClass
+        is used by specifying its name in a VolumeSnapshot object. VolumeSnapshotClasses
+        are non-namespaced
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        deletionPolicy:
+          description: deletionPolicy determines whether a VolumeSnapshotContent created
+            through the VolumeSnapshotClass should be deleted when its bound VolumeSnapshot
+            is deleted. Supported values are "Retain" and "Delete". "Retain" means
+            that the VolumeSnapshotContent and its physical snapshot on underlying
+            storage system are kept. "Delete" means that the VolumeSnapshotContent
+            and its physical snapshot on underlying storage system are deleted. Required.
+          enum:
+          - Delete
+          - Retain
+          type: string
+        driver:
+          description: driver is the name of the storage driver that handles this
+            VolumeSnapshotClass. Required.
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        parameters:
+          additionalProperties:
+            type: string
+          description: parameters is a key-value map with storage driver specific
+            parameters for creating snapshots. These values are opaque to Kubernetes.
+          type: object
+      required:
+      - deletionPolicy
+      - driver
+      type: object
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: volumesnapshotcontents.snapshot.storage.k8s.io
+spec:
+  group: snapshot.storage.k8s.io
+  names:
+    kind: VolumeSnapshotContent
+    listKind: VolumeSnapshotContentList
+    plural: volumesnapshotcontents
+    singular: volumesnapshotcontent
+  scope: Cluster
+  subresources:
+    status: {}
+# this field is supported in kubernetes 1.15+
+# https://v1-15.docs.kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/
+#preserveUnknownFields: false
+  validation:
+    openAPIV3Schema:
+      description: VolumeSnapshotContent represents the actual "on-disk" snapshot
+        object in the underlying storage system
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        spec:
+          description: spec defines properties of a VolumeSnapshotContent created
+            by the underlying storage system. Required.
+          properties:
+            deletionPolicy:
+              description: deletionPolicy determines whether this VolumeSnapshotContent
+                and its physical snapshot on the underlying storage system should
+                be deleted when its bound VolumeSnapshot is deleted. Supported values
+                are "Retain" and "Delete". "Retain" means that the VolumeSnapshotContent
+                and its physical snapshot on underlying storage system are kept. "Delete"
+                means that the VolumeSnapshotContent and its physical snapshot on
+                underlying storage system are deleted. In dynamic snapshot creation
+                case, this field will be filled in with the "DeletionPolicy" field
+                defined in the VolumeSnapshotClass the VolumeSnapshot refers to. For
+                pre-existing snapshots, users MUST specify this field when creating
+                the VolumeSnapshotContent object. Required.
+              enum:
+              - Delete
+              - Retain
+              type: string
+            driver:
+              description: driver is the name of the CSI driver used to create the
+                physical snapshot on the underlying storage system. This MUST be the
+                same as the name returned by the CSI GetPluginName() call for that
+                driver. Required.
+              type: string
+            source:
+              description: source specifies from where a snapshot will be created.
+                This field is immutable after creation. Required.
+              properties:
+                snapshotHandle:
+                  description: snapshotHandle specifies the CSI "snapshot_id" of a
+                    pre-existing snapshot on the underlying storage system. This field
+                    is immutable.
+                  type: string
+                volumeHandle:
+                  description: volumeHandle specifies the CSI "volume_id" of the volume
+                    from which a snapshot should be dynamically taken from. This field
+                    is immutable.
+                  type: string
+              type: object
+            volumeSnapshotClassName:
+              description: name of the VolumeSnapshotClass to which this snapshot
+                belongs.
+              type: string
+            volumeSnapshotRef:
+              description: volumeSnapshotRef specifies the VolumeSnapshot object to
+                which this VolumeSnapshotContent object is bound. VolumeSnapshot.Spec.VolumeSnapshotContentName
+                field must reference to this VolumeSnapshotContent's name for the
+                bidirectional binding to be valid. For a pre-existing VolumeSnapshotContent
+                object, name and namespace of the VolumeSnapshot object MUST be provided
+                for binding to happen. This field is immutable after creation. Required.
+              properties:
+                apiVersion:
+                  description: API version of the referent.
+                  type: string
+                fieldPath:
+                  description: 'If referring to a piece of an object instead of an
+                    entire object, this string should contain a valid JSON/Go field
+                    access statement, such as desiredState.manifest.containers[2].
+                    For example, if the object reference is to a container within
+                    a pod, this would take on a value like: "spec.containers{name}"
+                    (where "name" refers to the name of the container that triggered
+                    the event) or if no container name is specified "spec.containers[2]"
+                    (container with index 2 in this pod). This syntax is chosen only
+                    to have some well-defined way of referencing a part of an object.
+                    TODO: this design is not final and this field is subject to change
+                    in the future.'
+                  type: string
+                kind:
+                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+                resourceVersion:
+                  description: 'Specific resourceVersion to which this reference is
+                    made, if any. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                  type: string
+                uid:
+                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                  type: string
+              type: object
+          required:
+          - deletionPolicy
+          - driver
+          - source
+          - volumeSnapshotRef
+          type: object
+        status:
+          description: status represents the current information of a snapshot.
+          properties:
+            creationTime:
+              description: creationTime is the timestamp when the point-in-time snapshot
+                is taken by the underlying storage system. In dynamic snapshot creation
+                case, this field will be filled in with the "creation_time" value
+                returned from CSI "CreateSnapshotRequest" gRPC call. For a pre-existing
+                snapshot, this field will be filled with the "creation_time" value
+                returned from the CSI "ListSnapshots" gRPC call if the driver supports
+                it. If not specified, it indicates the creation time is unknown. The
+                format of this field is a Unix nanoseconds time encoded as an int64.
+                On Unix, the command `date +%s%N` returns the current time in nanoseconds
+                since 1970-01-01 00:00:00 UTC.
+              format: int64
+              type: integer
+            error:
+              description: error is the latest observed error during snapshot creation,
+                if any.
+              properties:
+                message:
+                  description: 'message is a string detailing the encountered error
+                    during snapshot creation if specified. NOTE: message may be logged,
+                    and it should not contain sensitive information.'
+                  type: string
+                time:
+                  description: time is the timestamp when the error was encountered.
+                  format: date-time
+                  type: string
+              type: object
+            readyToUse:
+              description: readyToUse indicates if a snapshot is ready to be used
+                to restore a volume. In dynamic snapshot creation case, this field
+                will be filled in with the "ready_to_use" value returned from CSI
+                "CreateSnapshotRequest" gRPC call. For a pre-existing snapshot, this
+                field will be filled with the "ready_to_use" value returned from the
+                CSI "ListSnapshots" gRPC call if the driver supports it, otherwise,
+                this field will be set to "True". If not specified, it means the readiness
+                of a snapshot is unknown.
+              type: boolean
+            restoreSize:
+              description: restoreSize represents the complete size of the snapshot
+                in bytes. In dynamic snapshot creation case, this field will be filled
+                in with the "size_bytes" value returned from CSI "CreateSnapshotRequest"
+                gRPC call. For a pre-existing snapshot, this field will be filled
+                with the "size_bytes" value returned from the CSI "ListSnapshots"
+                gRPC call if the driver supports it. When restoring a volume from
+                this snapshot, the size of the volume MUST NOT be smaller than the
+                restoreSize if it is specified, otherwise the restoration will fail.
+                If not specified, it indicates that the size is unknown.
+              format: int64
+              minimum: 0
+              type: integer
+            snapshotHandle:
+              description: snapshotHandle is the CSI "snapshot_id" of a snapshot on
+                the underlying storage system. If not specified, it indicates that
+                dynamic snapshot creation has either failed or it is still in progress.
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: volumesnapshots.snapshot.storage.k8s.io
+spec:
+  group: snapshot.storage.k8s.io
+  names:
+    kind: VolumeSnapshot
+    listKind: VolumeSnapshotList
+    plural: volumesnapshots
+    singular: volumesnapshot
+  scope: Namespaced
+  subresources:
+    status: {}
+# this field is supported in kubernetes 1.15+
+# https://v1-15.docs.kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/
+#preserveUnknownFields: false
+  validation:
+    openAPIV3Schema:
+      description: VolumeSnapshot is a user's request for either creating a point-in-time
+        snapshot of a persistent volume, or binding to a pre-existing snapshot.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        spec:
+          description: 'spec defines the desired characteristics of a snapshot requested
+            by a user. More info: https://kubernetes.io/docs/concepts/storage/volume-snapshots#volumesnapshots
+            Required.'
+          properties:
+            source:
+              description: source specifies where a snapshot will be created from.
+                This field is immutable after creation. Required.
+              properties:
+                persistentVolumeClaimName:
+                  description: persistentVolumeClaimName specifies the name of the
+                    PersistentVolumeClaim object in the same namespace as the VolumeSnapshot
+                    object where the snapshot should be dynamically taken from. This
+                    field is immutable.
+                  type: string
+                volumeSnapshotContentName:
+                  description: volumeSnapshotContentName specifies the name of a pre-existing
+                    VolumeSnapshotContent object. This field is immutable.
+                  type: string
+              type: object
+            volumeSnapshotClassName:
+              description: 'volumeSnapshotClassName is the name of the VolumeSnapshotClass
+                requested by the VolumeSnapshot. If not specified, the default snapshot
+                class will be used if one exists. If not specified, and there is no
+                default snapshot class, dynamic snapshot creation will fail. Empty
+                string is not allowed for this field. TODO(xiangqian): a webhook validation
+                on empty string. More info: https://kubernetes.io/docs/concepts/storage/volume-snapshot-classes'
+              type: string
+          required:
+          - source
+          type: object
+        status:
+          description: 'status represents the current information of a snapshot. NOTE:
+            status can be modified by sources other than system controllers, and must
+            not be depended upon for accuracy. Controllers should only use information
+            from the VolumeSnapshotContent object after verifying that the binding
+            is accurate and complete.'
+          properties:
+            boundVolumeSnapshotContentName:
+              description: 'boundVolumeSnapshotContentName represents the name of
+                the VolumeSnapshotContent object to which the VolumeSnapshot object
+                is bound. If not specified, it indicates that the VolumeSnapshot object
+                has not been successfully bound to a VolumeSnapshotContent object
+                yet. NOTE: Specified boundVolumeSnapshotContentName alone does not
+                mean binding       is valid. Controllers MUST always verify bidirectional
+                binding between       VolumeSnapshot and VolumeSnapshotContent to
+                avoid possible security issues.'
+              type: string
+            creationTime:
+              description: creationTime is the timestamp when the point-in-time snapshot
+                is taken by the underlying storage system. In dynamic snapshot creation
+                case, this field will be filled in with the "creation_time" value
+                returned from CSI "CreateSnapshotRequest" gRPC call. For a pre-existing
+                snapshot, this field will be filled with the "creation_time" value
+                returned from the CSI "ListSnapshots" gRPC call if the driver supports
+                it. If not specified, it indicates that the creation time of the snapshot
+                is unknown.
+              format: date-time
+              type: string
+            error:
+              description: error is the last observed error during snapshot creation,
+                if any. This field could be helpful to upper level controllers(i.e.,
+                application controller) to decide whether they should continue on
+                waiting for the snapshot to be created based on the type of error
+                reported.
+              properties:
+                message:
+                  description: 'message is a string detailing the encountered error
+                    during snapshot creation if specified. NOTE: message may be logged,
+                    and it should not contain sensitive information.'
+                  type: string
+                time:
+                  description: time is the timestamp when the error was encountered.
+                  format: date-time
+                  type: string
+              type: object
+            readyToUse:
+              description: readyToUse indicates if a snapshot is ready to be used
+                to restore a volume. In dynamic snapshot creation case, this field
+                will be filled in with the "ready_to_use" value returned from CSI
+                "CreateSnapshotRequest" gRPC call. For a pre-existing snapshot, this
+                field will be filled with the "ready_to_use" value returned from the
+                CSI "ListSnapshots" gRPC call if the driver supports it, otherwise,
+                this field will be set to "True". If not specified, it means the readiness
+                of a snapshot is unknown.
+              type: boolean
+            restoreSize:
+              description: restoreSize represents the complete size of the snapshot
+                in bytes. In dynamic snapshot creation case, this field will be filled
+                in with the "size_bytes" value returned from CSI "CreateSnapshotRequest"
+                gRPC call. For a pre-existing snapshot, this field will be filled
+                with the "size_bytes" value returned from the CSI "ListSnapshots"
+                gRPC call if the driver supports it. When restoring a volume from
+                this snapshot, the size of the volume MUST NOT be smaller than the
+                restoreSize if it is specified, otherwise the restoration will fail.
+                If not specified, it indicates that the size is unknown.
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+
+apiVersion: storage.k8s.io/v1beta1
+kind: CSIDriver
+metadata:
+  name: cstor.csi.openebs.io
+spec:
+  # Supports persistent inline volumes.
+  volumeLifecycleModes:
+  - Persistent
+  # To determine at runtime which mode a volume uses, pod info and its
+  # "csi.storage.k8s.io/ephemeral" entry are needed.
+  podInfoOnMount: true
+  attachRequired: true
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-csi-snapshotter-binding
+subjects:
+  - kind: ServiceAccount
+    name: openebs-cstor-csi-controller-sa
+    namespace: openebs
+roleRef:
+  kind: ClusterRole
+  name: openebs-cstor-csi-snapshotter-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-csi-snapshotter-role
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents/status"]
+    verbs: ["update"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots/status"]
+    verbs: ["update"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["create", "list", "watch", "delete", "get", "update"]
+
+---
+##############################################
+###########                       ############
+###########   Controller plugin   ############
+###########                       ############
+##############################################
+
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: openebs-cstor-csi-controller-sa
+  namespace: openebs
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-csi-provisioner-role
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes", "services"]
+    verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses", "csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["get", "list"]
+
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["*"]
+  - apiGroups: ["*"]
+    resources: ["cstorvolumeattachments", "cstorvolumes","cstorvolumeconfigs"]
+    verbs: ["*"]
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-csi-provisioner-binding
+subjects:
+  - kind: ServiceAccount
+    name: openebs-cstor-csi-controller-sa
+    namespace: openebs
+roleRef:
+  kind: ClusterRole
+  name: openebs-cstor-csi-provisioner-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: openebs-cstor-csi-controller
+  namespace: openebs
+  labels:
+    name: openebs-cstor-csi-controller
+    openebs.io/component-name: openebs-cstor-csi-controller
+    openebs.io/version: dev
+spec:
+  selector:
+    matchLabels:
+      app: openebs-cstor-csi-controller
+      role: openebs-cstor-csi
+      name: openebs-cstor-csi-controller
+      openebs.io/component-name: openebs-cstor-csi-controller
+  serviceName: "openebs-csi"
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: openebs-cstor-csi-controller
+        role: openebs-cstor-csi
+        name: openebs-cstor-csi-controller
+        openebs.io/component-name: openebs-cstor-csi-controller
+        openebs.io/version: dev
+    spec:
+      priorityClassName: system-cluster-critical
+      serviceAccount: openebs-cstor-csi-controller-sa
+      containers:
+        - name: csi-resizer
+          image: quay.io/k8scsi/csi-resizer:v0.4.0
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+            - "--leader-election"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: csi-snapshotter
+          image: quay.io/k8scsi/csi-snapshotter:v2.0.1
+          args:
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: snapshot-controller
+          image: quay.io/k8scsi/snapshot-controller:v2.0.1
+          args:
+            - "--v=5"
+            - "--leader-election=false"
+          imagePullPolicy: IfNotPresent
+        - name: csi-provisioner
+          image: quay.io/k8scsi/csi-provisioner:v1.6.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--provisioner=cstor.csi.openebs.io"
+            - "--csi-address=$(ADDRESS)"
+            - "--v=5"
+            - "--feature-gates=Topology=true"
+            - "--extra-create-metadata=true"
+          env:
+            - name: MY_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: csi-attacher
+          image: quay.io/k8scsi/csi-attacher:v2.0.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: csi-cluster-driver-registrar
+          image: quay.io/k8scsi/csi-cluster-driver-registrar:v1.0.1
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--v=5"
+            - "--driver-requires-attachment=true"
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: cstor-csi-plugin
+          image: openebs/cstor-csi-driver:2.0.0-RC2
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: OPENEBS_CONTROLLER_DRIVER
+              value: controller
+            - name: OPENEBS_CSI_ENDPOINT
+              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+            - name: OPENEBS_CSI_API_URL
+              value: https://openebs.io
+              # OpenEBS namespace where the openebs cstor operator components
+              # has been installed
+            - name: OPENEBS_NAMESPACE
+              value: openebs
+          args :
+            - "--endpoint=$(OPENEBS_CSI_ENDPOINT)"
+            - "--url=$(OPENEBS_CSI_API_URL)"
+            - "--plugin=$(OPENEBS_CONTROLLER_DRIVER)"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+      volumes:
+        - name: socket-dir
+          emptyDir: {}
+---
+
+############################## CSI- Attacher #######################
+# Attacher must be able to work with PVs, nodes and VolumeAttachments
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-csi-attacher-role
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csinodeinfos"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments", "csinodes"]
+    verbs: ["get", "list", "watch", "update"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-csi-attacher-binding
+subjects:
+  - kind: ServiceAccount
+    name: openebs-cstor-csi-controller-sa
+    namespace: openebs
+roleRef:
+  kind: ClusterRole
+  name: openebs-cstor-csi-attacher-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-csi-cluster-registrar-role
+rules:
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csidrivers"]
+    verbs: ["create", "delete"]
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-csi-cluster-registrar-binding
+subjects:
+  - kind: ServiceAccount
+    name: openebs-cstor-csi-controller-sa
+    namespace: openebs
+roleRef:
+  kind: ClusterRole
+  name: openebs-cstor-csi-cluster-registrar-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+########################################
+###########                 ############
+###########   Node plugin   ############
+###########                 ############
+########################################
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openebs-cstor-csi-node-sa
+  namespace: openebs
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-csi-registrar-role
+rules:
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes", "nodes", "services"]
+    verbs: ["get", "list", "patch"]
+  - apiGroups: ["*"]
+    resources: ["cstorvolumeattachments", "cstorvolumes","cstorvolumeconfigs"]
+    verbs: ["get", "list", "watch", "create", "update", "delete", "patch"]
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-csi-registrar-binding
+subjects:
+  - kind: ServiceAccount
+    name: openebs-cstor-csi-node-sa
+    namespace: openebs
+roleRef:
+  kind: ClusterRole
+  name: openebs-cstor-csi-registrar-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: openebs-cstor-csi-iscsiadm
+  namespace: openebs
+data:
+  iscsiadm: |
+    #!/bin/sh
+    if [ -x /host/sbin/iscsiadm ]; then
+      chroot /host /sbin/iscsiadm "$@"
+    elif [ -x /host/usr/local/sbin/iscsiadm ]; then
+      chroot /host /usr/local/sbin/iscsiadm "$@"
+    elif [ -x /host/bin/iscsiadm ]; then
+      chroot /host /bin/iscsiadm "$@"
+    elif [ -x /host/usr/local/bin/iscsiadm ]; then
+      chroot /host /usr/local/bin/iscsiadm "$@"
+    else
+      chroot /host iscsiadm "$@"
+    fi
+
+---
+
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: openebs-cstor-csi-node
+  namespace: openebs
+  labels:
+    app: openebs-cstor-csi-node
+    name: openebs-cstor-csi-node
+    openebs.io/component-name: openebs-cstor-csi-node
+    openebs.io/version: dev
+spec:
+  selector:
+    matchLabels:
+      app: openebs-cstor-csi-node
+      role: openebs-cstor-csi
+      name: openebs-cstor-csi-node
+      openebs.io/component-name: openebs-cstor-csi-node
+  template:
+    metadata:
+      labels:
+        app: openebs-cstor-csi-node
+        role: openebs-cstor-csi
+        name: openebs-cstor-csi-node
+        openebs.io/component-name: openebs-cstor-csi-node
+        openebs.io/version: dev
+    spec:
+      priorityClassName: system-node-critical
+      serviceAccount: openebs-cstor-csi-node-sa
+      hostNetwork: true
+      containers:
+        - name: csi-node-driver-registrar
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.0.1
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+            - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "rm -rf /registration/cstor.csi.openebs.io /registration/cstor.csi.openebs.io-reg.sock"]
+          env:
+            - name: ADDRESS
+              value: /plugin/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: /var/lib/kubelet/plugins/cstor.csi.openebs.io/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: NODE_DRIVER
+              value: openebs-cstor-csi
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /plugin
+            - name: registration-dir
+              mountPath: /registration
+        - name: cstor-csi-plugin
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["CAP_MKNOD", "CAP_SYS_ADMIN", "SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+          image: openebs/cstor-csi-driver:2.0.0-RC2
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--nodeid=$(OPENEBS_NODE_ID)"
+            - "--endpoint=$(OPENEBS_CSI_ENDPOINT)"
+            - "--url=$(OPENEBS_CSI_API_URL)"
+            - "--plugin=$(OPENEBS_NODE_DRIVER)"
+          env:
+            - name: OPENEBS_NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: OPENEBS_CSI_ENDPOINT
+              value: unix:///plugin/csi.sock
+            - name: OPENEBS_NODE_DRIVER
+              value: node
+            - name: OPENEBS_CSI_API_URL
+              value: https://openebs.io
+              # OpenEBS namespace where the openebs cstor operator components
+              # has been installed
+            - name: OPENEBS_NAMESPACE
+              value: openebs
+              # Enable/Disable auto-remount feature, when volumes
+              # recovers form the read-only state
+            - name: REMOUNT
+              value: "false"
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /plugin
+            - name: device-dir
+              mountPath: /dev
+            - name: pods-mount-dir
+              mountPath: /var/lib/kubelet/
+              # needed so that any mounts setup inside this container are
+              # propagated back to the host machine.
+              mountPropagation: "Bidirectional"
+            - name: host-root
+              mountPath: /host
+              mountPropagation: "HostToContainer"
+            - name: chroot-iscsiadm
+              mountPath: /sbin/iscsiadm
+              subPath: iscsiadm
+      volumes:
+        - name: device-dir
+          hostPath:
+            path: /dev
+            type: Directory
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry/
+            type: DirectoryOrCreate
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/cstor.csi.openebs.io/
+            type: DirectoryOrCreate
+        - name: pods-mount-dir
+          hostPath:
+            path: /var/lib/kubelet/
+            type: Directory
+        - name: chroot-iscsiadm
+          configMap:
+            defaultMode: 0555
+            name: openebs-cstor-csi-iscsiadm
+        - name: host-root
+          hostPath:
+            path: /
+            type: Directory
+---
+###########################################################################
+####                                                                   ####
+####                     CStor-Operator yaml                           ####
+####                                                                   ####
+###########################################################################
+#
+#
+###########################################################################
+#                                                                       ###
+#                        CStorPoolCluster CRD                           ###
+#                                                                       ###
+###########################################################################
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  name: cstorpoolclusters.cstor.openebs.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.healthyInstances
+    description: The number of healthy cStorPoolInstances
+    name: HealthyInstances
+    type: integer
+  - JSONPath: .status.provisionedInstances
+    description: The number of provisioned cStorPoolInstances
+    name: ProvisionedInstances
+    type: integer
+  - JSONPath: .status.desiredInstances
+    description: The number of desired cStorPoolInstances
+    name: DesiredInstances
+    type: integer
+  - JSONPath: .metadata.creationTimestamp
+    description: Age of CStorPoolCluster
+    name: Age
+    type: date
+  group: cstor.openebs.io
+  names:
+    kind: CStorPoolCluster
+    listKind: CStorPoolClusterList
+    plural: cstorpoolclusters
+    shortNames:
+    - cspc
+    singular: cstorpoolcluster
+  preserveUnknownFields: false
+  scope: Namespaced
+  subresources: {}
+  validation:
+    openAPIV3Schema:
+      description: CStorPoolCluster describes a CStorPoolCluster custom resource.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: CStorPoolClusterSpec is the spec for a CStorPoolClusterSpec
+            resource
+          properties:
+            auxResources:
+              description: AuxResources are the compute resources required by the
+                cstor-pool pod side car containers.
+              nullable: true
+              properties:
+                limits:
+                  additionalProperties:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: 'Limits describes the maximum amount of compute resources
+                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+                requests:
+                  additionalProperties:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: 'Requests describes the minimum amount of compute resources
+                    required. If Requests is omitted for a container, it defaults
+                    to Limits if that is explicitly specified, otherwise to an implementation-defined
+                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+              type: object
+            pools:
+              description: Pools is the spec for pools for various nodes where it
+                should be created.
+              items:
+                description: PoolSpec is the spec for pool on node where it should
+                  be created.
+                properties:
+                  dataRaidGroups:
+                    description: DataRaidGroups is the raid group configuration for
+                      the given pool.
+                    items:
+                      description: RaidGroup contains the details of a raid group
+                        for the pool
+                      properties:
+                        blockDevices:
+                          items:
+                            description: CStorPoolInstanceBlockDevice contains the
+                              details of block devices that constitutes a raid group.
+                            properties:
+                              blockDeviceName:
+                                description: BlockDeviceName is the name of the block
+                                  device.
+                                type: string
+                              capacity:
+                                description: Capacity is the capacity of the block
+                                  device. It is system generated
+                                format: int64
+                                type: integer
+                              devLink:
+                                description: DevLink is the dev link for block devices
+                                type: string
+                            required:
+                            - blockDeviceName
+                            type: object
+                          type: array
+                      required:
+                      - blockDevices
+                      type: object
+                    type: array
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: NodeSelector is the labels that will be used to select
+                      a node for pool provisioning. Required field
+                    type: object
+                  poolConfig:
+                    description: PoolConfig is the default pool config that applies
+                      to the pool on node.
+                    properties:
+                      auxResources:
+                        description: AuxResources are the compute resources required
+                          by the cstor-pool pod side car containers.
+                        nullable: true
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                        type: object
+                      compression:
+                        description: 'Compression to enable compression Optional --
+                          defaults to off Possible values : lz, off'
+                        type: string
+                      dataRaidGroupType:
+                        description: DataRaidGroupType is the  raid type.
+                        type: string
+                      priorityClassName:
+                        description: PriorityClassName if specified applies to this
+                          pool pod If left empty, DefaultPriorityClassName is applied.
+                          (See CStorPoolClusterSpec.DefaultPriorityClassName) If both
+                          are empty, not priority class is applied.
+                        nullable: true
+                        type: string
+                      resources:
+                        description: Resources are the compute resources required
+                          by the cstor-pool container.
+                        nullable: true
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                        type: object
+                      roThresholdLimit:
+                        description: 'ROThresholdLimit is threshold(percentage base)
+                          limit for pool read only mode. If ROThresholdLimit(%) amount
+                          of pool storage is reached then pool will set to readonly.
+                          NOTE: 1. If ROThresholdLimit is set to 100 then entire    pool
+                          storage will be used by default it will be set to 85%. 2.
+                          ROThresholdLimit value will be 0 <= ROThresholdLimit <=
+                          100.'
+                        nullable: true
+                        type: integer
+                      thickProvision:
+                        description: ThickProvision to enable thick provisioning Optional
+                          -- defaults to false
+                        type: boolean
+                      tolerations:
+                        description: Tolerations, if specified, the pool pod's tolerations.
+                        items:
+                          description: The pod this Toleration is attached to tolerates
+                            any taint that matches the triple <key,value,effect> using
+                            the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match.
+                                Empty means match all taint effects. When specified,
+                                allowed values are NoSchedule, PreferNoSchedule and
+                                NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration
+                                applies to. Empty means match all taint keys. If the
+                                key is empty, operator must be Exists; this combination
+                                means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship
+                                to the value. Valid operators are Exists and Equal.
+                                Defaults to Equal. Exists is equivalent to wildcard
+                                for value, so that a pod can tolerate all taints of
+                                a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period
+                                of time the toleration (which must be of effect NoExecute,
+                                otherwise this field is ignored) tolerates the taint.
+                                By default, it is not set, which means tolerate the
+                                taint forever (do not evict). Zero and negative values
+                                will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration
+                                matches to. If the operator is Exists, the value should
+                                be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        nullable: true
+                        type: array
+                      writeCacheGroupType:
+                        description: WriteCacheGroupType is the write cache raid type.
+                        type: string
+                    required:
+                    - dataRaidGroupType
+                    type: object
+                  writeCacheRaidGroups:
+                    description: WriteCacheRaidGroups is the write cache raid group.
+                    items:
+                      description: RaidGroup contains the details of a raid group
+                        for the pool
+                      properties:
+                        blockDevices:
+                          items:
+                            description: CStorPoolInstanceBlockDevice contains the
+                              details of block devices that constitutes a raid group.
+                            properties:
+                              blockDeviceName:
+                                description: BlockDeviceName is the name of the block
+                                  device.
+                                type: string
+                              capacity:
+                                description: Capacity is the capacity of the block
+                                  device. It is system generated
+                                format: int64
+                                type: integer
+                              devLink:
+                                description: DevLink is the dev link for block devices
+                                type: string
+                            required:
+                            - blockDeviceName
+                            type: object
+                          type: array
+                      required:
+                      - blockDevices
+                      type: object
+                    nullable: true
+                    type: array
+                required:
+                - dataRaidGroups
+                - nodeSelector
+                type: object
+              type: array
+            priorityClassName:
+              description: DefaultPriorityClassName if specified applies to all the
+                pool pods in the pool spec if the priorityClass at the pool level
+                is not specified.
+              type: string
+            resources:
+              description: DefaultResources are the compute resources required by
+                the cstor-pool container. If the resources at PoolConfig is not specified,
+                this is written to CSPI PoolConfig.
+              nullable: true
+              properties:
+                limits:
+                  additionalProperties:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: 'Limits describes the maximum amount of compute resources
+                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+                requests:
+                  additionalProperties:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: 'Requests describes the minimum amount of compute resources
+                    required. If Requests is omitted for a container, it defaults
+                    to Limits if that is explicitly specified, otherwise to an implementation-defined
+                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+              type: object
+            tolerations:
+              description: Tolerations, if specified, are the pool pod's tolerations
+                If tolerations at PoolConfig is empty, this is written to CSPI PoolConfig.
+              items:
+                description: The pod this Toleration is attached to tolerates any
+                  taint that matches the triple <key,value,effect> using the matching
+                  operator <operator>.
+                properties:
+                  effect:
+                    description: Effect indicates the taint effect to match. Empty
+                      means match all taint effects. When specified, allowed values
+                      are NoSchedule, PreferNoSchedule and NoExecute.
+                    type: string
+                  key:
+                    description: Key is the taint key that the toleration applies
+                      to. Empty means match all taint keys. If the key is empty, operator
+                      must be Exists; this combination means to match all values and
+                      all keys.
+                    type: string
+                  operator:
+                    description: Operator represents a key's relationship to the value.
+                      Valid operators are Exists and Equal. Defaults to Equal. Exists
+                      is equivalent to wildcard for value, so that a pod can tolerate
+                      all taints of a particular category.
+                    type: string
+                  tolerationSeconds:
+                    description: TolerationSeconds represents the period of time the
+                      toleration (which must be of effect NoExecute, otherwise this
+                      field is ignored) tolerates the taint. By default, it is not
+                      set, which means tolerate the taint forever (do not evict).
+                      Zero and negative values will be treated as 0 (evict immediately)
+                      by the system.
+                    format: int64
+                    type: integer
+                  value:
+                    description: Value is the taint value the toleration matches to.
+                      If the operator is Exists, the value should be empty, otherwise
+                      just a regular string.
+                    type: string
+                type: object
+              nullable: true
+              type: array
+          type: object
+        status:
+          description: CStorPoolClusterStatus represents the latest available observations
+            of a CSPC's current state.
+          properties:
+            conditions:
+              description: Current state of CSPC.
+              items:
+                description: CStorPoolClusterCondition describes the state of a CSPC
+                  at a certain point.
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    description: The last time this condition was updated.
+                    format: date-time
+                    type: string
+                  message:
+                    description: A human readable message indicating details about
+                      the transition.
+                    type: string
+                  reason:
+                    description: The reason for the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of CSPC condition.
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              nullable: true
+              type: array
+            desiredInstances:
+              description: DesiredInstances is the number of CSPI(s) that should be
+                provisioned.
+              format: int32
+              nullable: true
+              type: integer
+            healthyInstances:
+              description: HealthyInstances is the number of CSPI(s) that are healthy.
+              format: int32
+              nullable: true
+              type: integer
+            provisionedInstances:
+              description: ProvisionedInstances is the the number of CSPI present
+                at the current state.
+              format: int32
+              nullable: true
+              type: integer
+          type: object
+        versionDetails:
+          description: VersionDetails provides the details for upgrade
+          properties:
+            autoUpgrade:
+              description: If AutoUpgrade is set to true then the resource is upgraded
+                automatically without any manual steps
+              type: boolean
+            desired:
+              description: Desired is the version that we want to upgrade or the control
+                plane version
+              type: string
+            status:
+              description: Status gives the status of reconciliation triggered when
+                the desired and current version are not same
+              properties:
+                current:
+                  description: Current is the version of resource
+                  type: string
+                dependentsUpgraded:
+                  description: DependentsUpgraded gives the details whether all children
+                    of a resource are upgraded to desired version or not
+                  type: boolean
+                lastUpdateTime:
+                  description: LastUpdateTime is the time the status was last  updated
+                  format: date-time
+                  nullable: true
+                  type: string
+                message:
+                  description: Message is a human readable message if some error occurs
+                  type: string
+                reason:
+                  description: Reason is the actual reason for the error state
+                  type: string
+                state:
+                  description: State is the state of reconciliation
+                  type: string
+              type: object
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+################################################################################
+###                                                                         ####
+###                       CStorPoolInstance CRD                             ####
+###                                                                         ####
+################################################################################
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  name: cstorpoolinstances.cstor.openebs.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.hostName
+    description: Host name where cstorpool instances scheduled
+    name: HostName
+    type: string
+  - JSONPath: .status.capacity.used
+    description: The amount of storage space within the pool that has been physically
+      allocated
+    name: Allocated
+    type: string
+  - JSONPath: .status.capacity.free
+    description: The amount of usable free space available in the pool
+    name: Free
+    type: string
+  - JSONPath: .status.capacity.total
+    description: Total amount of usable space in pool
+    name: Capacity
+    type: string
+  - JSONPath: .status.readOnly
+    description: Identifies the pool read only mode
+    name: ReadOnly
+    type: boolean
+  - JSONPath: .status.provisionedReplicas
+    description: Represents no.of replicas present in the pool
+    name: ProvisionedReplicas
+    type: integer
+  - JSONPath: .status.healthyReplicas
+    description: Represents no.of healthy replicas present in the pool
+    name: HealthyReplicas
+    type: integer
+  - JSONPath: .spec.poolConfig.dataRaidGroupType
+    description: Represents the type of the storage pool
+    name: Type
+    type: string
+  - JSONPath: .status.phase
+    description: Identifies the current health of the pool
+    name: Status
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: Age of CStorPoolInstance
+    name: Age
+    type: date
+  group: cstor.openebs.io
+  names:
+    kind: CStorPoolInstance
+    listKind: CStorPoolInstanceList
+    plural: cstorpoolinstances
+    shortNames:
+    - cspi
+    singular: cstorpoolinstance
+  preserveUnknownFields: false
+  scope: Namespaced
+  subresources: {}
+  validation:
+    openAPIV3Schema:
+      description: CStorPoolInstance describes a cstor pool instance resource.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: Spec is the specification of the cstorpoolinstance resource.
+          properties:
+            dataRaidGroups:
+              description: DataRaidGroups is the raid group configuration for the
+                given pool.
+              items:
+                description: RaidGroup contains the details of a raid group for the
+                  pool
+                properties:
+                  blockDevices:
+                    items:
+                      description: CStorPoolInstanceBlockDevice contains the details
+                        of block devices that constitutes a raid group.
+                      properties:
+                        blockDeviceName:
+                          description: BlockDeviceName is the name of the block device.
+                          type: string
+                        capacity:
+                          description: Capacity is the capacity of the block device.
+                            It is system generated
+                          format: int64
+                          type: integer
+                        devLink:
+                          description: DevLink is the dev link for block devices
+                          type: string
+                      required:
+                      - blockDeviceName
+                      type: object
+                    type: array
+                required:
+                - blockDevices
+                type: object
+              type: array
+            hostName:
+              description: HostName is the name of kubernetes node where the pool
+                should be created.
+              type: string
+            nodeSelector:
+              additionalProperties:
+                type: string
+              description: NodeSelector is the labels that will be used to select
+                a node for pool provisioning. Required field
+              type: object
+            poolConfig:
+              description: PoolConfig is the default pool config that applies to the
+                pool on node.
+              properties:
+                auxResources:
+                  description: AuxResources are the compute resources required by
+                    the cstor-pool pod side car containers.
+                  nullable: true
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                  type: object
+                compression:
+                  description: 'Compression to enable compression Optional -- defaults
+                    to off Possible values : lz, off'
+                  type: string
+                dataRaidGroupType:
+                  description: DataRaidGroupType is the  raid type.
+                  type: string
+                priorityClassName:
+                  description: PriorityClassName if specified applies to this pool
+                    pod If left empty, DefaultPriorityClassName is applied. (See CStorPoolClusterSpec.DefaultPriorityClassName)
+                    If both are empty, not priority class is applied.
+                  nullable: true
+                  type: string
+                resources:
+                  description: Resources are the compute resources required by the
+                    cstor-pool container.
+                  nullable: true
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                  type: object
+                roThresholdLimit:
+                  description: 'ROThresholdLimit is threshold(percentage base) limit
+                    for pool read only mode. If ROThresholdLimit(%) amount of pool
+                    storage is reached then pool will set to readonly. NOTE: 1. If
+                    ROThresholdLimit is set to 100 then entire    pool storage will
+                    be used by default it will be set to 85%. 2. ROThresholdLimit
+                    value will be 0 <= ROThresholdLimit <= 100.'
+                  nullable: true
+                  type: integer
+                thickProvision:
+                  description: ThickProvision to enable thick provisioning Optional
+                    -- defaults to false
+                  type: boolean
+                tolerations:
+                  description: Tolerations, if specified, the pool pod's tolerations.
+                  items:
+                    description: The pod this Toleration is attached to tolerates
+                      any taint that matches the triple <key,value,effect> using the
+                      matching operator <operator>.
+                    properties:
+                      effect:
+                        description: Effect indicates the taint effect to match. Empty
+                          means match all taint effects. When specified, allowed values
+                          are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                      key:
+                        description: Key is the taint key that the toleration applies
+                          to. Empty means match all taint keys. If the key is empty,
+                          operator must be Exists; this combination means to match
+                          all values and all keys.
+                        type: string
+                      operator:
+                        description: Operator represents a key's relationship to the
+                          value. Valid operators are Exists and Equal. Defaults to
+                          Equal. Exists is equivalent to wildcard for value, so that
+                          a pod can tolerate all taints of a particular category.
+                        type: string
+                      tolerationSeconds:
+                        description: TolerationSeconds represents the period of time
+                          the toleration (which must be of effect NoExecute, otherwise
+                          this field is ignored) tolerates the taint. By default,
+                          it is not set, which means tolerate the taint forever (do
+                          not evict). Zero and negative values will be treated as
+                          0 (evict immediately) by the system.
+                        format: int64
+                        type: integer
+                      value:
+                        description: Value is the taint value the toleration matches
+                          to. If the operator is Exists, the value should be empty,
+                          otherwise just a regular string.
+                        type: string
+                    type: object
+                  nullable: true
+                  type: array
+                writeCacheGroupType:
+                  description: WriteCacheGroupType is the write cache raid type.
+                  type: string
+              required:
+              - dataRaidGroupType
+              type: object
+            writeCacheRaidGroups:
+              description: WriteCacheRaidGroups is the write cache raid group.
+              items:
+                description: RaidGroup contains the details of a raid group for the
+                  pool
+                properties:
+                  blockDevices:
+                    items:
+                      description: CStorPoolInstanceBlockDevice contains the details
+                        of block devices that constitutes a raid group.
+                      properties:
+                        blockDeviceName:
+                          description: BlockDeviceName is the name of the block device.
+                          type: string
+                        capacity:
+                          description: Capacity is the capacity of the block device.
+                            It is system generated
+                          format: int64
+                          type: integer
+                        devLink:
+                          description: DevLink is the dev link for block devices
+                          type: string
+                      required:
+                      - blockDeviceName
+                      type: object
+                    type: array
+                required:
+                - blockDevices
+                type: object
+              nullable: true
+              type: array
+          required:
+          - dataRaidGroups
+          - nodeSelector
+          type: object
+        status:
+          description: Status is the possible statuses of the cstorpoolinstance resource.
+          properties:
+            capacity:
+              description: Capacity describes the capacity details of a cstor pool
+              properties:
+                free:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  description: Amount of usable space in the pool after excluding
+                    metadata and raid parity
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                total:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  description: Sum of usable capacity in all the data raidgroups
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                used:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  description: Amount of physical data (and its metadata) written
+                    to pool after applying compression, etc..,
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                zfs:
+                  description: ZFSCapacityAttributes contains advanced information
+                    about pool capacity details
+                  properties:
+                    logicalUsed:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: LogicalUsed is the amount of space that is "logically"
+                        consumed by this pool and all its descendents. The logical
+                        space ignores the effect of the compression and copies properties,
+                        giving a quantity closer to the amount of data that applications
+                        see. However, it does include space consumed by metadata.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  required:
+                  - logicalUsed
+                  type: object
+              required:
+              - free
+              - total
+              - used
+              - zfs
+              type: object
+            conditions:
+              description: Current state of CSPI with details.
+              items:
+                description: CSPIConditionType describes the state of a CSPI at a
+                  certain point.
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    description: The last time this condition was updated.
+                    format: date-time
+                    type: string
+                  message:
+                    description: A human readable message indicating details about
+                      the transition.
+                    type: string
+                  reason:
+                    description: The reason for the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of CSPC condition.
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+            healthyReplicas:
+              description: HealthyReplicas describes the total count of healthy Volume
+                Replicas in the cstor pool
+              format: int32
+              type: integer
+            phase:
+              description: ' The phase of a CStorPool is a simple, high-level summary
+                of the pool state on the  node.'
+              type: string
+            provisionedReplicas:
+              description: ProvisionedReplicas describes the total count of Volume
+                Replicas present in the cstor pool
+              format: int32
+              type: integer
+            readOnly:
+              description: ReadOnly if pool is readOnly or not
+              type: boolean
+          type: object
+        versionDetails:
+          description: VersionDetails is the openebs version.
+          properties:
+            autoUpgrade:
+              description: If AutoUpgrade is set to true then the resource is upgraded
+                automatically without any manual steps
+              type: boolean
+            desired:
+              description: Desired is the version that we want to upgrade or the control
+                plane version
+              type: string
+            status:
+              description: Status gives the status of reconciliation triggered when
+                the desired and current version are not same
+              properties:
+                current:
+                  description: Current is the version of resource
+                  type: string
+                dependentsUpgraded:
+                  description: DependentsUpgraded gives the details whether all children
+                    of a resource are upgraded to desired version or not
+                  type: boolean
+                lastUpdateTime:
+                  description: LastUpdateTime is the time the status was last  updated
+                  format: date-time
+                  nullable: true
+                  type: string
+                message:
+                  description: Message is a human readable message if some error occurs
+                  type: string
+                reason:
+                  description: Reason is the actual reason for the error state
+                  type: string
+                state:
+                  description: State is the state of reconciliation
+                  type: string
+              type: object
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+#########################################################################
+####                                                                #####
+####                         CStorVolumeConfig CRD                  #####
+####                                                                #####
+#########################################################################
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  name: cstorvolumeconfigs.cstor.openebs.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.capacity.storage
+    description: Identifies the volume capacity
+    name: Capacity
+    type: string
+  - JSONPath: .status.phase
+    description: Identifies the volume provisioning status
+    name: Status
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: Age of CStorVolumeReplica
+    name: Age
+    type: date
+  group: cstor.openebs.io
+  names:
+    kind: CStorVolumeConfig
+    listKind: CStorVolumeConfigList
+    plural: cstorvolumeconfigs
+    shortNames:
+    - cvc
+    singular: cstorvolumeconfig
+  preserveUnknownFields: false
+  scope: Namespaced
+  subresources: {}
+  validation:
+    openAPIV3Schema:
+      description: CStorVolumeConfig describes a cstor volume config resource created
+        as custom resource. CStorVolumeConfig is a request for creating cstor volume
+        related resources like deployment, svc etc.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        publish:
+          description: Publish contains info related to attachment of a volume to
+            a node. i.e. NodeId etc.
+          properties:
+            nodeId:
+              description: NodeID contains publish info related to attachment of a
+                volume to a node.
+              type: string
+          type: object
+        spec:
+          description: Spec defines a specification of a cstor volume config required
+            to provisione cstor volume resources
+          properties:
+            capacity:
+              additionalProperties:
+                anyOf:
+                - type: integer
+                - type: string
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+              description: Capacity represents the actual resources of the underlying
+                cstor volume.
+              type: object
+            cstorVolumeRef:
+              description: CStorVolumeRef has the information about where CstorVolumeClaim
+                is created from.
+              properties:
+                apiVersion:
+                  description: API version of the referent.
+                  type: string
+                fieldPath:
+                  description: 'If referring to a piece of an object instead of an
+                    entire object, this string should contain a valid JSON/Go field
+                    access statement, such as desiredState.manifest.containers[2].
+                    For example, if the object reference is to a container within
+                    a pod, this would take on a value like: "spec.containers{name}"
+                    (where "name" refers to the name of the container that triggered
+                    the event) or if no container name is specified "spec.containers[2]"
+                    (container with index 2 in this pod). This syntax is chosen only
+                    to have some well-defined way of referencing a part of an object.
+                    TODO: this design is not final and this field is subject to change
+                    in the future.'
+                  type: string
+                kind:
+                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+                resourceVersion:
+                  description: 'Specific resourceVersion to which this reference is
+                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                  type: string
+                uid:
+                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                  type: string
+              type: object
+            cstorVolumeSource:
+              description: CStorVolumeSource contains the source volumeName@snapShotname
+                combaination.  This will be filled only if it is a clone creation.
+              type: string
+            policy:
+              description: Policy contains volume specific required policies target
+                and replicas
+              properties:
+                provision:
+                  description: replicaAffinity is set to true then volume replica
+                    resources need to be distributed across the pool instances
+                  properties:
+                    blockSize:
+                      description: BlockSize is the logical block size in multiple
+                        of 512 bytes BlockSize specifies the block size of the volume.
+                        The blocksize cannot be changed once the volume has been written,
+                        so it should be set at volume creation time. The default blocksize
+                        for volumes is 4 Kbytes. Any power of 2 from 512 bytes to
+                        128 Kbytes is valid.
+                      format: int32
+                      type: integer
+                    replicaAffinity:
+                      description: replicaAffinity is set to true then volume replica
+                        resources need to be distributed across the cstor pool instances
+                        based on the given topology
+                      type: boolean
+                  required:
+                  - replicaAffinity
+                  type: object
+                replica:
+                  description: ReplicaSpec represents configuration related to replicas
+                    resources
+                  properties:
+                    compression:
+                      description: The zle compression algorithm compresses runs of
+                        zeros.
+                      type: string
+                    zvolWorkers:
+                      description: IOWorkers represents number of threads that executes
+                        client IOs
+                      type: string
+                  type: object
+                replicaPoolInfo:
+                  description: 'ReplicaPoolInfo holds the pool information of volume
+                    replicas. Ex: If volume is provisioned on which CStor pool volume
+                    replicas exist'
+                  items:
+                    description: ReplicaPoolInfo represents the pool information of
+                      volume replica
+                    properties:
+                      poolName:
+                        description: PoolName represents the pool name where volume
+                          replica exists
+                        type: string
+                    required:
+                    - poolName
+                    type: object
+                  type: array
+                target:
+                  description: TargetSpec represents configuration related to cstor
+                    target and its resources
+                  properties:
+                    affinity:
+                      description: PodAffinity if specified, are the target pod's
+                        affinities
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          description: The scheduler will prefer to schedule pods
+                            to nodes that satisfy the affinity expressions specified
+                            by this field, but it may choose a node that violates
+                            one or more of the expressions. The node that is most
+                            preferred is the one with the greatest sum of weights,
+                            i.e. for each node that meets all of the scheduling requirements
+                            (resource request, requiredDuringScheduling affinity expressions,
+                            etc.), compute a sum by iterating through the elements
+                            of this field and adding "weight" to the sum if the node
+                            has pods which matches the corresponding podAffinityTerm;
+                            the node(s) with the highest sum are the most preferred.
+                          items:
+                            description: The weights of all of the matched WeightedPodAffinityTerm
+                              fields are added per-node to find the most preferred
+                              node(s)
+                            properties:
+                              podAffinityTerm:
+                                description: Required. A pod affinity term, associated
+                                  with the corresponding weight.
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies which namespaces
+                                      the labelSelector applies to (matches against);
+                                      null or empty list means "this pod's namespace"
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified
+                                      namespaces, where co-located is defined as running
+                                      on a node whose value of the label with key
+                                      topologyKey matches that of any node on which
+                                      any of the selected pods is running. Empty topologyKey
+                                      is not allowed.
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              weight:
+                                description: weight associated with matching the corresponding
+                                  podAffinityTerm, in the range 1-100.
+                                format: int32
+                                type: integer
+                            required:
+                            - podAffinityTerm
+                            - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          description: If the affinity requirements specified by this
+                            field are not met at scheduling time, the pod will not
+                            be scheduled onto the node. If the affinity requirements
+                            specified by this field cease to be met at some point
+                            during pod execution (e.g. due to a pod label update),
+                            the system may or may not try to eventually evict the
+                            pod from its node. When there are multiple elements, the
+                            lists of nodes corresponding to each podAffinityTerm are
+                            intersected, i.e. all terms must be satisfied.
+                          items:
+                            description: Defines a set of pods (namely those matching
+                              the labelSelector relative to the given namespace(s))
+                              that this pod should be co-located (affinity) or not
+                              co-located (anti-affinity) with, where co-located is
+                              defined as running on a node whose value of the label
+                              with key <topologyKey> matches that of any node on which
+                              a pod of the set of pods is running
+                            properties:
+                              labelSelector:
+                                description: A label query over a set of resources,
+                                  in this case pods.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaces:
+                                description: namespaces specifies which namespaces
+                                  the labelSelector applies to (matches against);
+                                  null or empty list means "this pod's namespace"
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods
+                                  matching the labelSelector in the specified namespaces,
+                                  where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches
+                                  that of any node on which any of the selected pods
+                                  is running. Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          type: array
+                      type: object
+                    auxResources:
+                      description: AuxResources are the compute resources required
+                        by the cstor-target pod side car containers.
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                      type: object
+                    luWorkers:
+                      description: IOWorkers sets the number of threads that are working
+                        on above queue
+                      format: int64
+                      type: integer
+                    monitor:
+                      description: Monitor enables or disables the target exporter
+                        sidecar
+                      type: boolean
+                    nodeSelector:
+                      additionalProperties:
+                        type: string
+                      description: NodeSelector is the labels that will be used to
+                        select a node for target pod scheduleing Required field
+                      type: object
+                    priorityClassName:
+                      description: PriorityClassName if specified applies to this
+                        target pod If left empty, no priority class is applied.
+                      type: string
+                    queueDepth:
+                      description: QueueDepth sets the queue size at iSCSI target
+                        which limits the ongoing IO count from client
+                      type: string
+                    replicationFactor:
+                      description: ReplicationFactor represents maximum number of
+                        replicas that are allowed to connect to the target
+                      format: int64
+                      type: integer
+                    resources:
+                      description: Resources are the compute resources required by
+                        the cstor-target container.
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                      type: object
+                    tolerations:
+                      description: Tolerations, if specified, are the target pod's
+                        tolerations
+                      items:
+                        description: The pod this Toleration is attached to tolerates
+                          any taint that matches the triple <key,value,effect> using
+                          the matching operator <operator>.
+                        properties:
+                          effect:
+                            description: Effect indicates the taint effect to match.
+                              Empty means match all taint effects. When specified,
+                              allowed values are NoSchedule, PreferNoSchedule and
+                              NoExecute.
+                            type: string
+                          key:
+                            description: Key is the taint key that the toleration
+                              applies to. Empty means match all taint keys. If the
+                              key is empty, operator must be Exists; this combination
+                              means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: Operator represents a key's relationship
+                              to the value. Valid operators are Exists and Equal.
+                              Defaults to Equal. Exists is equivalent to wildcard
+                              for value, so that a pod can tolerate all taints of
+                              a particular category.
+                            type: string
+                          tolerationSeconds:
+                            description: TolerationSeconds represents the period of
+                              time the toleration (which must be of effect NoExecute,
+                              otherwise this field is ignored) tolerates the taint.
+                              By default, it is not set, which means tolerate the
+                              taint forever (do not evict). Zero and negative values
+                              will be treated as 0 (evict immediately) by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: Value is the taint value the toleration matches
+                              to. If the operator is Exists, the value should be empty,
+                              otherwise just a regular string.
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+              type: object
+            provision:
+              description: Provision represents the initial volume configuration for
+                the underlying cstor volume based on the persistent volume request
+                by user. Provision properties are immutable
+              properties:
+                capacity:
+                  additionalProperties:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Capacity represents initial capacity of volume replica
+                    required during volume clone operations to maintain some metadata
+                    info related to child resources like snapshot, cloned volumes.
+                  type: object
+                replicaCount:
+                  description: ReplicaCount represents initial cstor volume replica
+                    count, its will not be updated later on based on scale up/down
+                    operations, only readonly operations and validations.
+                  type: integer
+              required:
+              - capacity
+              - replicaCount
+              type: object
+          required:
+          - capacity
+          - policy
+          - provision
+          type: object
+        status:
+          description: Status represents the current information/status for the cstor
+            volume config, populated by the controller.
+          properties:
+            capacity:
+              additionalProperties:
+                anyOf:
+                - type: integer
+                - type: string
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+              description: Capacity the actual resources of the underlying volume.
+              type: object
+            condition:
+              items:
+                description: CStorVolumeConfigCondition contains details about state
+                  of cstor volume
+                properties:
+                  lastProbeTime:
+                    description: Last time we probed the condition.
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Reason is a brief CamelCase string that describes
+                      any failure
+                    type: string
+                  type:
+                    description: Current Condition of cstor volume config. If underlying
+                      persistent volume is being resized then the Condition will be
+                      set to 'ResizeStarted' etc
+                    type: string
+                required:
+                - message
+                - reason
+                - type
+                type: object
+              type: array
+            phase:
+              description: Phase represents the current phase of CStorVolumeConfig.
+              type: string
+            poolInfo:
+              description: PoolInfo represents current pool names where volume replicas
+                exists
+              items:
+                type: string
+              type: array
+          type: object
+        versionDetails:
+          description: VersionDetails provides the details for upgrade
+          properties:
+            autoUpgrade:
+              description: If AutoUpgrade is set to true then the resource is upgraded
+                automatically without any manual steps
+              type: boolean
+            desired:
+              description: Desired is the version that we want to upgrade or the control
+                plane version
+              type: string
+            status:
+              description: Status gives the status of reconciliation triggered when
+                the desired and current version are not same
+              properties:
+                current:
+                  description: Current is the version of resource
+                  type: string
+                dependentsUpgraded:
+                  description: DependentsUpgraded gives the details whether all children
+                    of a resource are upgraded to desired version or not
+                  type: boolean
+                lastUpdateTime:
+                  description: LastUpdateTime is the time the status was last  updated
+                  format: date-time
+                  nullable: true
+                  type: string
+                message:
+                  description: Message is a human readable message if some error occurs
+                  type: string
+                reason:
+                  description: Reason is the actual reason for the error state
+                  type: string
+                state:
+                  description: State is the state of reconciliation
+                  type: string
+              type: object
+          type: object
+      required:
+      - spec
+      - status
+      - versionDetails
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+################################################################
+####                                                       #####
+####                  CStorVolumePolicies                  #####
+####                                                       #####
+################################################################
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  name: cstorvolumepolicies.cstor.openebs.io
+spec:
+  group: cstor.openebs.io
+  names:
+    kind: CStorVolumePolicy
+    listKind: CStorVolumePolicyList
+    plural: cstorvolumepolicies
+    shortNames:
+    - cvp
+    singular: cstorvolumepolicy
+  preserveUnknownFields: false
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: CStorVolumePolicy describes a configuration required for cstor
+        volume resources
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: Spec defines a configuration info of a cstor volume required
+            to provisione cstor volume resources
+          properties:
+            provision:
+              description: replicaAffinity is set to true then volume replica resources
+                need to be distributed across the pool instances
+              properties:
+                blockSize:
+                  description: BlockSize is the logical block size in multiple of
+                    512 bytes BlockSize specifies the block size of the volume. The
+                    blocksize cannot be changed once the volume has been written,
+                    so it should be set at volume creation time. The default blocksize
+                    for volumes is 4 Kbytes. Any power of 2 from 512 bytes to 128
+                    Kbytes is valid.
+                  format: int32
+                  type: integer
+                replicaAffinity:
+                  description: replicaAffinity is set to true then volume replica
+                    resources need to be distributed across the cstor pool instances
+                    based on the given topology
+                  type: boolean
+              required:
+              - replicaAffinity
+              type: object
+            replica:
+              description: ReplicaSpec represents configuration related to replicas
+                resources
+              properties:
+                compression:
+                  description: The zle compression algorithm compresses runs of zeros.
+                  type: string
+                zvolWorkers:
+                  description: IOWorkers represents number of threads that executes
+                    client IOs
+                  type: string
+              type: object
+            replicaPoolInfo:
+              description: 'ReplicaPoolInfo holds the pool information of volume replicas.
+                Ex: If volume is provisioned on which CStor pool volume replicas exist'
+              items:
+                description: ReplicaPoolInfo represents the pool information of volume
+                  replica
+                properties:
+                  poolName:
+                    description: PoolName represents the pool name where volume replica
+                      exists
+                    type: string
+                required:
+                - poolName
+                type: object
+              type: array
+            target:
+              description: TargetSpec represents configuration related to cstor target
+                and its resources
+              properties:
+                affinity:
+                  description: PodAffinity if specified, are the target pod's affinities
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the affinity expressions specified by this field,
+                        but it may choose a node that violates one or more of the
+                        expressions. The node that is most preferred is the one with
+                        the greatest sum of weights, i.e. for each node that meets
+                        all of the scheduling requirements (resource request, requiredDuringScheduling
+                        affinity expressions, etc.), compute a sum by iterating through
+                        the elements of this field and adding "weight" to the sum
+                        if the node has pods which matches the corresponding podAffinityTerm;
+                        the node(s) with the highest sum are the most preferred.
+                      items:
+                        description: The weights of all of the matched WeightedPodAffinityTerm
+                          fields are added per-node to find the most preferred node(s)
+                        properties:
+                          podAffinityTerm:
+                            description: Required. A pod affinity term, associated
+                              with the corresponding weight.
+                            properties:
+                              labelSelector:
+                                description: A label query over a set of resources,
+                                  in this case pods.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaces:
+                                description: namespaces specifies which namespaces
+                                  the labelSelector applies to (matches against);
+                                  null or empty list means "this pod's namespace"
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods
+                                  matching the labelSelector in the specified namespaces,
+                                  where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches
+                                  that of any node on which any of the selected pods
+                                  is running. Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          weight:
+                            description: weight associated with matching the corresponding
+                              podAffinityTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                        - podAffinityTerm
+                        - weight
+                        type: object
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: If the affinity requirements specified by this
+                        field are not met at scheduling time, the pod will not be
+                        scheduled onto the node. If the affinity requirements specified
+                        by this field cease to be met at some point during pod execution
+                        (e.g. due to a pod label update), the system may or may not
+                        try to eventually evict the pod from its node. When there
+                        are multiple elements, the lists of nodes corresponding to
+                        each podAffinityTerm are intersected, i.e. all terms must
+                        be satisfied.
+                      items:
+                        description: Defines a set of pods (namely those matching
+                          the labelSelector relative to the given namespace(s)) that
+                          this pod should be co-located (affinity) or not co-located
+                          (anti-affinity) with, where co-located is defined as running
+                          on a node whose value of the label with key <topologyKey>
+                          matches that of any node on which a pod of the set of pods
+                          is running
+                        properties:
+                          labelSelector:
+                            description: A label query over a set of resources, in
+                              this case pods.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          namespaces:
+                            description: namespaces specifies which namespaces the
+                              labelSelector applies to (matches against); null or
+                              empty list means "this pod's namespace"
+                            items:
+                              type: string
+                            type: array
+                          topologyKey:
+                            description: This pod should be co-located (affinity)
+                              or not co-located (anti-affinity) with the pods matching
+                              the labelSelector in the specified namespaces, where
+                              co-located is defined as running on a node whose value
+                              of the label with key topologyKey matches that of any
+                              node on which any of the selected pods is running. Empty
+                              topologyKey is not allowed.
+                            type: string
+                        required:
+                        - topologyKey
+                        type: object
+                      type: array
+                  type: object
+                auxResources:
+                  description: AuxResources are the compute resources required by
+                    the cstor-target pod side car containers.
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                  type: object
+                luWorkers:
+                  description: IOWorkers sets the number of threads that are working
+                    on above queue
+                  format: int64
+                  type: integer
+                monitor:
+                  description: Monitor enables or disables the target exporter sidecar
+                  type: boolean
+                nodeSelector:
+                  additionalProperties:
+                    type: string
+                  description: NodeSelector is the labels that will be used to select
+                    a node for target pod scheduleing Required field
+                  type: object
+                priorityClassName:
+                  description: PriorityClassName if specified applies to this target
+                    pod If left empty, no priority class is applied.
+                  type: string
+                queueDepth:
+                  description: QueueDepth sets the queue size at iSCSI target which
+                    limits the ongoing IO count from client
+                  type: string
+                replicationFactor:
+                  description: ReplicationFactor represents maximum number of replicas
+                    that are allowed to connect to the target
+                  format: int64
+                  type: integer
+                resources:
+                  description: Resources are the compute resources required by the
+                    cstor-target container.
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                  type: object
+                tolerations:
+                  description: Tolerations, if specified, are the target pod's tolerations
+                  items:
+                    description: The pod this Toleration is attached to tolerates
+                      any taint that matches the triple <key,value,effect> using the
+                      matching operator <operator>.
+                    properties:
+                      effect:
+                        description: Effect indicates the taint effect to match. Empty
+                          means match all taint effects. When specified, allowed values
+                          are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                      key:
+                        description: Key is the taint key that the toleration applies
+                          to. Empty means match all taint keys. If the key is empty,
+                          operator must be Exists; this combination means to match
+                          all values and all keys.
+                        type: string
+                      operator:
+                        description: Operator represents a key's relationship to the
+                          value. Valid operators are Exists and Equal. Defaults to
+                          Equal. Exists is equivalent to wildcard for value, so that
+                          a pod can tolerate all taints of a particular category.
+                        type: string
+                      tolerationSeconds:
+                        description: TolerationSeconds represents the period of time
+                          the toleration (which must be of effect NoExecute, otherwise
+                          this field is ignored) tolerates the taint. By default,
+                          it is not set, which means tolerate the taint forever (do
+                          not evict). Zero and negative values will be treated as
+                          0 (evict immediately) by the system.
+                        format: int64
+                        type: integer
+                      value:
+                        description: Value is the taint value the toleration matches
+                          to. If the operator is Exists, the value should be empty,
+                          otherwise just a regular string.
+                        type: string
+                    type: object
+                  type: array
+              type: object
+          type: object
+        status:
+          description: CStorVolumePolicyStatus is for handling status of CstorVolumePolicy
+          properties:
+            phase:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+#############################################################################################
+###                                                                                    ######
+###                    CStorVolumeReplicas CRD                                         ######
+###                                                                                    ######
+#############################################################################################
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  name: cstorvolumereplicas.cstor.openebs.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.capacity.total
+    description: The amount of disk space consumed by a dataset and all its descendents
+    name: Allocated
+    type: string
+  - JSONPath: .status.capacity.used
+    description: The amount of space that is logically consumed by this dataset
+    name: Used
+    type: string
+  - JSONPath: .status.phase
+    description: Identifies the current state of the replicas
+    name: Status
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: Age of CStorVolumeReplica
+    name: Age
+    type: date
+  group: cstor.openebs.io
+  names:
+    kind: CStorVolumeReplica
+    listKind: CStorVolumeReplicaList
+    plural: cstorvolumereplicas
+    shortNames:
+    - cvr
+    singular: cstorvolumereplica
+  preserveUnknownFields: false
+  scope: Namespaced
+  subresources: {}
+  validation:
+    openAPIV3Schema:
+      description: CStorVolumeReplica describes a cstor volume resource created as
+        custom resource
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: CStorVolumeReplicaSpec is the spec for a CStorVolumeReplica
+            resource
+          properties:
+            blockSize:
+              description: BlockSize is the logical block size in multiple of 512
+                bytes BlockSize specifies the block size of the volume. The blocksize
+                cannot be changed once the volume has been written, so it should be
+                set at volume creation time. The default blocksize for volumes is
+                4 Kbytes. Any power of 2 from 512 bytes to 128 Kbytes is valid.
+              format: int32
+              type: integer
+            capacity:
+              description: Represents the actual capacity of the underlying volume
+              type: string
+            compression:
+              description: 'Controls the compression algorithm used for this volumes
+                examples: on|off|gzip|gzip-N|lz4|lzjb|zle'
+              type: string
+            replicaid:
+              description: ReplicaID is unique number to identify the replica
+              type: string
+            targetIP:
+              description: TargetIP represents iscsi target IP through which replica
+                cummunicates IO workloads and other volume operations like snapshot
+                and resize requests
+              type: string
+            zvolWorkers:
+              description: ZvolWorkers represents number of threads that executes
+                client IOs
+              type: string
+          type: object
+        status:
+          description: CStorVolumeReplicaStatus is for handling status of cvr.
+          properties:
+            capacity:
+              description: CStorVolumeCapacityDetails represents capacity info of
+                replica
+              properties:
+                total:
+                  description: The amount of space consumed by this volume replica
+                    and all its descendents
+                  type: string
+                used:
+                  description: The amount of space that is "logically" accessible
+                    by this dataset. The logical space ignores the effect of the compression
+                    and copies properties, giving a quantity closer to the amount
+                    of data that applications see.  However, it does include space
+                    consumed by metadata
+                  type: string
+              required:
+              - total
+              - used
+              type: object
+            lastTransitionTime:
+              description: LastTransitionTime refers to the time when the phase changes
+              format: date-time
+              nullable: true
+              type: string
+            lastUpdateTime:
+              description: The last updated time
+              format: date-time
+              nullable: true
+              type: string
+            message:
+              description: A human readable message indicating details about the transition.
+              type: string
+            pendingSnapshots:
+              additionalProperties:
+                description: CStorSnapshotInfo represents the snapshot information
+                  related to particular snapshot
+                properties:
+                  logicalReferenced:
+                    description: LogicalReferenced describes the amount of space that
+                      is "logically" accessable by this snapshot. This logical space
+                      ignores the effect of the compression and copies properties,
+                      giving a quantity closer to the amount of data that application
+                      see. It also includes space consumed by metadata.
+                    format: int64
+                    type: integer
+                required:
+                - logicalReferenced
+                type: object
+              description: PendingSnapshots contains list of pending snapshots that
+                are not yet available on this replica
+              type: object
+            phase:
+              description: CStorVolumeReplicaPhase is to holds different phases of
+                replica
+              type: string
+            snapshots:
+              additionalProperties:
+                description: CStorSnapshotInfo represents the snapshot information
+                  related to particular snapshot
+                properties:
+                  logicalReferenced:
+                    description: LogicalReferenced describes the amount of space that
+                      is "logically" accessable by this snapshot. This logical space
+                      ignores the effect of the compression and copies properties,
+                      giving a quantity closer to the amount of data that application
+                      see. It also includes space consumed by metadata.
+                    format: int64
+                    type: integer
+                required:
+                - logicalReferenced
+                type: object
+              description: Snapshots contains list of snapshots, and their properties,
+                created on CVR
+              type: object
+          type: object
+        versionDetails:
+          description: VersionDetails provides the details for upgrade
+          properties:
+            autoUpgrade:
+              description: If AutoUpgrade is set to true then the resource is upgraded
+                automatically without any manual steps
+              type: boolean
+            desired:
+              description: Desired is the version that we want to upgrade or the control
+                plane version
+              type: string
+            status:
+              description: Status gives the status of reconciliation triggered when
+                the desired and current version are not same
+              properties:
+                current:
+                  description: Current is the version of resource
+                  type: string
+                dependentsUpgraded:
+                  description: DependentsUpgraded gives the details whether all children
+                    of a resource are upgraded to desired version or not
+                  type: boolean
+                lastUpdateTime:
+                  description: LastUpdateTime is the time the status was last  updated
+                  format: date-time
+                  nullable: true
+                  type: string
+                message:
+                  description: Message is a human readable message if some error occurs
+                  type: string
+                reason:
+                  description: Reason is the actual reason for the error state
+                  type: string
+                state:
+                  description: State is the state of reconciliation
+                  type: string
+              type: object
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+###############################################################################
+####                                                                       ####
+####               CStorVolume CRD                                         ####
+####                                                                       ####
+###############################################################################
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  name: cstorvolumes.cstor.openebs.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.capacity
+    description: Current volume capacity
+    name: Capacity
+    type: string
+  - JSONPath: .status.phase
+    description: Identifies the current health of the volume
+    name: Status
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: Age of CStorVolume
+    name: Age
+    type: date
+  group: cstor.openebs.io
+  names:
+    kind: CStorVolume
+    listKind: CStorVolumeList
+    plural: cstorvolumes
+    shortNames:
+    - cv
+    singular: cstorvolume
+  preserveUnknownFields: false
+  scope: Namespaced
+  subresources: {}
+  validation:
+    openAPIV3Schema:
+      description: CStorVolume describes a cstor volume resource created as custom
+        resource
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: CStorVolumeSpec is the spec for a CStorVolume resource
+          properties:
+            capacity:
+              anyOf:
+              - type: integer
+              - type: string
+              description: Capacity represents the desired size of the underlying
+                volume.
+              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+              x-kubernetes-int-or-string: true
+            consistencyFactor:
+              description: ConsistencyFactor is minimum number of volume replicas
+                i.e. `RF/2 + 1` has to be connected to the target for write operations.
+                Basically more then 50% of replica has to be connected to target.
+              type: integer
+            desiredReplicationFactor:
+              description: DesiredReplicationFactor represents maximum number of replicas
+                that are allowed to connect to the target. Required for scale operations
+              type: integer
+            iqn:
+              description: Target iSCSI Qualified Name.combination of nodeBase
+              type: string
+            replicaDetails:
+              description: ReplicaDetails refers to the trusty replica information
+              properties:
+                knownReplicas:
+                  additionalProperties:
+                    type: string
+                  description: KnownReplicas represents the replicas that target can
+                    trust to read data
+                  type: object
+              type: object
+            replicationFactor:
+              description: ReplicationFactor represents number of volume replica created
+                during volume provisioning connect to the target
+              type: integer
+            targetIP:
+              description: TargetIP IP of the iSCSI target service
+              type: string
+            targetPort:
+              description: iSCSI Target Port typically TCP ports 3260
+              type: string
+            targetPortal:
+              description: iSCSI Target Portal. The Portal is combination of IP:port
+                (typically TCP ports 3260)
+              type: string
+          type: object
+        status:
+          description: CStorVolumeStatus is for handling status of cvr.
+          properties:
+            capacity:
+              anyOf:
+              - type: integer
+              - type: string
+              description: Represents the actual capacity of the underlying volume.
+              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+              x-kubernetes-int-or-string: true
+            conditions:
+              description: Current Condition of cstorvolume. If underlying persistent
+                volume is being resized then the Condition will be set to 'ResizePending'.
+              items:
+                description: CStorVolumeCondition contains details about state of
+                  cstorvolume
+                properties:
+                  lastProbeTime:
+                    description: Last time we probed the condition.
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, this should be a short, machine understandable
+                      string that gives the reason for condition's last transition.
+                      If it reports "ResizePending" that means the underlying cstorvolume
+                      is being resized.
+                    type: string
+                  status:
+                    description: ConditionStatus states in which state condition is
+                      present
+                    type: string
+                  type:
+                    description: CStorVolumeConditionType is a valid value of CStorVolumeCondition.Type
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+            lastTransitionTime:
+              description: LastTransitionTime refers to the time when the phase changes
+              format: date-time
+              nullable: true
+              type: string
+            lastUpdateTime:
+              description: LastUpdateTime refers to the time when last status updated
+                due to any operations
+              format: date-time
+              nullable: true
+              type: string
+            message:
+              description: A human-readable message indicating details about why the
+                volume is in this state.
+              type: string
+            phase:
+              description: CStorVolumePhase is to hold result of action.
+              type: string
+            replicaDetails:
+              description: ReplicaDetails refers to the trusty replica information
+              properties:
+                knownReplicas:
+                  additionalProperties:
+                    type: string
+                  description: KnownReplicas represents the replicas that target can
+                    trust to read data
+                  type: object
+              type: object
+            replicaStatuses:
+              items:
+                description: ReplicaStatus stores the status of replicas
+                properties:
+                  checkpointedIOSeq:
+                    description: Represents IO number of replica persisted on the
+                      disk
+                    type: string
+                  inflightRead:
+                    description: Ongoing reads I/O from target to replica
+                    type: string
+                  inflightSync:
+                    description: Ongoing sync I/O from target to replica
+                    type: string
+                  inflightWrite:
+                    description: ongoing writes I/O from target to replica
+                    type: string
+                  mode:
+                    description: Mode represents replica status i.e. Healthy, Degraded
+                    type: string
+                  quorum:
+                    description: 'Quorum indicates wheather data wrtitten to the replica
+                      is lost or exists. "0" means: data has been lost( might be ephimeral
+                      case) and will recostruct data from other Healthy replicas in
+                      a write-only mode 1 means: written data is exists on replica'
+                    type: string
+                  replicaId:
+                    description: ID is replica unique identifier
+                    type: string
+                  upTime:
+                    description: time since the replica connected to target
+                    type: integer
+                required:
+                - checkpointedIOSeq
+                - inflightRead
+                - inflightSync
+                - inflightWrite
+                - mode
+                - quorum
+                - replicaId
+                - upTime
+                type: object
+              type: array
+          type: object
+        versionDetails:
+          description: VersionDetails provides the details for upgrade
+          properties:
+            autoUpgrade:
+              description: If AutoUpgrade is set to true then the resource is upgraded
+                automatically without any manual steps
+              type: boolean
+            desired:
+              description: Desired is the version that we want to upgrade or the control
+                plane version
+              type: string
+            status:
+              description: Status gives the status of reconciliation triggered when
+                the desired and current version are not same
+              properties:
+                current:
+                  description: Current is the version of resource
+                  type: string
+                dependentsUpgraded:
+                  description: DependentsUpgraded gives the details whether all children
+                    of a resource are upgraded to desired version or not
+                  type: boolean
+                lastUpdateTime:
+                  description: LastUpdateTime is the time the status was last  updated
+                  format: date-time
+                  nullable: true
+                  type: string
+                message:
+                  description: Message is a human readable message if some error occurs
+                  type: string
+                reason:
+                  description: Reason is the actual reason for the error state
+                  type: string
+                state:
+                  description: State is the state of reconciliation
+                  type: string
+              type: object
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+############################################################
+####                                                    ####
+####                   CStorBackup CRD                  ####
+####                                                    ####
+############################################################
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cstorbackups.openebs.io
+spec:
+  group: openebs.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: cstorbackups
+    singular: cstorbackup
+    kind: CStorBackup
+    shortNames:
+    - cbkp
+    - cbkps
+    - cbackups
+    - cbackup
+  additionalPrinterColumns:
+    - JSONPath: .spec.volumeName
+      name: volume
+      description: volume on which backup performed
+      type: string
+    - JSONPath: .spec.backupName
+      name: backup/schedule
+      description: Backup/schedule name
+      type: string
+    - JSONPath: .status
+      name: Status
+      description: Backup status
+      type: string
+---
+############################################################
+####                                                    ####
+####             CStorCompletedBackup CRD               ####
+####                                                    ####
+############################################################
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cstorcompletedbackups.openebs.io
+spec:
+  group: openebs.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: cstorcompletedbackups
+    singular: cstorcompletedbackup
+    kind: CStorCompletedBackup
+    shortNames:
+    - cbkpc
+    - cbackupcompleted
+  additionalPrinterColumns:
+    - JSONPath: .spec.volumeName
+      name: volume
+      description: volume on which backup performed
+      type: string
+    - JSONPath: .spec.backupName
+      name: backup/schedule
+      description: Backup/schedule name
+      type: string
+    - JSONPath: .spec.prevSnapName
+      name: lastSnap
+      description: Last successful backup snapshot
+      type: string
+---
+############################################################
+####                                                    ####
+####             CStorRestore CRD                       ####
+####                                                    ####
+############################################################
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cstorrestores.openebs.io
+spec:
+  group: openebs.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: cstorrestores
+    singular: cstorrestore
+    kind: CStorRestore
+    shortNames:
+    - crst
+    - crsts
+    - crestores
+    - crestore
+  additionalPrinterColumns:
+    - JSONPath: .spec.restoreName
+      name: backup
+      description: backup name which is  restored
+      type: string
+    - JSONPath: .spec.volumeName
+      name: volume
+      description: volume on which restore performed
+      type: string
+    - JSONPath: .status
+      name: Status
+      description: Restore status
+      type: string
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cspc-operator
+  namespace: openebs
+  labels:
+    name: cspc-operator
+    openebs.io/component-name: cspc-operator
+    openebs.io/version: 2.0.0-RC1
+spec:
+  selector:
+    matchLabels:
+      name: cspc-operator
+      openebs.io/component-name: cspc-operator
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        name: cspc-operator
+        openebs.io/component-name: cspc-operator
+        openebs.io/version: 2.0.0-RC1
+    spec:
+      serviceAccountName: openebs-maya-operator
+      containers:
+      - name: cspc-operator
+        imagePullPolicy: IfNotPresent
+        image: openebs/cspc-operator-amd64:2.0.0-RC2
+        env:
+        - name: OPENEBS_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OPENEBS_SERVICEACCOUNT_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: CSPC_OPERATOR_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        # OPENEBS_IO_BASE_DIR is used to configure base directory for openebs on host path.
+        # Where OpenEBS can store required files. Default base path will be /var/openebs
+        # - name: OPENEBS_IO_BASE_DIR
+        #   value: "/var/openebs"
+        # OPENEBS_IO_CSTOR_POOL_SPARSE_DIR can be used to specify the hostpath
+        # to be used for saving the shared content between the side cars
+        # of cstor pool pod. This ENV is also used to indicate the location
+        # of the sparse devices.
+        # The default path used is /var/openebs/sparse
+        #- name: OPENEBS_IO_CSTOR_POOL_SPARSE_DIR
+        #  value: "/var/openebs/sparse"
+        - name: OPENEBS_IO_CSPI_MGMT_IMAGE
+          value: "openebs/cstor-pool-manager-amd64:2.0.0-RC2"
+        - name: OPENEBS_IO_CSTOR_POOL_IMAGE
+          value: "openebs/cstor-pool:2.0.0-RC2"
+        - name:  OPENEBS_IO_CSTOR_POOL_EXPORTER_IMAGE
+          value: "openebs/m-exporter:2.0.0-RC2"
+        - name: RESYNC_INTERVAL
+          value: "30"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cvc-operator
+  namespace: openebs
+  labels:
+    name: cvc-operator
+    openebs.io/component-name: cvc-operator
+    openebs.io/version: 2.0.0-RC1
+spec:
+  selector:
+    matchLabels:
+      name: cvc-operator
+      openebs.io/component-name: cvc-operator
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        name: cvc-operator
+        openebs.io/component-name: cvc-operator
+        openebs.io/version: 2.0.0-RC1
+    spec:
+      serviceAccountName: openebs-maya-operator
+      containers:
+      - name: cvc-operator
+        imagePullPolicy: IfNotPresent
+        image: openebs/cvc-operator-amd64:2.0.0-RC2
+        env:
+        # OPENEBS_IO_BASE_DIR is used to configure base directory for openebs on host path.
+        # Where OpenEBS can store required files. Default base path will be /var/openebs
+        # - name: OPENEBS_IO_BASE_DIR
+        #   value: "/var/openebs"
+        # OPENEBS_IO_CSTOR_TARGET_DIR can be used to specify the hostpath
+        # that to be used for saving the core dump of cstor volume pod.
+        # The default path used is /var/openebs/sparse
+        #- name: OPENEBS_IO_CSTOR_TARGET_DIR
+        #  value: "/var/openebs/sparse"
+        - name: OPENEBS_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OPENEBS_SERVICEACCOUNT_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: OPENEBS_IO_CSTOR_TARGET_IMAGE
+          value: "openebs/cstor-istgt:2.0.0-RC2"
+        - name:  OPENEBS_IO_CSTOR_VOLUME_MGMT_IMAGE
+          value: "openebs/cstor-volume-manager-amd64:2.0.0-RC2"
+        - name:  OPENEBS_IO_VOLUME_MONITOR_IMAGE
+          value: "openebs/m-exporter:2.0.0-RC2"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cvc-operator-service
+  namespace: openebs
+  labels:
+    openebs.io/component-name: cvc-operator-svc
+spec:
+  ports:
+  - name: api
+    port: 5757
+    protocol: TCP
+    targetPort: 5757
+  selector:
+    name: cvc-operator
+  sessionAffinity: None
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openebs-cstor-admission-server
+  namespace: openebs
+  labels:
+    app: cstor-admission-webhook
+    openebs.io/component-name: cstor-admission-webhook
+    openebs.io/version: 2.0.0-RC1
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+    rollingUpdate: null
+  selector:
+    matchLabels:
+      app: cstor-admission-webhook
+  template:
+    metadata:
+      labels:
+        app: cstor-admission-webhook
+        openebs.io/component-name: cstor-admission-webhook
+        openebs.io/version: 2.0.0-RC1
+    spec:
+      serviceAccountName: openebs-maya-operator
+      containers:
+        - name: admission-webhook
+          image: openebs/cstor-webhook-amd64:2.0.0-RC2
+          imagePullPolicy: IfNotPresent
+          args:
+            - -alsologtostderr
+            - -v=2
+            - 2>&1
+          env:
+            - name: OPENEBS_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ADMISSION_WEBHOOK_NAME
+              value: "openebs-cstor-admission-server"
+            - name: ADMISSION_WEBHOOK_FAILURE_POLICY
+              value: "Fail"

--- a/2.0.0/cstor-operator-2.0.0-RC2.yaml
+++ b/2.0.0/cstor-operator-2.0.0-RC2.yaml
@@ -742,7 +742,7 @@ metadata:
   labels:
     name: openebs-cstor-csi-controller
     openebs.io/component-name: openebs-cstor-csi-controller
-    openebs.io/version: dev
+    openebs.io/version: 2.0.0-RC2
 spec:
   selector:
     matchLabels:
@@ -759,7 +759,7 @@ spec:
         role: openebs-cstor-csi
         name: openebs-cstor-csi-controller
         openebs.io/component-name: openebs-cstor-csi-controller
-        openebs.io/version: dev
+        openebs.io/version: 2.0.0-RC2
     spec:
       priorityClassName: system-cluster-critical
       serviceAccount: openebs-cstor-csi-controller-sa
@@ -1003,7 +1003,7 @@ metadata:
     app: openebs-cstor-csi-node
     name: openebs-cstor-csi-node
     openebs.io/component-name: openebs-cstor-csi-node
-    openebs.io/version: dev
+    openebs.io/version: 2.0.0-RC2
 spec:
   selector:
     matchLabels:
@@ -1018,7 +1018,7 @@ spec:
         role: openebs-cstor-csi
         name: openebs-cstor-csi-node
         openebs.io/component-name: openebs-cstor-csi-node
-        openebs.io/version: dev
+        openebs.io/version: 2.0.0-RC2
     spec:
       priorityClassName: system-node-critical
       serviceAccount: openebs-cstor-csi-node-sa
@@ -3755,7 +3755,7 @@ metadata:
   labels:
     name: cspc-operator
     openebs.io/component-name: cspc-operator
-    openebs.io/version: 2.0.0-RC1
+    openebs.io/version: 2.0.0-RC2
 spec:
   selector:
     matchLabels:
@@ -3769,7 +3769,7 @@ spec:
       labels:
         name: cspc-operator
         openebs.io/component-name: cspc-operator
-        openebs.io/version: 2.0.0-RC1
+        openebs.io/version: 2.0.0-RC2
     spec:
       serviceAccountName: openebs-maya-operator
       containers:
@@ -3817,7 +3817,7 @@ metadata:
   labels:
     name: cvc-operator
     openebs.io/component-name: cvc-operator
-    openebs.io/version: 2.0.0-RC1
+    openebs.io/version: 2.0.0-RC2
 spec:
   selector:
     matchLabels:
@@ -3831,7 +3831,7 @@ spec:
       labels:
         name: cvc-operator
         openebs.io/component-name: cvc-operator
-        openebs.io/version: 2.0.0-RC1
+        openebs.io/version: 2.0.0-RC2
     spec:
       serviceAccountName: openebs-maya-operator
       containers:
@@ -3888,7 +3888,7 @@ metadata:
   labels:
     app: cstor-admission-webhook
     openebs.io/component-name: cstor-admission-webhook
-    openebs.io/version: 2.0.0-RC1
+    openebs.io/version: 2.0.0-RC2
 spec:
   replicas: 1
   strategy:
@@ -3902,7 +3902,7 @@ spec:
       labels:
         app: cstor-admission-webhook
         openebs.io/component-name: cstor-admission-webhook
-        openebs.io/version: 2.0.0-RC1
+        openebs.io/version: 2.0.0-RC2
     spec:
       serviceAccountName: openebs-maya-operator
       containers:

--- a/2.0.0/cstor-operator.yaml
+++ b/2.0.0/cstor-operator.yaml
@@ -1,0 +1,3931 @@
+# Create the OpenEBS namespace
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openebs
+---
+# Create Maya Service Account
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openebs-maya-operator
+  namespace: openebs
+---
+# Define Role that allows operations on K8s pods/deployments
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: openebs-cstor-operator
+rules:
+- apiGroups: ["*"]
+  resources: ["nodes", "nodes/proxy"]
+  verbs: ["*"]
+- apiGroups: ["*"]
+  resources: ["namespaces", "services", "pods", "deployments", "deployments/finalizers", "replicationcontrollers", "replicasets", "events", "endpoints", "configmaps", "secrets", "jobs", "cronjobs"]
+  verbs: ["*"]
+- apiGroups: ["*"]
+  resources: ["statefulsets", "daemonsets"]
+  verbs: ["*"]
+- apiGroups: ["*"]
+  resources: ["resourcequotas", "limitranges"]
+  verbs: ["list", "watch"]
+- apiGroups: ["*"]
+  resources: ["certificatesigningrequests"]
+  verbs: ["list", "watch"]
+- apiGroups: ["*"]
+  resources: ["storageclasses", "persistentvolumeclaims", "persistentvolumes"]
+  verbs: ["*"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: [ "get", "list", "create", "update", "delete", "patch"]
+- apiGroups: ["openebs.io"]
+  resources: ["*"]
+  verbs: ["*" ]
+- apiGroups: ["cstor.openebs.io"]
+  resources: ["*"]
+  verbs: ["*" ]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "watch", "list", "delete", "update", "create"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
+  verbs: ["get", "create", "list", "delete", "update", "patch"]
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+- apiGroups: ["*"]
+  resources: ["upgradetasks"]
+  verbs: ["*"]
+- apiGroups: ["*"]
+  resources: ["poddisruptionbudgets"]
+  verbs: ["get", "list", "create", "delete", "watch"]
+---
+# Bind the Service Account with the Role Privileges.
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: openebs-cstor-operator
+subjects:
+- kind: ServiceAccount
+  name: openebs-maya-operator
+  namespace: openebs
+roleRef:
+  kind: ClusterRole
+  name: openebs-cstor-operator
+  apiGroup: rbac.authorization.k8s.io
+---
+# Define Role that allows operations required for migration of snapshots
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: openebs-cstor-migration
+rules:
+- apiGroups: ["snapshot.storage.k8s.io"]
+  resources: ["volumesnapshotclasses"]
+  verbs: ["get", "list"]
+- apiGroups: ["snapshot.storage.k8s.io"]
+  resources: ["volumesnapshotcontents"]
+  verbs: ["create", "get", "list"]
+- apiGroups: ["snapshot.storage.k8s.io"]
+  resources: ["volumesnapshots"]
+  verbs: ["create", "get", "list"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: openebs-cstor-migration
+subjects:
+- kind: ServiceAccount
+  name: openebs-maya-operator
+  namespace: openebs
+roleRef:
+  kind: ClusterRole
+  name: openebs-cstor-migration
+  apiGroup: rbac.authorization.k8s.io
+---
+# This manifest deploys the OpenEBS CStor and CSI control plane components,
+# with associated CRs & RBAC rules. This manifest has been verified
+# only with different linux flavours and linux distros
+#
+# For supporting a differnet OS other than the above,
+# 1) Get the list of shared object files required for iscsiadm binary in that OS version.
+# 2) Check which files are already present in the cstor-csi-driver container present in csi node pod.
+# 3) Mount the required missing files inside the container.
+#
+####################################################
+###########                             ############
+###########  CSI Node and Driver CRDs   ############
+###########                             ############
+####################################################
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: csinodeinfos.csi.storage.k8s.io
+spec:
+  group: csi.storage.k8s.io
+  names:
+    kind: CSINodeInfo
+    plural: csinodeinfos
+  scope: Cluster
+  validation:
+    openAPIV3Schema:
+      properties:
+        csiDrivers:
+          description: List of CSI drivers running on the node and their properties.
+          items:
+            properties:
+              driver:
+                description: The CSI driver that this object refers to.
+                type: string
+              nodeID:
+                description: The node from the driver point of view.
+                type: string
+              topologyKeys:
+                description: List of keys supported by the driver.
+                items:
+                  type: string
+                type: array
+          type: array
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cstorvolumeattachments.cstor.openebs.io
+spec:
+  group: cstor.openebs.io
+  version: v1
+  scope: Namespaced
+  names:
+    plural: cstorvolumeattachments
+    singular: cstorvolumeattachment
+    kind: CStorVolumeAttachment
+    shortNames:
+    - cstorvolumeattachment
+    - cva
+---
+##############################################
+###########                       ############
+###########   Snapshot CRDs       ############
+###########                       ############
+##############################################
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: volumesnapshotclasses.snapshot.storage.k8s.io
+spec:
+  group: snapshot.storage.k8s.io
+  names:
+    kind: VolumeSnapshotClass
+    listKind: VolumeSnapshotClassList
+    plural: volumesnapshotclasses
+    singular: volumesnapshotclass
+  scope: Cluster
+# this field is supported in kubernetes 1.15+
+# https://v1-15.docs.kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/
+#preserveUnknownFields: false
+  validation:
+    openAPIV3Schema:
+      description: VolumeSnapshotClass specifies parameters that a underlying storage
+        system uses when creating a volume snapshot. A specific VolumeSnapshotClass
+        is used by specifying its name in a VolumeSnapshot object. VolumeSnapshotClasses
+        are non-namespaced
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        deletionPolicy:
+          description: deletionPolicy determines whether a VolumeSnapshotContent created
+            through the VolumeSnapshotClass should be deleted when its bound VolumeSnapshot
+            is deleted. Supported values are "Retain" and "Delete". "Retain" means
+            that the VolumeSnapshotContent and its physical snapshot on underlying
+            storage system are kept. "Delete" means that the VolumeSnapshotContent
+            and its physical snapshot on underlying storage system are deleted. Required.
+          enum:
+          - Delete
+          - Retain
+          type: string
+        driver:
+          description: driver is the name of the storage driver that handles this
+            VolumeSnapshotClass. Required.
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        parameters:
+          additionalProperties:
+            type: string
+          description: parameters is a key-value map with storage driver specific
+            parameters for creating snapshots. These values are opaque to Kubernetes.
+          type: object
+      required:
+      - deletionPolicy
+      - driver
+      type: object
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: volumesnapshotcontents.snapshot.storage.k8s.io
+spec:
+  group: snapshot.storage.k8s.io
+  names:
+    kind: VolumeSnapshotContent
+    listKind: VolumeSnapshotContentList
+    plural: volumesnapshotcontents
+    singular: volumesnapshotcontent
+  scope: Cluster
+  subresources:
+    status: {}
+# this field is supported in kubernetes 1.15+
+# https://v1-15.docs.kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/
+#preserveUnknownFields: false
+  validation:
+    openAPIV3Schema:
+      description: VolumeSnapshotContent represents the actual "on-disk" snapshot
+        object in the underlying storage system
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        spec:
+          description: spec defines properties of a VolumeSnapshotContent created
+            by the underlying storage system. Required.
+          properties:
+            deletionPolicy:
+              description: deletionPolicy determines whether this VolumeSnapshotContent
+                and its physical snapshot on the underlying storage system should
+                be deleted when its bound VolumeSnapshot is deleted. Supported values
+                are "Retain" and "Delete". "Retain" means that the VolumeSnapshotContent
+                and its physical snapshot on underlying storage system are kept. "Delete"
+                means that the VolumeSnapshotContent and its physical snapshot on
+                underlying storage system are deleted. In dynamic snapshot creation
+                case, this field will be filled in with the "DeletionPolicy" field
+                defined in the VolumeSnapshotClass the VolumeSnapshot refers to. For
+                pre-existing snapshots, users MUST specify this field when creating
+                the VolumeSnapshotContent object. Required.
+              enum:
+              - Delete
+              - Retain
+              type: string
+            driver:
+              description: driver is the name of the CSI driver used to create the
+                physical snapshot on the underlying storage system. This MUST be the
+                same as the name returned by the CSI GetPluginName() call for that
+                driver. Required.
+              type: string
+            source:
+              description: source specifies from where a snapshot will be created.
+                This field is immutable after creation. Required.
+              properties:
+                snapshotHandle:
+                  description: snapshotHandle specifies the CSI "snapshot_id" of a
+                    pre-existing snapshot on the underlying storage system. This field
+                    is immutable.
+                  type: string
+                volumeHandle:
+                  description: volumeHandle specifies the CSI "volume_id" of the volume
+                    from which a snapshot should be dynamically taken from. This field
+                    is immutable.
+                  type: string
+              type: object
+            volumeSnapshotClassName:
+              description: name of the VolumeSnapshotClass to which this snapshot
+                belongs.
+              type: string
+            volumeSnapshotRef:
+              description: volumeSnapshotRef specifies the VolumeSnapshot object to
+                which this VolumeSnapshotContent object is bound. VolumeSnapshot.Spec.VolumeSnapshotContentName
+                field must reference to this VolumeSnapshotContent's name for the
+                bidirectional binding to be valid. For a pre-existing VolumeSnapshotContent
+                object, name and namespace of the VolumeSnapshot object MUST be provided
+                for binding to happen. This field is immutable after creation. Required.
+              properties:
+                apiVersion:
+                  description: API version of the referent.
+                  type: string
+                fieldPath:
+                  description: 'If referring to a piece of an object instead of an
+                    entire object, this string should contain a valid JSON/Go field
+                    access statement, such as desiredState.manifest.containers[2].
+                    For example, if the object reference is to a container within
+                    a pod, this would take on a value like: "spec.containers{name}"
+                    (where "name" refers to the name of the container that triggered
+                    the event) or if no container name is specified "spec.containers[2]"
+                    (container with index 2 in this pod). This syntax is chosen only
+                    to have some well-defined way of referencing a part of an object.
+                    TODO: this design is not final and this field is subject to change
+                    in the future.'
+                  type: string
+                kind:
+                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+                resourceVersion:
+                  description: 'Specific resourceVersion to which this reference is
+                    made, if any. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                  type: string
+                uid:
+                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                  type: string
+              type: object
+          required:
+          - deletionPolicy
+          - driver
+          - source
+          - volumeSnapshotRef
+          type: object
+        status:
+          description: status represents the current information of a snapshot.
+          properties:
+            creationTime:
+              description: creationTime is the timestamp when the point-in-time snapshot
+                is taken by the underlying storage system. In dynamic snapshot creation
+                case, this field will be filled in with the "creation_time" value
+                returned from CSI "CreateSnapshotRequest" gRPC call. For a pre-existing
+                snapshot, this field will be filled with the "creation_time" value
+                returned from the CSI "ListSnapshots" gRPC call if the driver supports
+                it. If not specified, it indicates the creation time is unknown. The
+                format of this field is a Unix nanoseconds time encoded as an int64.
+                On Unix, the command `date +%s%N` returns the current time in nanoseconds
+                since 1970-01-01 00:00:00 UTC.
+              format: int64
+              type: integer
+            error:
+              description: error is the latest observed error during snapshot creation,
+                if any.
+              properties:
+                message:
+                  description: 'message is a string detailing the encountered error
+                    during snapshot creation if specified. NOTE: message may be logged,
+                    and it should not contain sensitive information.'
+                  type: string
+                time:
+                  description: time is the timestamp when the error was encountered.
+                  format: date-time
+                  type: string
+              type: object
+            readyToUse:
+              description: readyToUse indicates if a snapshot is ready to be used
+                to restore a volume. In dynamic snapshot creation case, this field
+                will be filled in with the "ready_to_use" value returned from CSI
+                "CreateSnapshotRequest" gRPC call. For a pre-existing snapshot, this
+                field will be filled with the "ready_to_use" value returned from the
+                CSI "ListSnapshots" gRPC call if the driver supports it, otherwise,
+                this field will be set to "True". If not specified, it means the readiness
+                of a snapshot is unknown.
+              type: boolean
+            restoreSize:
+              description: restoreSize represents the complete size of the snapshot
+                in bytes. In dynamic snapshot creation case, this field will be filled
+                in with the "size_bytes" value returned from CSI "CreateSnapshotRequest"
+                gRPC call. For a pre-existing snapshot, this field will be filled
+                with the "size_bytes" value returned from the CSI "ListSnapshots"
+                gRPC call if the driver supports it. When restoring a volume from
+                this snapshot, the size of the volume MUST NOT be smaller than the
+                restoreSize if it is specified, otherwise the restoration will fail.
+                If not specified, it indicates that the size is unknown.
+              format: int64
+              minimum: 0
+              type: integer
+            snapshotHandle:
+              description: snapshotHandle is the CSI "snapshot_id" of a snapshot on
+                the underlying storage system. If not specified, it indicates that
+                dynamic snapshot creation has either failed or it is still in progress.
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: volumesnapshots.snapshot.storage.k8s.io
+spec:
+  group: snapshot.storage.k8s.io
+  names:
+    kind: VolumeSnapshot
+    listKind: VolumeSnapshotList
+    plural: volumesnapshots
+    singular: volumesnapshot
+  scope: Namespaced
+  subresources:
+    status: {}
+# this field is supported in kubernetes 1.15+
+# https://v1-15.docs.kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/
+#preserveUnknownFields: false
+  validation:
+    openAPIV3Schema:
+      description: VolumeSnapshot is a user's request for either creating a point-in-time
+        snapshot of a persistent volume, or binding to a pre-existing snapshot.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        spec:
+          description: 'spec defines the desired characteristics of a snapshot requested
+            by a user. More info: https://kubernetes.io/docs/concepts/storage/volume-snapshots#volumesnapshots
+            Required.'
+          properties:
+            source:
+              description: source specifies where a snapshot will be created from.
+                This field is immutable after creation. Required.
+              properties:
+                persistentVolumeClaimName:
+                  description: persistentVolumeClaimName specifies the name of the
+                    PersistentVolumeClaim object in the same namespace as the VolumeSnapshot
+                    object where the snapshot should be dynamically taken from. This
+                    field is immutable.
+                  type: string
+                volumeSnapshotContentName:
+                  description: volumeSnapshotContentName specifies the name of a pre-existing
+                    VolumeSnapshotContent object. This field is immutable.
+                  type: string
+              type: object
+            volumeSnapshotClassName:
+              description: 'volumeSnapshotClassName is the name of the VolumeSnapshotClass
+                requested by the VolumeSnapshot. If not specified, the default snapshot
+                class will be used if one exists. If not specified, and there is no
+                default snapshot class, dynamic snapshot creation will fail. Empty
+                string is not allowed for this field. TODO(xiangqian): a webhook validation
+                on empty string. More info: https://kubernetes.io/docs/concepts/storage/volume-snapshot-classes'
+              type: string
+          required:
+          - source
+          type: object
+        status:
+          description: 'status represents the current information of a snapshot. NOTE:
+            status can be modified by sources other than system controllers, and must
+            not be depended upon for accuracy. Controllers should only use information
+            from the VolumeSnapshotContent object after verifying that the binding
+            is accurate and complete.'
+          properties:
+            boundVolumeSnapshotContentName:
+              description: 'boundVolumeSnapshotContentName represents the name of
+                the VolumeSnapshotContent object to which the VolumeSnapshot object
+                is bound. If not specified, it indicates that the VolumeSnapshot object
+                has not been successfully bound to a VolumeSnapshotContent object
+                yet. NOTE: Specified boundVolumeSnapshotContentName alone does not
+                mean binding       is valid. Controllers MUST always verify bidirectional
+                binding between       VolumeSnapshot and VolumeSnapshotContent to
+                avoid possible security issues.'
+              type: string
+            creationTime:
+              description: creationTime is the timestamp when the point-in-time snapshot
+                is taken by the underlying storage system. In dynamic snapshot creation
+                case, this field will be filled in with the "creation_time" value
+                returned from CSI "CreateSnapshotRequest" gRPC call. For a pre-existing
+                snapshot, this field will be filled with the "creation_time" value
+                returned from the CSI "ListSnapshots" gRPC call if the driver supports
+                it. If not specified, it indicates that the creation time of the snapshot
+                is unknown.
+              format: date-time
+              type: string
+            error:
+              description: error is the last observed error during snapshot creation,
+                if any. This field could be helpful to upper level controllers(i.e.,
+                application controller) to decide whether they should continue on
+                waiting for the snapshot to be created based on the type of error
+                reported.
+              properties:
+                message:
+                  description: 'message is a string detailing the encountered error
+                    during snapshot creation if specified. NOTE: message may be logged,
+                    and it should not contain sensitive information.'
+                  type: string
+                time:
+                  description: time is the timestamp when the error was encountered.
+                  format: date-time
+                  type: string
+              type: object
+            readyToUse:
+              description: readyToUse indicates if a snapshot is ready to be used
+                to restore a volume. In dynamic snapshot creation case, this field
+                will be filled in with the "ready_to_use" value returned from CSI
+                "CreateSnapshotRequest" gRPC call. For a pre-existing snapshot, this
+                field will be filled with the "ready_to_use" value returned from the
+                CSI "ListSnapshots" gRPC call if the driver supports it, otherwise,
+                this field will be set to "True". If not specified, it means the readiness
+                of a snapshot is unknown.
+              type: boolean
+            restoreSize:
+              description: restoreSize represents the complete size of the snapshot
+                in bytes. In dynamic snapshot creation case, this field will be filled
+                in with the "size_bytes" value returned from CSI "CreateSnapshotRequest"
+                gRPC call. For a pre-existing snapshot, this field will be filled
+                with the "size_bytes" value returned from the CSI "ListSnapshots"
+                gRPC call if the driver supports it. When restoring a volume from
+                this snapshot, the size of the volume MUST NOT be smaller than the
+                restoreSize if it is specified, otherwise the restoration will fail.
+                If not specified, it indicates that the size is unknown.
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+
+apiVersion: storage.k8s.io/v1beta1
+kind: CSIDriver
+metadata:
+  name: cstor.csi.openebs.io
+spec:
+  # Supports persistent inline volumes.
+  volumeLifecycleModes:
+  - Persistent
+  # To determine at runtime which mode a volume uses, pod info and its
+  # "csi.storage.k8s.io/ephemeral" entry are needed.
+  podInfoOnMount: true
+  attachRequired: true
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-csi-snapshotter-binding
+subjects:
+  - kind: ServiceAccount
+    name: openebs-cstor-csi-controller-sa
+    namespace: openebs
+roleRef:
+  kind: ClusterRole
+  name: openebs-cstor-csi-snapshotter-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-csi-snapshotter-role
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents/status"]
+    verbs: ["update"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots/status"]
+    verbs: ["update"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["create", "list", "watch", "delete", "get", "update"]
+
+---
+##############################################
+###########                       ############
+###########   Controller plugin   ############
+###########                       ############
+##############################################
+
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: openebs-cstor-csi-controller-sa
+  namespace: openebs
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-csi-provisioner-role
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes", "services"]
+    verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses", "csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["get", "list"]
+
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["*"]
+  - apiGroups: ["*"]
+    resources: ["cstorvolumeattachments", "cstorvolumes","cstorvolumeconfigs"]
+    verbs: ["*"]
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-csi-provisioner-binding
+subjects:
+  - kind: ServiceAccount
+    name: openebs-cstor-csi-controller-sa
+    namespace: openebs
+roleRef:
+  kind: ClusterRole
+  name: openebs-cstor-csi-provisioner-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: openebs-cstor-csi-controller
+  namespace: openebs
+  labels:
+    name: openebs-cstor-csi-controller
+    openebs.io/component-name: openebs-cstor-csi-controller
+    openebs.io/version: 2.0.0
+spec:
+  selector:
+    matchLabels:
+      app: openebs-cstor-csi-controller
+      role: openebs-cstor-csi
+      name: openebs-cstor-csi-controller
+      openebs.io/component-name: openebs-cstor-csi-controller
+  serviceName: "openebs-csi"
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: openebs-cstor-csi-controller
+        role: openebs-cstor-csi
+        name: openebs-cstor-csi-controller
+        openebs.io/component-name: openebs-cstor-csi-controller
+        openebs.io/version: 2.0.0
+    spec:
+      priorityClassName: system-cluster-critical
+      serviceAccount: openebs-cstor-csi-controller-sa
+      containers:
+        - name: csi-resizer
+          image: quay.io/k8scsi/csi-resizer:v0.4.0
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+            - "--leader-election"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: csi-snapshotter
+          image: quay.io/k8scsi/csi-snapshotter:v2.0.1
+          args:
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: snapshot-controller
+          image: quay.io/k8scsi/snapshot-controller:v2.0.1
+          args:
+            - "--v=5"
+            - "--leader-election=false"
+          imagePullPolicy: IfNotPresent
+        - name: csi-provisioner
+          image: quay.io/k8scsi/csi-provisioner:v1.6.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--provisioner=cstor.csi.openebs.io"
+            - "--csi-address=$(ADDRESS)"
+            - "--v=5"
+            - "--feature-gates=Topology=true"
+            - "--extra-create-metadata=true"
+          env:
+            - name: MY_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: csi-attacher
+          image: quay.io/k8scsi/csi-attacher:v2.0.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: csi-cluster-driver-registrar
+          image: quay.io/k8scsi/csi-cluster-driver-registrar:v1.0.1
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--v=5"
+            - "--driver-requires-attachment=true"
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: cstor-csi-plugin
+          image: openebs/cstor-csi-driver:2.0.0
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: OPENEBS_CONTROLLER_DRIVER
+              value: controller
+            - name: OPENEBS_CSI_ENDPOINT
+              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+            - name: OPENEBS_CSI_API_URL
+              value: https://openebs.io
+              # OpenEBS namespace where the openebs cstor operator components
+              # has been installed
+            - name: OPENEBS_NAMESPACE
+              value: openebs
+          args :
+            - "--endpoint=$(OPENEBS_CSI_ENDPOINT)"
+            - "--url=$(OPENEBS_CSI_API_URL)"
+            - "--plugin=$(OPENEBS_CONTROLLER_DRIVER)"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+      volumes:
+        - name: socket-dir
+          emptyDir: {}
+---
+
+############################## CSI- Attacher #######################
+# Attacher must be able to work with PVs, nodes and VolumeAttachments
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-csi-attacher-role
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csinodeinfos"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments", "csinodes"]
+    verbs: ["get", "list", "watch", "update"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-csi-attacher-binding
+subjects:
+  - kind: ServiceAccount
+    name: openebs-cstor-csi-controller-sa
+    namespace: openebs
+roleRef:
+  kind: ClusterRole
+  name: openebs-cstor-csi-attacher-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-csi-cluster-registrar-role
+rules:
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csidrivers"]
+    verbs: ["create", "delete"]
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-csi-cluster-registrar-binding
+subjects:
+  - kind: ServiceAccount
+    name: openebs-cstor-csi-controller-sa
+    namespace: openebs
+roleRef:
+  kind: ClusterRole
+  name: openebs-cstor-csi-cluster-registrar-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+########################################
+###########                 ############
+###########   Node plugin   ############
+###########                 ############
+########################################
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openebs-cstor-csi-node-sa
+  namespace: openebs
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-csi-registrar-role
+rules:
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes", "nodes", "services"]
+    verbs: ["get", "list", "patch"]
+  - apiGroups: ["*"]
+    resources: ["cstorvolumeattachments", "cstorvolumes","cstorvolumeconfigs"]
+    verbs: ["get", "list", "watch", "create", "update", "delete", "patch"]
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openebs-cstor-csi-registrar-binding
+subjects:
+  - kind: ServiceAccount
+    name: openebs-cstor-csi-node-sa
+    namespace: openebs
+roleRef:
+  kind: ClusterRole
+  name: openebs-cstor-csi-registrar-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: openebs-cstor-csi-iscsiadm
+  namespace: openebs
+data:
+  iscsiadm: |
+    #!/bin/sh
+    if [ -x /host/sbin/iscsiadm ]; then
+      chroot /host /sbin/iscsiadm "$@"
+    elif [ -x /host/usr/local/sbin/iscsiadm ]; then
+      chroot /host /usr/local/sbin/iscsiadm "$@"
+    elif [ -x /host/bin/iscsiadm ]; then
+      chroot /host /bin/iscsiadm "$@"
+    elif [ -x /host/usr/local/bin/iscsiadm ]; then
+      chroot /host /usr/local/bin/iscsiadm "$@"
+    else
+      chroot /host iscsiadm "$@"
+    fi
+
+---
+
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: openebs-cstor-csi-node
+  namespace: openebs
+  labels:
+    app: openebs-cstor-csi-node
+    name: openebs-cstor-csi-node
+    openebs.io/component-name: openebs-cstor-csi-node
+    openebs.io/version: 2.0.0
+spec:
+  selector:
+    matchLabels:
+      app: openebs-cstor-csi-node
+      role: openebs-cstor-csi
+      name: openebs-cstor-csi-node
+      openebs.io/component-name: openebs-cstor-csi-node
+  template:
+    metadata:
+      labels:
+        app: openebs-cstor-csi-node
+        role: openebs-cstor-csi
+        name: openebs-cstor-csi-node
+        openebs.io/component-name: openebs-cstor-csi-node
+        openebs.io/version: 2.0.0
+    spec:
+      priorityClassName: system-node-critical
+      serviceAccount: openebs-cstor-csi-node-sa
+      hostNetwork: true
+      containers:
+        - name: csi-node-driver-registrar
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.0.1
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+            - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "rm -rf /registration/cstor.csi.openebs.io /registration/cstor.csi.openebs.io-reg.sock"]
+          env:
+            - name: ADDRESS
+              value: /plugin/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: /var/lib/kubelet/plugins/cstor.csi.openebs.io/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: NODE_DRIVER
+              value: openebs-cstor-csi
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /plugin
+            - name: registration-dir
+              mountPath: /registration
+        - name: cstor-csi-plugin
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["CAP_MKNOD", "CAP_SYS_ADMIN", "SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+          image: openebs/cstor-csi-driver:2.0.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--nodeid=$(OPENEBS_NODE_ID)"
+            - "--endpoint=$(OPENEBS_CSI_ENDPOINT)"
+            - "--url=$(OPENEBS_CSI_API_URL)"
+            - "--plugin=$(OPENEBS_NODE_DRIVER)"
+          env:
+            - name: OPENEBS_NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: OPENEBS_CSI_ENDPOINT
+              value: unix:///plugin/csi.sock
+            - name: OPENEBS_NODE_DRIVER
+              value: node
+            - name: OPENEBS_CSI_API_URL
+              value: https://openebs.io
+              # OpenEBS namespace where the openebs cstor operator components
+              # has been installed
+            - name: OPENEBS_NAMESPACE
+              value: openebs
+              # Enable/Disable auto-remount feature, when volumes
+              # recovers form the read-only state
+            - name: REMOUNT
+              value: "false"
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /plugin
+            - name: device-dir
+              mountPath: /dev
+            - name: pods-mount-dir
+              mountPath: /var/lib/kubelet/
+              # needed so that any mounts setup inside this container are
+              # propagated back to the host machine.
+              mountPropagation: "Bidirectional"
+            - name: host-root
+              mountPath: /host
+              mountPropagation: "HostToContainer"
+            - name: chroot-iscsiadm
+              mountPath: /sbin/iscsiadm
+              subPath: iscsiadm
+      volumes:
+        - name: device-dir
+          hostPath:
+            path: /dev
+            type: Directory
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry/
+            type: DirectoryOrCreate
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/cstor.csi.openebs.io/
+            type: DirectoryOrCreate
+        - name: pods-mount-dir
+          hostPath:
+            path: /var/lib/kubelet/
+            type: Directory
+        - name: chroot-iscsiadm
+          configMap:
+            defaultMode: 0555
+            name: openebs-cstor-csi-iscsiadm
+        - name: host-root
+          hostPath:
+            path: /
+            type: Directory
+---
+###########################################################################
+####                                                                   ####
+####                     CStor-Operator yaml                           ####
+####                                                                   ####
+###########################################################################
+#
+#
+###########################################################################
+#                                                                       ###
+#                        CStorPoolCluster CRD                           ###
+#                                                                       ###
+###########################################################################
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  name: cstorpoolclusters.cstor.openebs.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.healthyInstances
+    description: The number of healthy cStorPoolInstances
+    name: HealthyInstances
+    type: integer
+  - JSONPath: .status.provisionedInstances
+    description: The number of provisioned cStorPoolInstances
+    name: ProvisionedInstances
+    type: integer
+  - JSONPath: .status.desiredInstances
+    description: The number of desired cStorPoolInstances
+    name: DesiredInstances
+    type: integer
+  - JSONPath: .metadata.creationTimestamp
+    description: Age of CStorPoolCluster
+    name: Age
+    type: date
+  group: cstor.openebs.io
+  names:
+    kind: CStorPoolCluster
+    listKind: CStorPoolClusterList
+    plural: cstorpoolclusters
+    shortNames:
+    - cspc
+    singular: cstorpoolcluster
+  preserveUnknownFields: false
+  scope: Namespaced
+  subresources: {}
+  validation:
+    openAPIV3Schema:
+      description: CStorPoolCluster describes a CStorPoolCluster custom resource.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: CStorPoolClusterSpec is the spec for a CStorPoolClusterSpec
+            resource
+          properties:
+            auxResources:
+              description: AuxResources are the compute resources required by the
+                cstor-pool pod side car containers.
+              nullable: true
+              properties:
+                limits:
+                  additionalProperties:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: 'Limits describes the maximum amount of compute resources
+                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+                requests:
+                  additionalProperties:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: 'Requests describes the minimum amount of compute resources
+                    required. If Requests is omitted for a container, it defaults
+                    to Limits if that is explicitly specified, otherwise to an implementation-defined
+                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+              type: object
+            pools:
+              description: Pools is the spec for pools for various nodes where it
+                should be created.
+              items:
+                description: PoolSpec is the spec for pool on node where it should
+                  be created.
+                properties:
+                  dataRaidGroups:
+                    description: DataRaidGroups is the raid group configuration for
+                      the given pool.
+                    items:
+                      description: RaidGroup contains the details of a raid group
+                        for the pool
+                      properties:
+                        blockDevices:
+                          items:
+                            description: CStorPoolInstanceBlockDevice contains the
+                              details of block devices that constitutes a raid group.
+                            properties:
+                              blockDeviceName:
+                                description: BlockDeviceName is the name of the block
+                                  device.
+                                type: string
+                              capacity:
+                                description: Capacity is the capacity of the block
+                                  device. It is system generated
+                                format: int64
+                                type: integer
+                              devLink:
+                                description: DevLink is the dev link for block devices
+                                type: string
+                            required:
+                            - blockDeviceName
+                            type: object
+                          type: array
+                      required:
+                      - blockDevices
+                      type: object
+                    type: array
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: NodeSelector is the labels that will be used to select
+                      a node for pool provisioning. Required field
+                    type: object
+                  poolConfig:
+                    description: PoolConfig is the default pool config that applies
+                      to the pool on node.
+                    properties:
+                      auxResources:
+                        description: AuxResources are the compute resources required
+                          by the cstor-pool pod side car containers.
+                        nullable: true
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                        type: object
+                      compression:
+                        description: 'Compression to enable compression Optional --
+                          defaults to off Possible values : lz, off'
+                        type: string
+                      dataRaidGroupType:
+                        description: DataRaidGroupType is the  raid type.
+                        type: string
+                      priorityClassName:
+                        description: PriorityClassName if specified applies to this
+                          pool pod If left empty, DefaultPriorityClassName is applied.
+                          (See CStorPoolClusterSpec.DefaultPriorityClassName) If both
+                          are empty, not priority class is applied.
+                        nullable: true
+                        type: string
+                      resources:
+                        description: Resources are the compute resources required
+                          by the cstor-pool container.
+                        nullable: true
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                        type: object
+                      roThresholdLimit:
+                        description: 'ROThresholdLimit is threshold(percentage base)
+                          limit for pool read only mode. If ROThresholdLimit(%) amount
+                          of pool storage is reached then pool will set to readonly.
+                          NOTE: 1. If ROThresholdLimit is set to 100 then entire    pool
+                          storage will be used by default it will be set to 85%. 2.
+                          ROThresholdLimit value will be 0 <= ROThresholdLimit <=
+                          100.'
+                        nullable: true
+                        type: integer
+                      thickProvision:
+                        description: ThickProvision to enable thick provisioning Optional
+                          -- defaults to false
+                        type: boolean
+                      tolerations:
+                        description: Tolerations, if specified, the pool pod's tolerations.
+                        items:
+                          description: The pod this Toleration is attached to tolerates
+                            any taint that matches the triple <key,value,effect> using
+                            the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match.
+                                Empty means match all taint effects. When specified,
+                                allowed values are NoSchedule, PreferNoSchedule and
+                                NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration
+                                applies to. Empty means match all taint keys. If the
+                                key is empty, operator must be Exists; this combination
+                                means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship
+                                to the value. Valid operators are Exists and Equal.
+                                Defaults to Equal. Exists is equivalent to wildcard
+                                for value, so that a pod can tolerate all taints of
+                                a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period
+                                of time the toleration (which must be of effect NoExecute,
+                                otherwise this field is ignored) tolerates the taint.
+                                By default, it is not set, which means tolerate the
+                                taint forever (do not evict). Zero and negative values
+                                will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration
+                                matches to. If the operator is Exists, the value should
+                                be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        nullable: true
+                        type: array
+                      writeCacheGroupType:
+                        description: WriteCacheGroupType is the write cache raid type.
+                        type: string
+                    required:
+                    - dataRaidGroupType
+                    type: object
+                  writeCacheRaidGroups:
+                    description: WriteCacheRaidGroups is the write cache raid group.
+                    items:
+                      description: RaidGroup contains the details of a raid group
+                        for the pool
+                      properties:
+                        blockDevices:
+                          items:
+                            description: CStorPoolInstanceBlockDevice contains the
+                              details of block devices that constitutes a raid group.
+                            properties:
+                              blockDeviceName:
+                                description: BlockDeviceName is the name of the block
+                                  device.
+                                type: string
+                              capacity:
+                                description: Capacity is the capacity of the block
+                                  device. It is system generated
+                                format: int64
+                                type: integer
+                              devLink:
+                                description: DevLink is the dev link for block devices
+                                type: string
+                            required:
+                            - blockDeviceName
+                            type: object
+                          type: array
+                      required:
+                      - blockDevices
+                      type: object
+                    nullable: true
+                    type: array
+                required:
+                - dataRaidGroups
+                - nodeSelector
+                type: object
+              type: array
+            priorityClassName:
+              description: DefaultPriorityClassName if specified applies to all the
+                pool pods in the pool spec if the priorityClass at the pool level
+                is not specified.
+              type: string
+            resources:
+              description: DefaultResources are the compute resources required by
+                the cstor-pool container. If the resources at PoolConfig is not specified,
+                this is written to CSPI PoolConfig.
+              nullable: true
+              properties:
+                limits:
+                  additionalProperties:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: 'Limits describes the maximum amount of compute resources
+                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+                requests:
+                  additionalProperties:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: 'Requests describes the minimum amount of compute resources
+                    required. If Requests is omitted for a container, it defaults
+                    to Limits if that is explicitly specified, otherwise to an implementation-defined
+                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+              type: object
+            tolerations:
+              description: Tolerations, if specified, are the pool pod's tolerations
+                If tolerations at PoolConfig is empty, this is written to CSPI PoolConfig.
+              items:
+                description: The pod this Toleration is attached to tolerates any
+                  taint that matches the triple <key,value,effect> using the matching
+                  operator <operator>.
+                properties:
+                  effect:
+                    description: Effect indicates the taint effect to match. Empty
+                      means match all taint effects. When specified, allowed values
+                      are NoSchedule, PreferNoSchedule and NoExecute.
+                    type: string
+                  key:
+                    description: Key is the taint key that the toleration applies
+                      to. Empty means match all taint keys. If the key is empty, operator
+                      must be Exists; this combination means to match all values and
+                      all keys.
+                    type: string
+                  operator:
+                    description: Operator represents a key's relationship to the value.
+                      Valid operators are Exists and Equal. Defaults to Equal. Exists
+                      is equivalent to wildcard for value, so that a pod can tolerate
+                      all taints of a particular category.
+                    type: string
+                  tolerationSeconds:
+                    description: TolerationSeconds represents the period of time the
+                      toleration (which must be of effect NoExecute, otherwise this
+                      field is ignored) tolerates the taint. By default, it is not
+                      set, which means tolerate the taint forever (do not evict).
+                      Zero and negative values will be treated as 0 (evict immediately)
+                      by the system.
+                    format: int64
+                    type: integer
+                  value:
+                    description: Value is the taint value the toleration matches to.
+                      If the operator is Exists, the value should be empty, otherwise
+                      just a regular string.
+                    type: string
+                type: object
+              nullable: true
+              type: array
+          type: object
+        status:
+          description: CStorPoolClusterStatus represents the latest available observations
+            of a CSPC's current state.
+          properties:
+            conditions:
+              description: Current state of CSPC.
+              items:
+                description: CStorPoolClusterCondition describes the state of a CSPC
+                  at a certain point.
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    description: The last time this condition was updated.
+                    format: date-time
+                    type: string
+                  message:
+                    description: A human readable message indicating details about
+                      the transition.
+                    type: string
+                  reason:
+                    description: The reason for the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of CSPC condition.
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              nullable: true
+              type: array
+            desiredInstances:
+              description: DesiredInstances is the number of CSPI(s) that should be
+                provisioned.
+              format: int32
+              nullable: true
+              type: integer
+            healthyInstances:
+              description: HealthyInstances is the number of CSPI(s) that are healthy.
+              format: int32
+              nullable: true
+              type: integer
+            provisionedInstances:
+              description: ProvisionedInstances is the the number of CSPI present
+                at the current state.
+              format: int32
+              nullable: true
+              type: integer
+          type: object
+        versionDetails:
+          description: VersionDetails provides the details for upgrade
+          properties:
+            autoUpgrade:
+              description: If AutoUpgrade is set to true then the resource is upgraded
+                automatically without any manual steps
+              type: boolean
+            desired:
+              description: Desired is the version that we want to upgrade or the control
+                plane version
+              type: string
+            status:
+              description: Status gives the status of reconciliation triggered when
+                the desired and current version are not same
+              properties:
+                current:
+                  description: Current is the version of resource
+                  type: string
+                dependentsUpgraded:
+                  description: DependentsUpgraded gives the details whether all children
+                    of a resource are upgraded to desired version or not
+                  type: boolean
+                lastUpdateTime:
+                  description: LastUpdateTime is the time the status was last  updated
+                  format: date-time
+                  nullable: true
+                  type: string
+                message:
+                  description: Message is a human readable message if some error occurs
+                  type: string
+                reason:
+                  description: Reason is the actual reason for the error state
+                  type: string
+                state:
+                  description: State is the state of reconciliation
+                  type: string
+              type: object
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+################################################################################
+###                                                                         ####
+###                       CStorPoolInstance CRD                             ####
+###                                                                         ####
+################################################################################
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  name: cstorpoolinstances.cstor.openebs.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.hostName
+    description: Host name where cstorpool instances scheduled
+    name: HostName
+    type: string
+  - JSONPath: .status.capacity.used
+    description: The amount of storage space within the pool that has been physically
+      allocated
+    name: Allocated
+    priority: 1
+    type: string
+  - JSONPath: .status.capacity.free
+    description: The amount of usable free space available in the pool
+    name: Free
+    type: string
+  - JSONPath: .status.capacity.total
+    description: Total amount of usable space in pool
+    name: Capacity
+    type: string
+  - JSONPath: .status.readOnly
+    description: Identifies the pool read only mode
+    name: ReadOnly
+    type: boolean
+  - JSONPath: .status.provisionedReplicas
+    description: Represents no.of replicas present in the pool
+    name: ProvisionedReplicas
+    type: integer
+  - JSONPath: .status.healthyReplicas
+    description: Represents no.of healthy replicas present in the pool
+    name: HealthyReplicas
+    type: integer
+  - JSONPath: .spec.poolConfig.dataRaidGroupType
+    description: Represents the type of the storage pool
+    name: Type
+    priority: 1
+    type: string
+  - JSONPath: .status.phase
+    description: Identifies the current health of the pool
+    name: Status
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: Age of CStorPoolInstance
+    name: Age
+    type: date
+  group: cstor.openebs.io
+  names:
+    kind: CStorPoolInstance
+    listKind: CStorPoolInstanceList
+    plural: cstorpoolinstances
+    shortNames:
+    - cspi
+    singular: cstorpoolinstance
+  preserveUnknownFields: false
+  scope: Namespaced
+  subresources: {}
+  validation:
+    openAPIV3Schema:
+      description: CStorPoolInstance describes a cstor pool instance resource.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: Spec is the specification of the cstorpoolinstance resource.
+          properties:
+            dataRaidGroups:
+              description: DataRaidGroups is the raid group configuration for the
+                given pool.
+              items:
+                description: RaidGroup contains the details of a raid group for the
+                  pool
+                properties:
+                  blockDevices:
+                    items:
+                      description: CStorPoolInstanceBlockDevice contains the details
+                        of block devices that constitutes a raid group.
+                      properties:
+                        blockDeviceName:
+                          description: BlockDeviceName is the name of the block device.
+                          type: string
+                        capacity:
+                          description: Capacity is the capacity of the block device.
+                            It is system generated
+                          format: int64
+                          type: integer
+                        devLink:
+                          description: DevLink is the dev link for block devices
+                          type: string
+                      required:
+                      - blockDeviceName
+                      type: object
+                    type: array
+                required:
+                - blockDevices
+                type: object
+              type: array
+            hostName:
+              description: HostName is the name of kubernetes node where the pool
+                should be created.
+              type: string
+            nodeSelector:
+              additionalProperties:
+                type: string
+              description: NodeSelector is the labels that will be used to select
+                a node for pool provisioning. Required field
+              type: object
+            poolConfig:
+              description: PoolConfig is the default pool config that applies to the
+                pool on node.
+              properties:
+                auxResources:
+                  description: AuxResources are the compute resources required by
+                    the cstor-pool pod side car containers.
+                  nullable: true
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                  type: object
+                compression:
+                  description: 'Compression to enable compression Optional -- defaults
+                    to off Possible values : lz, off'
+                  type: string
+                dataRaidGroupType:
+                  description: DataRaidGroupType is the  raid type.
+                  type: string
+                priorityClassName:
+                  description: PriorityClassName if specified applies to this pool
+                    pod If left empty, DefaultPriorityClassName is applied. (See CStorPoolClusterSpec.DefaultPriorityClassName)
+                    If both are empty, not priority class is applied.
+                  nullable: true
+                  type: string
+                resources:
+                  description: Resources are the compute resources required by the
+                    cstor-pool container.
+                  nullable: true
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                  type: object
+                roThresholdLimit:
+                  description: 'ROThresholdLimit is threshold(percentage base) limit
+                    for pool read only mode. If ROThresholdLimit(%) amount of pool
+                    storage is reached then pool will set to readonly. NOTE: 1. If
+                    ROThresholdLimit is set to 100 then entire    pool storage will
+                    be used by default it will be set to 85%. 2. ROThresholdLimit
+                    value will be 0 <= ROThresholdLimit <= 100.'
+                  nullable: true
+                  type: integer
+                thickProvision:
+                  description: ThickProvision to enable thick provisioning Optional
+                    -- defaults to false
+                  type: boolean
+                tolerations:
+                  description: Tolerations, if specified, the pool pod's tolerations.
+                  items:
+                    description: The pod this Toleration is attached to tolerates
+                      any taint that matches the triple <key,value,effect> using the
+                      matching operator <operator>.
+                    properties:
+                      effect:
+                        description: Effect indicates the taint effect to match. Empty
+                          means match all taint effects. When specified, allowed values
+                          are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                      key:
+                        description: Key is the taint key that the toleration applies
+                          to. Empty means match all taint keys. If the key is empty,
+                          operator must be Exists; this combination means to match
+                          all values and all keys.
+                        type: string
+                      operator:
+                        description: Operator represents a key's relationship to the
+                          value. Valid operators are Exists and Equal. Defaults to
+                          Equal. Exists is equivalent to wildcard for value, so that
+                          a pod can tolerate all taints of a particular category.
+                        type: string
+                      tolerationSeconds:
+                        description: TolerationSeconds represents the period of time
+                          the toleration (which must be of effect NoExecute, otherwise
+                          this field is ignored) tolerates the taint. By default,
+                          it is not set, which means tolerate the taint forever (do
+                          not evict). Zero and negative values will be treated as
+                          0 (evict immediately) by the system.
+                        format: int64
+                        type: integer
+                      value:
+                        description: Value is the taint value the toleration matches
+                          to. If the operator is Exists, the value should be empty,
+                          otherwise just a regular string.
+                        type: string
+                    type: object
+                  nullable: true
+                  type: array
+                writeCacheGroupType:
+                  description: WriteCacheGroupType is the write cache raid type.
+                  type: string
+              required:
+              - dataRaidGroupType
+              type: object
+            writeCacheRaidGroups:
+              description: WriteCacheRaidGroups is the write cache raid group.
+              items:
+                description: RaidGroup contains the details of a raid group for the
+                  pool
+                properties:
+                  blockDevices:
+                    items:
+                      description: CStorPoolInstanceBlockDevice contains the details
+                        of block devices that constitutes a raid group.
+                      properties:
+                        blockDeviceName:
+                          description: BlockDeviceName is the name of the block device.
+                          type: string
+                        capacity:
+                          description: Capacity is the capacity of the block device.
+                            It is system generated
+                          format: int64
+                          type: integer
+                        devLink:
+                          description: DevLink is the dev link for block devices
+                          type: string
+                      required:
+                      - blockDeviceName
+                      type: object
+                    type: array
+                required:
+                - blockDevices
+                type: object
+              nullable: true
+              type: array
+          required:
+          - dataRaidGroups
+          - nodeSelector
+          type: object
+        status:
+          description: Status is the possible statuses of the cstorpoolinstance resource.
+          properties:
+            capacity:
+              description: Capacity describes the capacity details of a cstor pool
+              properties:
+                free:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  description: Amount of usable space in the pool after excluding
+                    metadata and raid parity
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                total:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  description: Sum of usable capacity in all the data raidgroups
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                used:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  description: Amount of physical data (and its metadata) written
+                    to pool after applying compression, etc..,
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                zfs:
+                  description: ZFSCapacityAttributes contains advanced information
+                    about pool capacity details
+                  properties:
+                    logicalUsed:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: LogicalUsed is the amount of space that is "logically"
+                        consumed by this pool and all its descendents. The logical
+                        space ignores the effect of the compression and copies properties,
+                        giving a quantity closer to the amount of data that applications
+                        see. However, it does include space consumed by metadata.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  required:
+                  - logicalUsed
+                  type: object
+              required:
+              - free
+              - total
+              - used
+              - zfs
+              type: object
+            conditions:
+              description: Current state of CSPI with details.
+              items:
+                description: CSPIConditionType describes the state of a CSPI at a
+                  certain point.
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    description: The last time this condition was updated.
+                    format: date-time
+                    type: string
+                  message:
+                    description: A human readable message indicating details about
+                      the transition.
+                    type: string
+                  reason:
+                    description: The reason for the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of CSPC condition.
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+            healthyReplicas:
+              description: HealthyReplicas describes the total count of healthy Volume
+                Replicas in the cstor pool
+              format: int32
+              type: integer
+            phase:
+              description: ' The phase of a CStorPool is a simple, high-level summary
+                of the pool state on the  node.'
+              type: string
+            provisionedReplicas:
+              description: ProvisionedReplicas describes the total count of Volume
+                Replicas present in the cstor pool
+              format: int32
+              type: integer
+            readOnly:
+              description: ReadOnly if pool is readOnly or not
+              type: boolean
+          required:
+          - healthyReplicas
+          - provisionedReplicas
+          - readOnly
+          type: object
+        versionDetails:
+          description: VersionDetails is the openebs version.
+          properties:
+            autoUpgrade:
+              description: If AutoUpgrade is set to true then the resource is upgraded
+                automatically without any manual steps
+              type: boolean
+            desired:
+              description: Desired is the version that we want to upgrade or the control
+                plane version
+              type: string
+            status:
+              description: Status gives the status of reconciliation triggered when
+                the desired and current version are not same
+              properties:
+                current:
+                  description: Current is the version of resource
+                  type: string
+                dependentsUpgraded:
+                  description: DependentsUpgraded gives the details whether all children
+                    of a resource are upgraded to desired version or not
+                  type: boolean
+                lastUpdateTime:
+                  description: LastUpdateTime is the time the status was last  updated
+                  format: date-time
+                  nullable: true
+                  type: string
+                message:
+                  description: Message is a human readable message if some error occurs
+                  type: string
+                reason:
+                  description: Reason is the actual reason for the error state
+                  type: string
+                state:
+                  description: State is the state of reconciliation
+                  type: string
+              type: object
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+#########################################################################
+####                                                                #####
+####                         CStorVolumeConfig CRD                  #####
+####                                                                #####
+#########################################################################
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  name: cstorvolumeconfigs.cstor.openebs.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.capacity.storage
+    description: Identifies the volume capacity
+    name: Capacity
+    type: string
+  - JSONPath: .status.phase
+    description: Identifies the volume provisioning status
+    name: Status
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: Age of CStorVolumeReplica
+    name: Age
+    type: date
+  group: cstor.openebs.io
+  names:
+    kind: CStorVolumeConfig
+    listKind: CStorVolumeConfigList
+    plural: cstorvolumeconfigs
+    shortNames:
+    - cvc
+    singular: cstorvolumeconfig
+  preserveUnknownFields: false
+  scope: Namespaced
+  subresources: {}
+  validation:
+    openAPIV3Schema:
+      description: CStorVolumeConfig describes a cstor volume config resource created
+        as custom resource. CStorVolumeConfig is a request for creating cstor volume
+        related resources like deployment, svc etc.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        publish:
+          description: Publish contains info related to attachment of a volume to
+            a node. i.e. NodeId etc.
+          properties:
+            nodeId:
+              description: NodeID contains publish info related to attachment of a
+                volume to a node.
+              type: string
+          type: object
+        spec:
+          description: Spec defines a specification of a cstor volume config required
+            to provisione cstor volume resources
+          properties:
+            capacity:
+              additionalProperties:
+                anyOf:
+                - type: integer
+                - type: string
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+              description: Capacity represents the actual resources of the underlying
+                cstor volume.
+              type: object
+            cstorVolumeRef:
+              description: CStorVolumeRef has the information about where CstorVolumeClaim
+                is created from.
+              properties:
+                apiVersion:
+                  description: API version of the referent.
+                  type: string
+                fieldPath:
+                  description: 'If referring to a piece of an object instead of an
+                    entire object, this string should contain a valid JSON/Go field
+                    access statement, such as desiredState.manifest.containers[2].
+                    For example, if the object reference is to a container within
+                    a pod, this would take on a value like: "spec.containers{name}"
+                    (where "name" refers to the name of the container that triggered
+                    the event) or if no container name is specified "spec.containers[2]"
+                    (container with index 2 in this pod). This syntax is chosen only
+                    to have some well-defined way of referencing a part of an object.
+                    TODO: this design is not final and this field is subject to change
+                    in the future.'
+                  type: string
+                kind:
+                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                  type: string
+                name:
+                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                  type: string
+                namespace:
+                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                  type: string
+                resourceVersion:
+                  description: 'Specific resourceVersion to which this reference is
+                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                  type: string
+                uid:
+                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                  type: string
+              type: object
+            cstorVolumeSource:
+              description: CStorVolumeSource contains the source volumeName@snapShotname
+                combaination.  This will be filled only if it is a clone creation.
+              type: string
+            policy:
+              description: Policy contains volume specific required policies target
+                and replicas
+              properties:
+                provision:
+                  description: replicaAffinity is set to true then volume replica
+                    resources need to be distributed across the pool instances
+                  properties:
+                    blockSize:
+                      description: BlockSize is the logical block size in multiple
+                        of 512 bytes BlockSize specifies the block size of the volume.
+                        The blocksize cannot be changed once the volume has been written,
+                        so it should be set at volume creation time. The default blocksize
+                        for volumes is 4 Kbytes. Any power of 2 from 512 bytes to
+                        128 Kbytes is valid.
+                      format: int32
+                      type: integer
+                    replicaAffinity:
+                      description: replicaAffinity is set to true then volume replica
+                        resources need to be distributed across the cstor pool instances
+                        based on the given topology
+                      type: boolean
+                  required:
+                  - replicaAffinity
+                  type: object
+                replica:
+                  description: ReplicaSpec represents configuration related to replicas
+                    resources
+                  properties:
+                    compression:
+                      description: The zle compression algorithm compresses runs of
+                        zeros.
+                      type: string
+                    zvolWorkers:
+                      description: IOWorkers represents number of threads that executes
+                        client IOs
+                      type: string
+                  type: object
+                replicaPoolInfo:
+                  description: 'ReplicaPoolInfo holds the pool information of volume
+                    replicas. Ex: If volume is provisioned on which CStor pool volume
+                    replicas exist'
+                  items:
+                    description: ReplicaPoolInfo represents the pool information of
+                      volume replica
+                    properties:
+                      poolName:
+                        description: PoolName represents the pool name where volume
+                          replica exists
+                        type: string
+                    required:
+                    - poolName
+                    type: object
+                  type: array
+                target:
+                  description: TargetSpec represents configuration related to cstor
+                    target and its resources
+                  properties:
+                    affinity:
+                      description: PodAffinity if specified, are the target pod's
+                        affinities
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          description: The scheduler will prefer to schedule pods
+                            to nodes that satisfy the affinity expressions specified
+                            by this field, but it may choose a node that violates
+                            one or more of the expressions. The node that is most
+                            preferred is the one with the greatest sum of weights,
+                            i.e. for each node that meets all of the scheduling requirements
+                            (resource request, requiredDuringScheduling affinity expressions,
+                            etc.), compute a sum by iterating through the elements
+                            of this field and adding "weight" to the sum if the node
+                            has pods which matches the corresponding podAffinityTerm;
+                            the node(s) with the highest sum are the most preferred.
+                          items:
+                            description: The weights of all of the matched WeightedPodAffinityTerm
+                              fields are added per-node to find the most preferred
+                              node(s)
+                            properties:
+                              podAffinityTerm:
+                                description: Required. A pod affinity term, associated
+                                  with the corresponding weight.
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies which namespaces
+                                      the labelSelector applies to (matches against);
+                                      null or empty list means "this pod's namespace"
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified
+                                      namespaces, where co-located is defined as running
+                                      on a node whose value of the label with key
+                                      topologyKey matches that of any node on which
+                                      any of the selected pods is running. Empty topologyKey
+                                      is not allowed.
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              weight:
+                                description: weight associated with matching the corresponding
+                                  podAffinityTerm, in the range 1-100.
+                                format: int32
+                                type: integer
+                            required:
+                            - podAffinityTerm
+                            - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          description: If the affinity requirements specified by this
+                            field are not met at scheduling time, the pod will not
+                            be scheduled onto the node. If the affinity requirements
+                            specified by this field cease to be met at some point
+                            during pod execution (e.g. due to a pod label update),
+                            the system may or may not try to eventually evict the
+                            pod from its node. When there are multiple elements, the
+                            lists of nodes corresponding to each podAffinityTerm are
+                            intersected, i.e. all terms must be satisfied.
+                          items:
+                            description: Defines a set of pods (namely those matching
+                              the labelSelector relative to the given namespace(s))
+                              that this pod should be co-located (affinity) or not
+                              co-located (anti-affinity) with, where co-located is
+                              defined as running on a node whose value of the label
+                              with key <topologyKey> matches that of any node on which
+                              a pod of the set of pods is running
+                            properties:
+                              labelSelector:
+                                description: A label query over a set of resources,
+                                  in this case pods.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaces:
+                                description: namespaces specifies which namespaces
+                                  the labelSelector applies to (matches against);
+                                  null or empty list means "this pod's namespace"
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods
+                                  matching the labelSelector in the specified namespaces,
+                                  where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches
+                                  that of any node on which any of the selected pods
+                                  is running. Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          type: array
+                      type: object
+                    auxResources:
+                      description: AuxResources are the compute resources required
+                        by the cstor-target pod side car containers.
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                      type: object
+                    luWorkers:
+                      description: IOWorkers sets the number of threads that are working
+                        on above queue
+                      format: int64
+                      type: integer
+                    monitor:
+                      description: Monitor enables or disables the target exporter
+                        sidecar
+                      type: boolean
+                    nodeSelector:
+                      additionalProperties:
+                        type: string
+                      description: NodeSelector is the labels that will be used to
+                        select a node for target pod scheduleing Required field
+                      type: object
+                    priorityClassName:
+                      description: PriorityClassName if specified applies to this
+                        target pod If left empty, no priority class is applied.
+                      type: string
+                    queueDepth:
+                      description: QueueDepth sets the queue size at iSCSI target
+                        which limits the ongoing IO count from client
+                      type: string
+                    replicationFactor:
+                      description: ReplicationFactor represents maximum number of
+                        replicas that are allowed to connect to the target
+                      format: int64
+                      type: integer
+                    resources:
+                      description: Resources are the compute resources required by
+                        the cstor-target container.
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                      type: object
+                    tolerations:
+                      description: Tolerations, if specified, are the target pod's
+                        tolerations
+                      items:
+                        description: The pod this Toleration is attached to tolerates
+                          any taint that matches the triple <key,value,effect> using
+                          the matching operator <operator>.
+                        properties:
+                          effect:
+                            description: Effect indicates the taint effect to match.
+                              Empty means match all taint effects. When specified,
+                              allowed values are NoSchedule, PreferNoSchedule and
+                              NoExecute.
+                            type: string
+                          key:
+                            description: Key is the taint key that the toleration
+                              applies to. Empty means match all taint keys. If the
+                              key is empty, operator must be Exists; this combination
+                              means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: Operator represents a key's relationship
+                              to the value. Valid operators are Exists and Equal.
+                              Defaults to Equal. Exists is equivalent to wildcard
+                              for value, so that a pod can tolerate all taints of
+                              a particular category.
+                            type: string
+                          tolerationSeconds:
+                            description: TolerationSeconds represents the period of
+                              time the toleration (which must be of effect NoExecute,
+                              otherwise this field is ignored) tolerates the taint.
+                              By default, it is not set, which means tolerate the
+                              taint forever (do not evict). Zero and negative values
+                              will be treated as 0 (evict immediately) by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: Value is the taint value the toleration matches
+                              to. If the operator is Exists, the value should be empty,
+                              otherwise just a regular string.
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+              type: object
+            provision:
+              description: Provision represents the initial volume configuration for
+                the underlying cstor volume based on the persistent volume request
+                by user. Provision properties are immutable
+              properties:
+                capacity:
+                  additionalProperties:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: Capacity represents initial capacity of volume replica
+                    required during volume clone operations to maintain some metadata
+                    info related to child resources like snapshot, cloned volumes.
+                  type: object
+                replicaCount:
+                  description: ReplicaCount represents initial cstor volume replica
+                    count, its will not be updated later on based on scale up/down
+                    operations, only readonly operations and validations.
+                  type: integer
+              required:
+              - capacity
+              - replicaCount
+              type: object
+          required:
+          - capacity
+          - policy
+          - provision
+          type: object
+        status:
+          description: Status represents the current information/status for the cstor
+            volume config, populated by the controller.
+          properties:
+            capacity:
+              additionalProperties:
+                anyOf:
+                - type: integer
+                - type: string
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+              description: Capacity the actual resources of the underlying volume.
+              type: object
+            condition:
+              items:
+                description: CStorVolumeConfigCondition contains details about state
+                  of cstor volume
+                properties:
+                  lastProbeTime:
+                    description: Last time we probed the condition.
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Reason is a brief CamelCase string that describes
+                      any failure
+                    type: string
+                  type:
+                    description: Current Condition of cstor volume config. If underlying
+                      persistent volume is being resized then the Condition will be
+                      set to 'ResizeStarted' etc
+                    type: string
+                required:
+                - message
+                - reason
+                - type
+                type: object
+              type: array
+            phase:
+              description: Phase represents the current phase of CStorVolumeConfig.
+              type: string
+            poolInfo:
+              description: PoolInfo represents current pool names where volume replicas
+                exists
+              items:
+                type: string
+              type: array
+          type: object
+        versionDetails:
+          description: VersionDetails provides the details for upgrade
+          properties:
+            autoUpgrade:
+              description: If AutoUpgrade is set to true then the resource is upgraded
+                automatically without any manual steps
+              type: boolean
+            desired:
+              description: Desired is the version that we want to upgrade or the control
+                plane version
+              type: string
+            status:
+              description: Status gives the status of reconciliation triggered when
+                the desired and current version are not same
+              properties:
+                current:
+                  description: Current is the version of resource
+                  type: string
+                dependentsUpgraded:
+                  description: DependentsUpgraded gives the details whether all children
+                    of a resource are upgraded to desired version or not
+                  type: boolean
+                lastUpdateTime:
+                  description: LastUpdateTime is the time the status was last  updated
+                  format: date-time
+                  nullable: true
+                  type: string
+                message:
+                  description: Message is a human readable message if some error occurs
+                  type: string
+                reason:
+                  description: Reason is the actual reason for the error state
+                  type: string
+                state:
+                  description: State is the state of reconciliation
+                  type: string
+              type: object
+          type: object
+      required:
+      - spec
+      - status
+      - versionDetails
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+################################################################
+####                                                       #####
+####                  CStorVolumePolicies                  #####
+####                                                       #####
+################################################################
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  name: cstorvolumepolicies.cstor.openebs.io
+spec:
+  group: cstor.openebs.io
+  names:
+    kind: CStorVolumePolicy
+    listKind: CStorVolumePolicyList
+    plural: cstorvolumepolicies
+    shortNames:
+    - cvp
+    singular: cstorvolumepolicy
+  preserveUnknownFields: false
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      description: CStorVolumePolicy describes a configuration required for cstor
+        volume resources
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: Spec defines a configuration info of a cstor volume required
+            to provisione cstor volume resources
+          properties:
+            provision:
+              description: replicaAffinity is set to true then volume replica resources
+                need to be distributed across the pool instances
+              properties:
+                blockSize:
+                  description: BlockSize is the logical block size in multiple of
+                    512 bytes BlockSize specifies the block size of the volume. The
+                    blocksize cannot be changed once the volume has been written,
+                    so it should be set at volume creation time. The default blocksize
+                    for volumes is 4 Kbytes. Any power of 2 from 512 bytes to 128
+                    Kbytes is valid.
+                  format: int32
+                  type: integer
+                replicaAffinity:
+                  description: replicaAffinity is set to true then volume replica
+                    resources need to be distributed across the cstor pool instances
+                    based on the given topology
+                  type: boolean
+              required:
+              - replicaAffinity
+              type: object
+            replica:
+              description: ReplicaSpec represents configuration related to replicas
+                resources
+              properties:
+                compression:
+                  description: The zle compression algorithm compresses runs of zeros.
+                  type: string
+                zvolWorkers:
+                  description: IOWorkers represents number of threads that executes
+                    client IOs
+                  type: string
+              type: object
+            replicaPoolInfo:
+              description: 'ReplicaPoolInfo holds the pool information of volume replicas.
+                Ex: If volume is provisioned on which CStor pool volume replicas exist'
+              items:
+                description: ReplicaPoolInfo represents the pool information of volume
+                  replica
+                properties:
+                  poolName:
+                    description: PoolName represents the pool name where volume replica
+                      exists
+                    type: string
+                required:
+                - poolName
+                type: object
+              type: array
+            target:
+              description: TargetSpec represents configuration related to cstor target
+                and its resources
+              properties:
+                affinity:
+                  description: PodAffinity if specified, are the target pod's affinities
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      description: The scheduler will prefer to schedule pods to nodes
+                        that satisfy the affinity expressions specified by this field,
+                        but it may choose a node that violates one or more of the
+                        expressions. The node that is most preferred is the one with
+                        the greatest sum of weights, i.e. for each node that meets
+                        all of the scheduling requirements (resource request, requiredDuringScheduling
+                        affinity expressions, etc.), compute a sum by iterating through
+                        the elements of this field and adding "weight" to the sum
+                        if the node has pods which matches the corresponding podAffinityTerm;
+                        the node(s) with the highest sum are the most preferred.
+                      items:
+                        description: The weights of all of the matched WeightedPodAffinityTerm
+                          fields are added per-node to find the most preferred node(s)
+                        properties:
+                          podAffinityTerm:
+                            description: Required. A pod affinity term, associated
+                              with the corresponding weight.
+                            properties:
+                              labelSelector:
+                                description: A label query over a set of resources,
+                                  in this case pods.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaces:
+                                description: namespaces specifies which namespaces
+                                  the labelSelector applies to (matches against);
+                                  null or empty list means "this pod's namespace"
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods
+                                  matching the labelSelector in the specified namespaces,
+                                  where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches
+                                  that of any node on which any of the selected pods
+                                  is running. Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          weight:
+                            description: weight associated with matching the corresponding
+                              podAffinityTerm, in the range 1-100.
+                            format: int32
+                            type: integer
+                        required:
+                        - podAffinityTerm
+                        - weight
+                        type: object
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      description: If the affinity requirements specified by this
+                        field are not met at scheduling time, the pod will not be
+                        scheduled onto the node. If the affinity requirements specified
+                        by this field cease to be met at some point during pod execution
+                        (e.g. due to a pod label update), the system may or may not
+                        try to eventually evict the pod from its node. When there
+                        are multiple elements, the lists of nodes corresponding to
+                        each podAffinityTerm are intersected, i.e. all terms must
+                        be satisfied.
+                      items:
+                        description: Defines a set of pods (namely those matching
+                          the labelSelector relative to the given namespace(s)) that
+                          this pod should be co-located (affinity) or not co-located
+                          (anti-affinity) with, where co-located is defined as running
+                          on a node whose value of the label with key <topologyKey>
+                          matches that of any node on which a pod of the set of pods
+                          is running
+                        properties:
+                          labelSelector:
+                            description: A label query over a set of resources, in
+                              this case pods.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values
+                                        array must be non-empty. If the operator is
+                                        Exists or DoesNotExist, the values array must
+                                        be empty. This array is replaced during a
+                                        strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          namespaces:
+                            description: namespaces specifies which namespaces the
+                              labelSelector applies to (matches against); null or
+                              empty list means "this pod's namespace"
+                            items:
+                              type: string
+                            type: array
+                          topologyKey:
+                            description: This pod should be co-located (affinity)
+                              or not co-located (anti-affinity) with the pods matching
+                              the labelSelector in the specified namespaces, where
+                              co-located is defined as running on a node whose value
+                              of the label with key topologyKey matches that of any
+                              node on which any of the selected pods is running. Empty
+                              topologyKey is not allowed.
+                            type: string
+                        required:
+                        - topologyKey
+                        type: object
+                      type: array
+                  type: object
+                auxResources:
+                  description: AuxResources are the compute resources required by
+                    the cstor-target pod side car containers.
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                  type: object
+                luWorkers:
+                  description: IOWorkers sets the number of threads that are working
+                    on above queue
+                  format: int64
+                  type: integer
+                monitor:
+                  description: Monitor enables or disables the target exporter sidecar
+                  type: boolean
+                nodeSelector:
+                  additionalProperties:
+                    type: string
+                  description: NodeSelector is the labels that will be used to select
+                    a node for target pod scheduleing Required field
+                  type: object
+                priorityClassName:
+                  description: PriorityClassName if specified applies to this target
+                    pod If left empty, no priority class is applied.
+                  type: string
+                queueDepth:
+                  description: QueueDepth sets the queue size at iSCSI target which
+                    limits the ongoing IO count from client
+                  type: string
+                replicationFactor:
+                  description: ReplicationFactor represents maximum number of replicas
+                    that are allowed to connect to the target
+                  format: int64
+                  type: integer
+                resources:
+                  description: Resources are the compute resources required by the
+                    cstor-target container.
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                  type: object
+                tolerations:
+                  description: Tolerations, if specified, are the target pod's tolerations
+                  items:
+                    description: The pod this Toleration is attached to tolerates
+                      any taint that matches the triple <key,value,effect> using the
+                      matching operator <operator>.
+                    properties:
+                      effect:
+                        description: Effect indicates the taint effect to match. Empty
+                          means match all taint effects. When specified, allowed values
+                          are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                      key:
+                        description: Key is the taint key that the toleration applies
+                          to. Empty means match all taint keys. If the key is empty,
+                          operator must be Exists; this combination means to match
+                          all values and all keys.
+                        type: string
+                      operator:
+                        description: Operator represents a key's relationship to the
+                          value. Valid operators are Exists and Equal. Defaults to
+                          Equal. Exists is equivalent to wildcard for value, so that
+                          a pod can tolerate all taints of a particular category.
+                        type: string
+                      tolerationSeconds:
+                        description: TolerationSeconds represents the period of time
+                          the toleration (which must be of effect NoExecute, otherwise
+                          this field is ignored) tolerates the taint. By default,
+                          it is not set, which means tolerate the taint forever (do
+                          not evict). Zero and negative values will be treated as
+                          0 (evict immediately) by the system.
+                        format: int64
+                        type: integer
+                      value:
+                        description: Value is the taint value the toleration matches
+                          to. If the operator is Exists, the value should be empty,
+                          otherwise just a regular string.
+                        type: string
+                    type: object
+                  type: array
+              type: object
+          type: object
+        status:
+          description: CStorVolumePolicyStatus is for handling status of CstorVolumePolicy
+          properties:
+            phase:
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+#############################################################################################
+###                                                                                    ######
+###                    CStorVolumeReplicas CRD                                         ######
+###                                                                                    ######
+#############################################################################################
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  name: cstorvolumereplicas.cstor.openebs.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.capacity.total
+    description: The amount of disk space consumed by a dataset and all its descendents
+    name: Allocated
+    type: string
+  - JSONPath: .status.capacity.used
+    description: The amount of space that is logically consumed by this dataset
+    name: Used
+    type: string
+  - JSONPath: .status.phase
+    description: Identifies the current state of the replicas
+    name: Status
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: Age of CStorVolumeReplica
+    name: Age
+    type: date
+  group: cstor.openebs.io
+  names:
+    kind: CStorVolumeReplica
+    listKind: CStorVolumeReplicaList
+    plural: cstorvolumereplicas
+    shortNames:
+    - cvr
+    singular: cstorvolumereplica
+  preserveUnknownFields: false
+  scope: Namespaced
+  subresources: {}
+  validation:
+    openAPIV3Schema:
+      description: CStorVolumeReplica describes a cstor volume resource created as
+        custom resource
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: CStorVolumeReplicaSpec is the spec for a CStorVolumeReplica
+            resource
+          properties:
+            blockSize:
+              description: BlockSize is the logical block size in multiple of 512
+                bytes BlockSize specifies the block size of the volume. The blocksize
+                cannot be changed once the volume has been written, so it should be
+                set at volume creation time. The default blocksize for volumes is
+                4 Kbytes. Any power of 2 from 512 bytes to 128 Kbytes is valid.
+              format: int32
+              type: integer
+            capacity:
+              description: Represents the actual capacity of the underlying volume
+              type: string
+            compression:
+              description: 'Controls the compression algorithm used for this volumes
+                examples: on|off|gzip|gzip-N|lz4|lzjb|zle'
+              type: string
+            replicaid:
+              description: ReplicaID is unique number to identify the replica
+              type: string
+            targetIP:
+              description: TargetIP represents iscsi target IP through which replica
+                cummunicates IO workloads and other volume operations like snapshot
+                and resize requests
+              type: string
+            zvolWorkers:
+              description: ZvolWorkers represents number of threads that executes
+                client IOs
+              type: string
+          type: object
+        status:
+          description: CStorVolumeReplicaStatus is for handling status of cvr.
+          properties:
+            capacity:
+              description: CStorVolumeCapacityDetails represents capacity info of
+                replica
+              properties:
+                total:
+                  description: The amount of space consumed by this volume replica
+                    and all its descendents
+                  type: string
+                used:
+                  description: The amount of space that is "logically" accessible
+                    by this dataset. The logical space ignores the effect of the compression
+                    and copies properties, giving a quantity closer to the amount
+                    of data that applications see.  However, it does include space
+                    consumed by metadata
+                  type: string
+              required:
+              - total
+              - used
+              type: object
+            lastTransitionTime:
+              description: LastTransitionTime refers to the time when the phase changes
+              format: date-time
+              nullable: true
+              type: string
+            lastUpdateTime:
+              description: The last updated time
+              format: date-time
+              nullable: true
+              type: string
+            message:
+              description: A human readable message indicating details about the transition.
+              type: string
+            pendingSnapshots:
+              additionalProperties:
+                description: CStorSnapshotInfo represents the snapshot information
+                  related to particular snapshot
+                properties:
+                  logicalReferenced:
+                    description: LogicalReferenced describes the amount of space that
+                      is "logically" accessable by this snapshot. This logical space
+                      ignores the effect of the compression and copies properties,
+                      giving a quantity closer to the amount of data that application
+                      see. It also includes space consumed by metadata.
+                    format: int64
+                    type: integer
+                required:
+                - logicalReferenced
+                type: object
+              description: PendingSnapshots contains list of pending snapshots that
+                are not yet available on this replica
+              type: object
+            phase:
+              description: CStorVolumeReplicaPhase is to holds different phases of
+                replica
+              type: string
+            snapshots:
+              additionalProperties:
+                description: CStorSnapshotInfo represents the snapshot information
+                  related to particular snapshot
+                properties:
+                  logicalReferenced:
+                    description: LogicalReferenced describes the amount of space that
+                      is "logically" accessable by this snapshot. This logical space
+                      ignores the effect of the compression and copies properties,
+                      giving a quantity closer to the amount of data that application
+                      see. It also includes space consumed by metadata.
+                    format: int64
+                    type: integer
+                required:
+                - logicalReferenced
+                type: object
+              description: Snapshots contains list of snapshots, and their properties,
+                created on CVR
+              type: object
+          type: object
+        versionDetails:
+          description: VersionDetails provides the details for upgrade
+          properties:
+            autoUpgrade:
+              description: If AutoUpgrade is set to true then the resource is upgraded
+                automatically without any manual steps
+              type: boolean
+            desired:
+              description: Desired is the version that we want to upgrade or the control
+                plane version
+              type: string
+            status:
+              description: Status gives the status of reconciliation triggered when
+                the desired and current version are not same
+              properties:
+                current:
+                  description: Current is the version of resource
+                  type: string
+                dependentsUpgraded:
+                  description: DependentsUpgraded gives the details whether all children
+                    of a resource are upgraded to desired version or not
+                  type: boolean
+                lastUpdateTime:
+                  description: LastUpdateTime is the time the status was last  updated
+                  format: date-time
+                  nullable: true
+                  type: string
+                message:
+                  description: Message is a human readable message if some error occurs
+                  type: string
+                reason:
+                  description: Reason is the actual reason for the error state
+                  type: string
+                state:
+                  description: State is the state of reconciliation
+                  type: string
+              type: object
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+###############################################################################
+####                                                                       ####
+####               CStorVolume CRD                                         ####
+####                                                                       ####
+###############################################################################
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  name: cstorvolumes.cstor.openebs.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.capacity
+    description: Current volume capacity
+    name: Capacity
+    type: string
+  - JSONPath: .status.phase
+    description: Identifies the current health of the volume
+    name: Status
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: Age of CStorVolume
+    name: Age
+    type: date
+  group: cstor.openebs.io
+  names:
+    kind: CStorVolume
+    listKind: CStorVolumeList
+    plural: cstorvolumes
+    shortNames:
+    - cv
+    singular: cstorvolume
+  preserveUnknownFields: false
+  scope: Namespaced
+  subresources: {}
+  validation:
+    openAPIV3Schema:
+      description: CStorVolume describes a cstor volume resource created as custom
+        resource
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: CStorVolumeSpec is the spec for a CStorVolume resource
+          properties:
+            capacity:
+              anyOf:
+              - type: integer
+              - type: string
+              description: Capacity represents the desired size of the underlying
+                volume.
+              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+              x-kubernetes-int-or-string: true
+            consistencyFactor:
+              description: ConsistencyFactor is minimum number of volume replicas
+                i.e. `RF/2 + 1` has to be connected to the target for write operations.
+                Basically more then 50% of replica has to be connected to target.
+              type: integer
+            desiredReplicationFactor:
+              description: DesiredReplicationFactor represents maximum number of replicas
+                that are allowed to connect to the target. Required for scale operations
+              type: integer
+            iqn:
+              description: Target iSCSI Qualified Name.combination of nodeBase
+              type: string
+            replicaDetails:
+              description: ReplicaDetails refers to the trusty replica information
+              properties:
+                knownReplicas:
+                  additionalProperties:
+                    type: string
+                  description: KnownReplicas represents the replicas that target can
+                    trust to read data
+                  type: object
+              type: object
+            replicationFactor:
+              description: ReplicationFactor represents number of volume replica created
+                during volume provisioning connect to the target
+              type: integer
+            targetIP:
+              description: TargetIP IP of the iSCSI target service
+              type: string
+            targetPort:
+              description: iSCSI Target Port typically TCP ports 3260
+              type: string
+            targetPortal:
+              description: iSCSI Target Portal. The Portal is combination of IP:port
+                (typically TCP ports 3260)
+              type: string
+          type: object
+        status:
+          description: CStorVolumeStatus is for handling status of cvr.
+          properties:
+            capacity:
+              anyOf:
+              - type: integer
+              - type: string
+              description: Represents the actual capacity of the underlying volume.
+              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+              x-kubernetes-int-or-string: true
+            conditions:
+              description: Current Condition of cstorvolume. If underlying persistent
+                volume is being resized then the Condition will be set to 'ResizePending'.
+              items:
+                description: CStorVolumeCondition contains details about state of
+                  cstorvolume
+                properties:
+                  lastProbeTime:
+                    description: Last time we probed the condition.
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Human-readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: Unique, this should be a short, machine understandable
+                      string that gives the reason for condition's last transition.
+                      If it reports "ResizePending" that means the underlying cstorvolume
+                      is being resized.
+                    type: string
+                  status:
+                    description: ConditionStatus states in which state condition is
+                      present
+                    type: string
+                  type:
+                    description: CStorVolumeConditionType is a valid value of CStorVolumeCondition.Type
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+            lastTransitionTime:
+              description: LastTransitionTime refers to the time when the phase changes
+              format: date-time
+              nullable: true
+              type: string
+            lastUpdateTime:
+              description: LastUpdateTime refers to the time when last status updated
+                due to any operations
+              format: date-time
+              nullable: true
+              type: string
+            message:
+              description: A human-readable message indicating details about why the
+                volume is in this state.
+              type: string
+            phase:
+              description: CStorVolumePhase is to hold result of action.
+              type: string
+            replicaDetails:
+              description: ReplicaDetails refers to the trusty replica information
+              properties:
+                knownReplicas:
+                  additionalProperties:
+                    type: string
+                  description: KnownReplicas represents the replicas that target can
+                    trust to read data
+                  type: object
+              type: object
+            replicaStatuses:
+              items:
+                description: ReplicaStatus stores the status of replicas
+                properties:
+                  checkpointedIOSeq:
+                    description: Represents IO number of replica persisted on the
+                      disk
+                    type: string
+                  inflightRead:
+                    description: Ongoing reads I/O from target to replica
+                    type: string
+                  inflightSync:
+                    description: Ongoing sync I/O from target to replica
+                    type: string
+                  inflightWrite:
+                    description: ongoing writes I/O from target to replica
+                    type: string
+                  mode:
+                    description: Mode represents replica status i.e. Healthy, Degraded
+                    type: string
+                  quorum:
+                    description: 'Quorum indicates wheather data wrtitten to the replica
+                      is lost or exists. "0" means: data has been lost( might be ephimeral
+                      case) and will recostruct data from other Healthy replicas in
+                      a write-only mode 1 means: written data is exists on replica'
+                    type: string
+                  replicaId:
+                    description: ID is replica unique identifier
+                    type: string
+                  upTime:
+                    description: time since the replica connected to target
+                    type: integer
+                required:
+                - checkpointedIOSeq
+                - inflightRead
+                - inflightSync
+                - inflightWrite
+                - mode
+                - quorum
+                - replicaId
+                - upTime
+                type: object
+              type: array
+          type: object
+        versionDetails:
+          description: VersionDetails provides the details for upgrade
+          properties:
+            autoUpgrade:
+              description: If AutoUpgrade is set to true then the resource is upgraded
+                automatically without any manual steps
+              type: boolean
+            desired:
+              description: Desired is the version that we want to upgrade or the control
+                plane version
+              type: string
+            status:
+              description: Status gives the status of reconciliation triggered when
+                the desired and current version are not same
+              properties:
+                current:
+                  description: Current is the version of resource
+                  type: string
+                dependentsUpgraded:
+                  description: DependentsUpgraded gives the details whether all children
+                    of a resource are upgraded to desired version or not
+                  type: boolean
+                lastUpdateTime:
+                  description: LastUpdateTime is the time the status was last  updated
+                  format: date-time
+                  nullable: true
+                  type: string
+                message:
+                  description: Message is a human readable message if some error occurs
+                  type: string
+                reason:
+                  description: Reason is the actual reason for the error state
+                  type: string
+                state:
+                  description: State is the state of reconciliation
+                  type: string
+              type: object
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+############################################################
+####                                                    ####
+####                   CStorBackup CRD                  ####
+####                                                    ####
+############################################################
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cstorbackups.openebs.io
+spec:
+  group: openebs.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: cstorbackups
+    singular: cstorbackup
+    kind: CStorBackup
+    shortNames:
+    - cbkp
+    - cbkps
+    - cbackups
+    - cbackup
+  additionalPrinterColumns:
+    - JSONPath: .spec.volumeName
+      name: volume
+      description: volume on which backup performed
+      type: string
+    - JSONPath: .spec.backupName
+      name: backup/schedule
+      description: Backup/schedule name
+      type: string
+    - JSONPath: .status
+      name: Status
+      description: Backup status
+      type: string
+---
+############################################################
+####                                                    ####
+####             CStorCompletedBackup CRD               ####
+####                                                    ####
+############################################################
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cstorcompletedbackups.openebs.io
+spec:
+  group: openebs.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: cstorcompletedbackups
+    singular: cstorcompletedbackup
+    kind: CStorCompletedBackup
+    shortNames:
+    - cbkpc
+    - cbackupcompleted
+  additionalPrinterColumns:
+    - JSONPath: .spec.volumeName
+      name: volume
+      description: volume on which backup performed
+      type: string
+    - JSONPath: .spec.backupName
+      name: backup/schedule
+      description: Backup/schedule name
+      type: string
+    - JSONPath: .spec.prevSnapName
+      name: lastSnap
+      description: Last successful backup snapshot
+      type: string
+---
+############################################################
+####                                                    ####
+####             CStorRestore CRD                       ####
+####                                                    ####
+############################################################
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cstorrestores.openebs.io
+spec:
+  group: openebs.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: cstorrestores
+    singular: cstorrestore
+    kind: CStorRestore
+    shortNames:
+    - crst
+    - crsts
+    - crestores
+    - crestore
+  additionalPrinterColumns:
+    - JSONPath: .spec.restoreName
+      name: backup
+      description: backup name which is  restored
+      type: string
+    - JSONPath: .spec.volumeName
+      name: volume
+      description: volume on which restore performed
+      type: string
+    - JSONPath: .status
+      name: Status
+      description: Restore status
+      type: string
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cspc-operator
+  namespace: openebs
+  labels:
+    name: cspc-operator
+    openebs.io/component-name: cspc-operator
+    openebs.io/version: 2.0.0
+spec:
+  selector:
+    matchLabels:
+      name: cspc-operator
+      openebs.io/component-name: cspc-operator
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        name: cspc-operator
+        openebs.io/component-name: cspc-operator
+        openebs.io/version: 2.0.0
+    spec:
+      serviceAccountName: openebs-maya-operator
+      containers:
+      - name: cspc-operator
+        imagePullPolicy: IfNotPresent
+        image: openebs/cspc-operator-amd64:2.0.0
+        env:
+        - name: OPENEBS_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OPENEBS_SERVICEACCOUNT_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: CSPC_OPERATOR_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        # OPENEBS_IO_BASE_DIR is used to configure base directory for openebs on host path.
+        # Where OpenEBS can store required files. Default base path will be /var/openebs
+        # - name: OPENEBS_IO_BASE_DIR
+        #   value: "/var/openebs"
+        # OPENEBS_IO_CSTOR_POOL_SPARSE_DIR can be used to specify the hostpath
+        # to be used for saving the shared content between the side cars
+        # of cstor pool pod. This ENV is also used to indicate the location
+        # of the sparse devices.
+        # The default path used is /var/openebs/sparse
+        #- name: OPENEBS_IO_CSTOR_POOL_SPARSE_DIR
+        #  value: "/var/openebs/sparse"
+        - name: OPENEBS_IO_CSPI_MGMT_IMAGE
+          value: "openebs/cstor-pool-manager-amd64:2.0.0"
+        - name: OPENEBS_IO_CSTOR_POOL_IMAGE
+          value: "openebs/cstor-pool:2.0.0"
+        - name:  OPENEBS_IO_CSTOR_POOL_EXPORTER_IMAGE
+          value: "openebs/m-exporter:2.0.0"
+        - name: RESYNC_INTERVAL
+          value: "30"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cvc-operator
+  namespace: openebs
+  labels:
+    name: cvc-operator
+    openebs.io/component-name: cvc-operator
+    openebs.io/version: 2.0.0
+spec:
+  selector:
+    matchLabels:
+      name: cvc-operator
+      openebs.io/component-name: cvc-operator
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        name: cvc-operator
+        openebs.io/component-name: cvc-operator
+        openebs.io/version: 2.0.0
+    spec:
+      serviceAccountName: openebs-maya-operator
+      containers:
+      - name: cvc-operator
+        imagePullPolicy: IfNotPresent
+        image: openebs/cvc-operator-amd64:2.0.0
+        env:
+        # OPENEBS_IO_BASE_DIR is used to configure base directory for openebs on host path.
+        # Where OpenEBS can store required files. Default base path will be /var/openebs
+        # - name: OPENEBS_IO_BASE_DIR
+        #   value: "/var/openebs"
+        # OPENEBS_IO_CSTOR_TARGET_DIR can be used to specify the hostpath
+        # that to be used for saving the core dump of cstor volume pod.
+        # The default path used is /var/openebs/sparse
+        #- name: OPENEBS_IO_CSTOR_TARGET_DIR
+        #  value: "/var/openebs/sparse"
+        - name: OPENEBS_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OPENEBS_SERVICEACCOUNT_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: OPENEBS_IO_CSTOR_TARGET_IMAGE
+          value: "openebs/cstor-istgt:2.0.0"
+        - name:  OPENEBS_IO_CSTOR_VOLUME_MGMT_IMAGE
+          value: "openebs/cstor-volume-manager-amd64:2.0.0"
+        - name:  OPENEBS_IO_VOLUME_MONITOR_IMAGE
+          value: "openebs/m-exporter:2.0.0"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cvc-operator-service
+  namespace: openebs
+  labels:
+    openebs.io/component-name: cvc-operator-svc
+spec:
+  ports:
+  - name: api
+    port: 5757
+    protocol: TCP
+    targetPort: 5757
+  selector:
+    name: cvc-operator
+  sessionAffinity: None
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openebs-cstor-admission-server
+  namespace: openebs
+  labels:
+    app: cstor-admission-webhook
+    openebs.io/component-name: cstor-admission-webhook
+    openebs.io/version: 2.0.0
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+    rollingUpdate: null
+  selector:
+    matchLabels:
+      app: cstor-admission-webhook
+  template:
+    metadata:
+      labels:
+        app: cstor-admission-webhook
+        openebs.io/component-name: cstor-admission-webhook
+        openebs.io/version: 2.0.0
+    spec:
+      serviceAccountName: openebs-maya-operator
+      containers:
+        - name: admission-webhook
+          image: openebs/cstor-webhook-amd64:2.0.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - -alsologtostderr
+            - -v=2
+            - 2>&1
+          env:
+            - name: OPENEBS_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ADMISSION_WEBHOOK_NAME
+              value: "openebs-cstor-admission-server"
+            - name: ADMISSION_WEBHOOK_FAILURE_POLICY
+              value: "Fail"

--- a/2.0.0/ndm-operator.yaml
+++ b/2.0.0/ndm-operator.yaml
@@ -1,0 +1,233 @@
+# This is the node-disk-manager related config.
+# It can be used to customize the disks probes and filters
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openebs-ndm-config
+  namespace: openebs
+  labels:
+    openebs.io/component-name: ndm-config
+data:
+  # udev-probe is default or primary probe which should be enabled to run ndm
+  # filterconfigs contails configs of filters - in their form fo include
+  # and exclude comma separated strings
+  node-disk-manager.config: |
+    probeconfigs:
+      - key: udev-probe
+        name: udev probe
+        state: true
+      - key: seachest-probe
+        name: seachest probe
+        state: false
+      - key: smart-probe
+        name: smart probe
+        state: true
+    filterconfigs:
+      - key: os-disk-exclude-filter
+        name: os disk exclude filter
+        state: true
+        exclude: "/,/etc/hosts,/boot"
+      - key: vendor-filter
+        name: vendor filter
+        state: true
+        include: ""
+        exclude: "CLOUDBYT,OpenEBS"
+      - key: path-filter
+        name: path filter
+        state: true
+        include: ""
+        exclude: "loop,/dev/fd0,/dev/sr0,/dev/ram,/dev/dm-,/dev/md,/dev/rbd"
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: openebs-ndm
+  namespace: openebs
+  labels:
+    name: openebs-ndm
+    openebs.io/component-name: ndm
+    openebs.io/version: 2.0.0
+spec:
+  selector:
+    matchLabels:
+      name: openebs-ndm
+      openebs.io/component-name: ndm
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: openebs-ndm
+        openebs.io/component-name: ndm
+        openebs.io/version: 2.0.0
+    spec:
+      # By default the node-disk-manager will be run on all kubernetes nodes
+      # If you would like to limit this to only some nodes, say the nodes
+      # that have storage attached, you could label those node and use
+      # nodeSelector.
+      #
+      # e.g. label the storage nodes with - "openebs.io/nodegroup"="storage-node"
+      # kubectl label node <node-name> "openebs.io/nodegroup"="storage-node"
+      #nodeSelector:
+      #  "openebs.io/nodegroup": "storage-node"
+      serviceAccountName: openebs-maya-operator
+      hostNetwork: true
+      # host PID is used to check status of iSCSI Service when the NDM
+      # API service is enabled
+      #hostPID: true
+      containers:
+      - name: node-disk-manager
+        image: openebs/node-disk-manager:0.8.0
+        args:
+          - -v=4
+        # The feature-gate is used to enable the new UUID algorithm.
+          - --feature-gates="GPTBasedUUID"
+        # The feature gate is used to start the gRPC API service. The gRPC server
+        # starts at 9115 port by default. This feature is currently in Alpha state
+        # - --feature-gates="APIService"
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: config
+          mountPath: /host/node-disk-manager.config
+          subPath: node-disk-manager.config
+          readOnly: true
+        - name: udev
+          mountPath: /run/udev
+        - name: procmount
+          mountPath: /host/proc
+          readOnly: true
+        - name: devmount
+          mountPath: /dev
+        - name: basepath
+          mountPath: /var/openebs/ndm
+        - name: sparsepath
+          mountPath: /var/openebs/sparse
+        env:
+        # namespace in which NDM is installed will be passed to NDM Daemonset
+        # as environment variable
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        # pass hostname as env variable using downward API to the NDM container
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        # specify the directory where the sparse files need to be created.
+        # if not specified, then sparse files will not be created.
+        - name: SPARSE_FILE_DIR
+          value: "/var/openebs/sparse"
+        # Size(bytes) of the sparse file to be created.
+        - name: SPARSE_FILE_SIZE
+          value: "10737418240"
+        # Specify the number of sparse files to be created
+        - name: SPARSE_FILE_COUNT
+          value: "0"
+        livenessProbe:
+          exec:
+            command:
+            - pgrep
+            - "ndm"
+          initialDelaySeconds: 30
+          periodSeconds: 60
+      volumes:
+      - name: config
+        configMap:
+          name: openebs-ndm-config
+      - name: udev
+        hostPath:
+          path: /run/udev
+          type: Directory
+      # mount /proc (to access mount file of process 1 of host) inside container
+      # to read mount-point of disks and partitions
+      - name: procmount
+        hostPath:
+          path: /proc
+          type: Directory
+      - name: devmount
+      # the /dev directory is mounted so that we have access to the devices that
+      # are connected at runtime of the pod.
+        hostPath:
+          path: /dev
+          type: Directory
+      - name: basepath
+        hostPath:
+          path: /var/openebs/ndm
+          type: DirectoryOrCreate
+      - name: sparsepath
+        hostPath:
+          path: /var/openebs/sparse
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openebs-ndm-operator
+  namespace: openebs
+  labels:
+    name: openebs-ndm-operator
+    openebs.io/component-name: ndm-operator
+    openebs.io/version: 2.0.0
+spec:
+  selector:
+    matchLabels:
+      name: openebs-ndm-operator
+      openebs.io/component-name: ndm-operator
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        name: openebs-ndm-operator
+        openebs.io/component-name: ndm-operator
+        openebs.io/version: 2.0.0
+    spec:
+      serviceAccountName: openebs-maya-operator
+      containers:
+        - name: node-disk-operator
+          image: openebs/node-disk-operator:0.8.0
+          imagePullPolicy: IfNotPresent
+          readinessProbe:
+            exec:
+              command:
+                - stat
+                - /tmp/operator-sdk-ready
+            initialDelaySeconds: 4
+            periodSeconds: 10
+            failureThreshold: 1
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            # the service account of the ndm-operator pod
+            - name: SERVICE_ACCOUNT
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
+            - name: OPERATOR_NAME
+              value: "node-disk-operator"
+            - name: CLEANUP_JOB_IMAGE
+              value: "openebs/linux-utils:2.0.0"
+            # OPENEBS_IO_INSTALL_CRD environment variable is used to enable/disable CRD installation
+            # from NDM operator. By default the CRDs will be installed
+            #- name: OPENEBS_IO_INSTALL_CRD
+            #  value: "true"
+          # Process name used for matching is limited to the 15 characters
+          # present in the pgrep output.
+          # So fullname can be used here with pgrep (cmd is < 15 chars).
+          livenessProbe:
+            exec:
+              command:
+              - pgrep
+              - "ndo"
+            initialDelaySeconds: 30
+            periodSeconds: 60
+---


### PR DESCRIPTION
This PR adds following operator yamls
- Add cstor operator 2.0.0-RC1 yaml
- Add cstor operator 2.0.0-RC2 yaml
- Add cstor operator 2.0.0 yaml
- Add ndm-operator 0.8.0 yaml(Which will be helpful to users installing only new cStor)

Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

#### Special notes for your reviewer:
- Verified changes locally

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/openebs]`)
