### PR TITLE
[stable/openebs]: update openebs k8s provisioner to 2.4.1

### DIFF
--- a/charts/openebs/Chart.yaml
+++ b/charts/openebs/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 2.4.1
+version: 2.4.2
 name: openebs
 appVersion: 2.4.0
 description: Containerized Storage for Containers

--- a/charts/openebs/README.md
+++ b/charts/openebs/README.md
@@ -65,7 +65,7 @@ The following table lists the configurable parameters of the OpenEBS chart and t
 | `apiserver.resources`                   | Set resource limits for API Server            | `{}`                                      |
 | `provisioner.enabled`                   | Enable Provisioner                            | `true`                                    |
 | `provisioner.image`                     | Image for Provisioner                         | `openebs/openebs-k8s-provisioner`         |
-| `provisioner.imageTag`                  | Image Tag for Provisioner                     | `2.4.0`                                  |
+| `provisioner.imageTag`                  | Image Tag for Provisioner                     | `2.4.1`                                  |
 | `provisioner.replicas`                  | Number of Provisioner Replicas                | `1`                                       |
 | `provisioner.resources`                 | Set resource limits for Provisioner           | `{}`                                      |
 | `provisioner.patchJivaNodeAffinity`     | Enable/disable node affinity on jiva replica deployment| `enabled`                                 |

--- a/charts/openebs/values.yaml
+++ b/charts/openebs/values.yaml
@@ -60,7 +60,7 @@ varDirectoryPath:
 provisioner:
   enabled: true
   image: "openebs/openebs-k8s-provisioner"
-  imageTag: "2.4.0"
+  imageTag: "2.4.1"
   replicas: 1
   enableLeaderElection: true
   patchJivaNodeAffinity: enabled


### PR DESCRIPTION
update openebs k8s provisioner to 2.4.1 to add support for kubernetes 1.20

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

#### Checklist

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. `[stable/openebs]`)
