### PR TITLE
[openebs]fix(release): OpenEBS 2.0.0 YAML for AWS

### DIFF
--- a/2.0.0/openebs-operator-2.0.0-aws.yaml
+++ b/2.0.0/openebs-operator-2.0.0-aws.yaml
@@ -487,7 +487,7 @@ spec:
       #hostPID: true
       containers:
       - name: node-disk-manager
-        image: 117940112483.dkr.ecr.us-east-1.amazonaws.com/3ed4f202-6b8f-4bc9-adaa-20ce0807bba3/cg-3606609021/openebs/provisioner-localpv:2.0.0-latest
+        image: 117940112483.dkr.ecr.us-east-1.amazonaws.com/3ed4f202-6b8f-4bc9-adaa-20ce0807bba3/cg-3606609021/openebs/node-disk-manager:2.0.0-latest
         args:
           - -v=4
         # The feature-gate is used to enable the new UUID algorithm.

--- a/openebs-operator-aws.yaml
+++ b/openebs-operator-aws.yaml
@@ -487,7 +487,7 @@ spec:
       #hostPID: true
       containers:
       - name: node-disk-manager
-        image: 117940112483.dkr.ecr.us-east-1.amazonaws.com/3ed4f202-6b8f-4bc9-adaa-20ce0807bba3/cg-3606609021/openebs/provisioner-localpv:2.0.0-latest
+        image: 117940112483.dkr.ecr.us-east-1.amazonaws.com/3ed4f202-6b8f-4bc9-adaa-20ce0807bba3/cg-3606609021/openebs/node-disk-manager:2.0.0-latest
         args:
           - -v=4
         # The feature-gate is used to enable the new UUID algorithm.


### PR DESCRIPTION
Wrong image mentioned for Node disk manager image. Updated with correct one.

Signed-off-by: Ranjith R <ranjith.raveendran@mayadata.io>

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Title of the PR starts with chart name (e.g. `[stable/openebs]`)
