### PR TITLE
Add location of the Mayastor Helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ When new changes to helm chart are pushed to master branch, the changes are pick
 
 ## Mayastor Helm Chart
 
-Helm chart for Mayastor is currently maintained [along the Mayastor code-base](https://github.com/openebs/Mayastor/tree/develop/chart). Please, note, that it is being actively maintained and can change without warning.
+Helm chart for Mayastor is currently maintained [along the Mayastor code-base](https://github.com/openebs/Mayastor/tree/develop/chart). Please, note, that it is being actively developed and can change or break without warning.
 
 ## OpenEBS Artifacts
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ When new changes to helm chart are pushed to master branch, the changes are pick
 - Upload the new version of the charts to the [GitHub releases](https://github.com/openebs/charts/releases).
 - Update the helm repo index file and push to the [GitHub Pages branch](https://github.com/openebs/charts/tree/gh-pages).
 
+## Mayastor Helm Chart
+
+Helm chart for Mayastor is currently maintained [along the Mayastor code-base](https://github.com/openebs/Mayastor/tree/develop/chart). Please, note, that it is being actively maintained and can change without warning.
 
 ## OpenEBS Artifacts
 


### PR DESCRIPTION
Mayastor published an initial version of its Helm chart. It is currently maintained within the same repository. This patch just adds a note to README.

(closes #168)