### PR TITLE
feat(operators): example config for jiva node affinity

### DIFF
--- a/2.4.0/openebs-operator-arm-dev.yaml
+++ b/2.4.0/openebs-operator-arm-dev.yaml
@@ -307,6 +307,11 @@ spec:
         # leader election is enabled.
         #- name: LEADER_ELECTION_ENABLED
         #  value: "true"
+        # OPENEBS_IO_JIVA_PATCH_NODE_AFFINITY is used to enable/disable setting node affinity
+        # to the jiva replica deployments. Default is `enabled`. The valid values are 
+        # `enabled` and `disabled`.
+        #- name: OPENEBS_IO_JIVA_PATCH_NODE_AFFINITY
+        #  value: "enabled"
          # Process name used for matching is limited to the 15 characters
          # present in the pgrep output.
          # So fullname can't be used here with pgrep (>15 chars).A regular expression

--- a/2.4.0/openebs-operator.yaml
+++ b/2.4.0/openebs-operator.yaml
@@ -307,6 +307,11 @@ spec:
         # leader election is enabled.
         #- name: LEADER_ELECTION_ENABLED
         #  value: "true"
+        # OPENEBS_IO_JIVA_PATCH_NODE_AFFINITY is used to enable/disable setting node affinity
+        # to the jiva replica deployments. Default is `enabled`. The valid values are 
+        # `enabled` and `disabled`.
+        #- name: OPENEBS_IO_JIVA_PATCH_NODE_AFFINITY
+        #  value: "enabled"
          # Process name used for matching is limited to the 15 characters
          # present in the pgrep output.
          # So fullname can't be used here with pgrep (>15 chars).A regular expression

--- a/openebs-operator-arm-dev.yaml
+++ b/openebs-operator-arm-dev.yaml
@@ -307,6 +307,11 @@ spec:
         # leader election is enabled.
         #- name: LEADER_ELECTION_ENABLED
         #  value: "true"
+        # OPENEBS_IO_JIVA_PATCH_NODE_AFFINITY is used to enable/disable setting node affinity
+        # to the jiva replica deployments. Default is `enabled`. The valid values are 
+        # `enabled` and `disabled`.
+        #- name: OPENEBS_IO_JIVA_PATCH_NODE_AFFINITY
+        #  value: "enabled"
          # Process name used for matching is limited to the 15 characters
          # present in the pgrep output.
          # So fullname can't be used here with pgrep (>15 chars).A regular expression

--- a/openebs-operator.yaml
+++ b/openebs-operator.yaml
@@ -307,6 +307,11 @@ spec:
         # leader election is enabled.
         #- name: LEADER_ELECTION_ENABLED
         #  value: "true"
+        # OPENEBS_IO_JIVA_PATCH_NODE_AFFINITY is used to enable/disable setting node affinity
+        # to the jiva replica deployments. Default is `enabled`. The valid values are 
+        # `enabled` and `disabled`.
+        #- name: OPENEBS_IO_JIVA_PATCH_NODE_AFFINITY
+        #  value: "enabled"
          # Process name used for matching is limited to the 15 characters
          # present in the pgrep output.
          # So fullname can't be used here with pgrep (>15 chars).A regular expression


### PR DESCRIPTION
Ref: https://github.com/openebs/openebs/issues/3226

With https://github.com/openebs/external-storage/pull/128, a new
configuration option is provided to enable/disable the setting
of node affinity on jiva replica deployments.

This PR provides an example on how to configure the ENV
variable on the openebs provisioner.

Signed-off-by: kmova <kiran.mova@mayadata.io>

