### PR TITLE
Switch openebs/linux-utils to multiarch

### DIFF
--- a/openebs-operator-arm-dev.yaml
+++ b/openebs-operator-arm-dev.yaml
@@ -203,7 +203,7 @@ spec:
         - name: OPENEBS_IO_CSTOR_POOL_EXPORTER_IMAGE
           value: "openebs/m-exporter-arm64:2.2.0"
         - name: OPENEBS_IO_HELPER_IMAGE
-          value: "openebs/linux-utils-arm64:2.2.0"
+          value: "openebs/linux-utils:2.2.0"
         # OPENEBS_IO_ENABLE_ANALYTICS if set to true sends anonymous usage
         # events to Google Analytics
         - name: OPENEBS_IO_ENABLE_ANALYTICS
@@ -626,7 +626,7 @@ spec:
             - name: OPERATOR_NAME
               value: "node-disk-operator"
             - name: CLEANUP_JOB_IMAGE
-              value: "openebs/linux-utils-arm64:2.2.0"
+              value: "openebs/linux-utils:2.2.0"
             # OPENEBS_IO_INSTALL_CRD environment variable is used to enable/disable CRD installation
             # from NDM operator. By default the CRDs will be installed
             #- name: OPENEBS_IO_INSTALL_CRD
@@ -758,7 +758,7 @@ spec:
         - name: OPENEBS_IO_INSTALLER_TYPE
           value: "openebs-operator-arm"
         - name: OPENEBS_IO_HELPER_IMAGE
-          value: "openebs/linux-utils-arm64:2.2.0"
+          value: "openebs/linux-utils:2.2.0"
         # LEADER_ELECTION_ENABLED is used to enable/disable leader election. By default
         # leader election is enabled.
         #- name: LEADER_ELECTION_ENABLED


### PR DESCRIPTION
openebs/linux-utils is multiarch so it should not have openebs/linux-utils-arm64 in the name

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/openebs]`)
