### PR TITLE
fix(yaml):fix localpv storage class in sample yaml

### DIFF
--- a/examples/local-device/local-device-pvc.yaml
+++ b/examples/local-device/local-device-pvc.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 metadata:
   name: local-device-pvc
 spec:
-  storageClassName: openebs-device
+  storageClassName: local-device
   accessModes:
     - ReadWriteOnce
   resources:


### PR DESCRIPTION
change localpv device storage class name to `openebs-device` in samples

Ref: https://github.com/openebs/openebs/issues/3312#issuecomment-745260953

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>
