### PR TITLE
fix(operator): update snapshot-controller to 3.0.2

### DIFF
--- a/2.4.0/cstor-operator.yaml
+++ b/2.4.0/cstor-operator.yaml
@@ -791,7 +791,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: snapshot-controller
-          image: quay.io/k8scsi/snapshot-controller:v2.0.1
+          image: quay.io/k8scsi/snapshot-controller:v3.0.2
           args:
             - "--v=5"
             - "--leader-election=false"

--- a/2.4.0/zfs-operator.yaml
+++ b/2.4.0/zfs-operator.yaml
@@ -1597,7 +1597,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: snapshot-controller
-          image: quay.io/k8scsi/snapshot-controller:v2.0.1
+          image: quay.io/k8scsi/snapshot-controller:v3.0.2
           args:
             - "--v=5"
             - "--leader-election=true"

--- a/cstor-operator.yaml
+++ b/cstor-operator.yaml
@@ -791,7 +791,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: snapshot-controller
-          image: quay.io/k8scsi/snapshot-controller:v2.0.1
+          image: quay.io/k8scsi/snapshot-controller:v3.0.2
           args:
             - "--v=5"
             - "--leader-election=false"

--- a/zfs-operator.yaml
+++ b/zfs-operator.yaml
@@ -1597,7 +1597,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: snapshot-controller
-          image: quay.io/k8scsi/snapshot-controller:v2.0.1
+          image: quay.io/k8scsi/snapshot-controller:v3.0.2
           args:
             - "--v=5"
             - "--leader-election=true"


### PR DESCRIPTION
- update snapshot controller to 3.0.2 to fix a security vulnerability

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>