### PR TITLE
fix(operator):  update openebs provisioner to 2.4.1

### DIFF
--- a/2.4.0/openebs-operator-arm-dev.yaml
+++ b/2.4.0/openebs-operator-arm-dev.yaml
@@ -277,7 +277,7 @@ spec:
       containers:
       - name: openebs-provisioner
         imagePullPolicy: IfNotPresent
-        image: openebs/openebs-k8s-provisioner:2.4.0
+        image: openebs/openebs-k8s-provisioner:2.4.1
         env:
         # OPENEBS_IO_K8S_MASTER enables openebs provisioner to connect to K8s
         # based on this address. This is ignored if empty.

--- a/2.4.0/openebs-operator.yaml
+++ b/2.4.0/openebs-operator.yaml
@@ -277,7 +277,7 @@ spec:
       containers:
       - name: openebs-provisioner
         imagePullPolicy: IfNotPresent
-        image: openebs/openebs-k8s-provisioner:2.4.0
+        image: openebs/openebs-k8s-provisioner:2.4.1
         env:
         # OPENEBS_IO_K8S_MASTER enables openebs provisioner to connect to K8s
         # based on this address. This is ignored if empty.

--- a/openebs-operator-arm-dev.yaml
+++ b/openebs-operator-arm-dev.yaml
@@ -277,7 +277,7 @@ spec:
       containers:
       - name: openebs-provisioner
         imagePullPolicy: IfNotPresent
-        image: openebs/openebs-k8s-provisioner:2.4.0
+        image: openebs/openebs-k8s-provisioner:2.4.1
         env:
         # OPENEBS_IO_K8S_MASTER enables openebs provisioner to connect to K8s
         # based on this address. This is ignored if empty.

--- a/openebs-operator.yaml
+++ b/openebs-operator.yaml
@@ -277,7 +277,7 @@ spec:
       containers:
       - name: openebs-provisioner
         imagePullPolicy: IfNotPresent
-        image: openebs/openebs-k8s-provisioner:2.4.0
+        image: openebs/openebs-k8s-provisioner:2.4.1
         env:
         # OPENEBS_IO_K8S_MASTER enables openebs provisioner to connect to K8s
         # based on this address. This is ignored if empty.


### PR DESCRIPTION
- update openebs-k8s-provisioner to 2.4.1 to work on kubernetes 1.20

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>