### PR TITLE
Added grafana charts for pools and volumes

### DIFF
--- a/grafana-charts/README.md
+++ b/grafana-charts/README.md
@@ -1,0 +1,37 @@
+# Monitor OpenEBS volumes and pools
+
+### Prerequisites
+* OpenEBS installed
+* OpenEBS Volumes created
+
+### Steps
+1. Run `kubectl apply -f [openebs-monitoring-pg.yaml](https://raw.githubusercontent.com/Ab-hishek/openebs-monitoring/master/openebs-monitoring-pg.yaml)`
+2. Run `kubectl get pods -o wide` to verify and to get where Prometheus and Grafana instances are running.
+3. Run `kubectl get nodes -o wide` to get the node’s IP.
+4. Run `kubectl get svc` and note down the port allocated to Prometheus and Grafana services.
+5. Open your browser and open `<nodeip:nodeport>`(32514 for Prometheus and 32515 for Grafana) and you should be able to see the Prometheus’s expression browser and Grafana’s UI on your browser.
+6. Login into it(default username and password is admin), add data source name as prometheus, select datasource type Prometheus and pass the `<nodeip:nodeport>`of Prometheus in the url field and click on run and test.
+7. Now go to the next tab (Dashboard) and import the desired dashboard.You should be able to get preloaded dashboard of prometheus.
+8. To create openebs dashboard, go to the import and paste the json from this folder.
+9. You should be able to get the graph of openebs volumes in the UI.
+
+### Note: For Storage Pool Dashboard and LocalPV Dashboard you will need to provide variables manually in the query params of the dashboard URL.
+
+For Storage pool dasboard, the Grafana URL looks like this:
+http://localhost:3000/d/5d86b1fd-b2e7-4bb2-befa-4dae5b6167d6/storage-pool-dashboard?var-pool=cstorpool-abhishek-dh27&var-kind=CStorPoolCluster&orgId=1
+Name - Storage Pool Dashboard
+UID- 5d86b1fd-b2e7-4bb2-befa-4dae5b6167d6
+Query Params :-
+var-pool
+var-kind
+
+For LocalPV dashboard, the Grafana URL looks like this:
+http://localhost:3000/d/2e59785a-af05-465e-b9a3-fca65a0e8572/localpv-dashboard?refresh=1m&var-openebs_volume=kubera-demo-minio-pv-claim&var-pvcname=kubera-demo-minio-pv-claim&var-namespace=default&var-storageclass=openebs-hostpath&var-type=local-hostpath&var-orgId=1&orgId=1
+Name - LocalPV dashboard
+UID - 2e59785a-af05-465e-b9a3-fca65a0e8572
+Query Params :-
+var-openebs_volume
+var-pvcname
+var-namespace
+var-storageclass
+var-type

--- a/grafana-charts/README.md
+++ b/grafana-charts/README.md
@@ -5,7 +5,7 @@
 * OpenEBS Volumes created
 
 ### Steps
-1. Run `kubectl apply -f [openebs-monitoring-pg.yaml](https://raw.githubusercontent.com/Ab-hishek/openebs-monitoring/master/openebs-monitoring-pg.yaml)`
+1. Run kubectl apply -f [openebs-monitoring-pg.yaml](https://raw.githubusercontent.com/Ab-hishek/openebs-monitoring/master/openebs-monitoring-pg.yaml)
 2. Run `kubectl get pods -o wide` to verify and to get where Prometheus and Grafana instances are running.
 3. Run `kubectl get nodes -o wide` to get the node’s IP.
 4. Run `kubectl get svc` and note down the port allocated to Prometheus and Grafana services.
@@ -17,21 +17,21 @@
 
 ### Note: For Storage Pool Dashboard and LocalPV Dashboard you will need to provide variables manually in the query params of the dashboard URL.
 
-For Storage pool dasboard, the Grafana URL looks like this:
-http://localhost:3000/d/5d86b1fd-b2e7-4bb2-befa-4dae5b6167d6/storage-pool-dashboard?var-pool=cstorpool-abhishek-dh27&var-kind=CStorPoolCluster&orgId=1
-Name - Storage Pool Dashboard
-UID- 5d86b1fd-b2e7-4bb2-befa-4dae5b6167d6
-Query Params :-
-var-pool
-var-kind
+For Storage pool dasboard, the Grafana URL looks like this:  
+http://localhost:3000/d/5d86b1fd-b2e7-4bb2-befa-4dae5b6167d6/storage-pool-dashboard?var-pool=cstorpool-abhishek-dh27&var-kind=CStorPoolCluster&orgId=1  
+Name - Storage Pool Dashboard  
+UID- 5d86b1fd-b2e7-4bb2-befa-4dae5b6167d6  
+Query Params :-  
+var-pool  
+var-kind  
 
-For LocalPV dashboard, the Grafana URL looks like this:
-http://localhost:3000/d/2e59785a-af05-465e-b9a3-fca65a0e8572/localpv-dashboard?refresh=1m&var-openebs_volume=kubera-demo-minio-pv-claim&var-pvcname=kubera-demo-minio-pv-claim&var-namespace=default&var-storageclass=openebs-hostpath&var-type=local-hostpath&var-orgId=1&orgId=1
-Name - LocalPV dashboard
-UID - 2e59785a-af05-465e-b9a3-fca65a0e8572
-Query Params :-
-var-openebs_volume
-var-pvcname
-var-namespace
-var-storageclass
-var-type
+For LocalPV dashboard, the Grafana URL looks like this:  
+http://localhost:3000/d/2e59785a-af05-465e-b9a3-fca65a0e8572/localpv-dashboard?refresh=1m&var-openebs_volume=kubera-demo-minio-pv-claim&var-pvcname=kubera-demo-minio-pv-claim&var-namespace=default&var-storageclass=openebs-hostpath&var-type=local-hostpath&var-orgId=1&orgId=1  
+Name - LocalPV dashboard  
+UID - 2e59785a-af05-465e-b9a3-fca65a0e8572  
+Query Params :-  
+var-openebs_volume  
+var-pvcname  
+var-namespace  
+var-storageclass  
+var-type  

--- a/grafana-charts/README.md
+++ b/grafana-charts/README.md
@@ -17,21 +17,21 @@
 
 ### Note: For Storage Pool Dashboard and LocalPV Dashboard you will need to provide variables manually in the query params of the dashboard URL.
 
-For Storage pool dasboard, the Grafana URL looks like this:  
+#### For Storage pool dasboard, the Grafana URL looks like this:  
 http://localhost:3000/d/5d86b1fd-b2e7-4bb2-befa-4dae5b6167d6/storage-pool-dashboard?var-pool=cstorpool-abhishek-dh27&var-kind=CStorPoolCluster&orgId=1  
-Name - Storage Pool Dashboard  
-UID- 5d86b1fd-b2e7-4bb2-befa-4dae5b6167d6  
-Query Params :-  
-var-pool  
-var-kind  
+* Name - Storage Pool Dashboard  
+* UID- 5d86b1fd-b2e7-4bb2-befa-4dae5b6167d6  
+* Query Params :-  
+  1. var-pool  
+  2. var-kind  
 
-For LocalPV dashboard, the Grafana URL looks like this:  
+#### For LocalPV dashboard, the Grafana URL looks like this:  
 http://localhost:3000/d/2e59785a-af05-465e-b9a3-fca65a0e8572/localpv-dashboard?refresh=1m&var-openebs_volume=kubera-demo-minio-pv-claim&var-pvcname=kubera-demo-minio-pv-claim&var-namespace=default&var-storageclass=openebs-hostpath&var-type=local-hostpath&var-orgId=1&orgId=1  
-Name - LocalPV dashboard  
-UID - 2e59785a-af05-465e-b9a3-fca65a0e8572  
-Query Params :-  
-var-openebs_volume  
-var-pvcname  
-var-namespace  
-var-storageclass  
-var-type  
+* Name - LocalPV dashboard  
+* UID - 2e59785a-af05-465e-b9a3-fca65a0e8572  
+* Query Params :-  
+  1. var-openebs_volume  
+  2. var-pvcname  
+  3. var-namespace  
+  4. var-storageclass  
+  5. var-type  

--- a/grafana-charts/Storagepooldashboard.json
+++ b/grafana-charts/Storagepooldashboard.json
@@ -1,0 +1,799 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "$$hashKey": "object:277",
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 103496,
+  "iteration": 1612454983940,
+  "links": [
+    {
+      "icon": "external link",
+      "includeVars": true,
+      "tags": [],
+      "targetBlank": true,
+      "title": "cStor volume replica dashboard",
+      "type": "link",
+      "url": "/grafana/d/644d0435-03e1-4da3-b768-7968f526cf68/cstor-volume-replicas-dashboard?submenu"
+    },
+    {
+      "icon": "doc",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": true,
+      "title": "report",
+      "tooltip": "",
+      "type": "link",
+      "url": "https://director.mayadata.io/reporter/?dashboard=5d86b1fd-b2e7-4bb2-befa-4dae5b6167d6"
+    }
+  ],
+  "panels": [
+    {
+      "content": "<html>\n<head>\n\n<script>\nwindow.onload = load('$Pool', '$spc','$cluster','$projectid','$groupid','$kind');\n\nfunction getCell(name, value) {\n  return \"<div class=\\\"outlet-header-meta-bar_item\\\"><div class=\\\"outlet-header-meta-bar_title\\\"><span>\"+name+\"</span></div><div class=\\\"outlet-header-meta-bar_value\\\"><span>\"+value+\"</span></div></div>\";\n}\n\nfunction load(poolNameStr, spcStr,clusterNameStr,projectIdStr,groupIdStr,kindStr) {\nvar poolNameStr = poolNameStr.replace( /[{}]/g, '' );\nvar spcStr = spcStr.replace( /[{}]/g, '' );\nvar clusterNameStr = clusterNameStr.replace( /[{}]/g, '' );\nvar projectIdStr = projectIdStr.replace( /[{}]/g, '' );\nvar groupIdStr = groupIdStr.replace( /[{}]/g, '' );\nvar kindStr = kindStr.replace( /[{}]/g, '' );\n// var pools = poolsStr.replace( /[{}]/g, '' );\n// var rc = replicaCount.replace( /[{}]/g, '' );\n// if(!rc) {\n//   rc = \"none\";\n// }\n// var uptimes = uptime.replace( /[{}]/g, '' );\n// if(uptimes) {\n// var seconds = parseInt(uptimes, 10);\n\n// var days = Math.floor(seconds / (3600*24));\n// seconds  -= days*3600*24;\n// var hrs   = Math.floor(seconds / 3600);\n// seconds  -= hrs*3600;\n// var mnts = Math.floor(seconds / 60);\n// seconds  -= mnts*60;\n// uptimes = days+\" days, \"+hrs+\" Hrs, \"+mnts+\" Mins, \"+seconds+\" Secs\";\n// }\n// else {\n//   uptimes = \"No Data\";\n// }\n\n\n\nz=\"\";\nz+=getCell(\"Pool Name\", poolNameStr);\nz+=getCell(\"Cluster\", clusterNameStr);\n//z+=getCell(\"Name\", volName);\nz+=getCell(kindStr, spcStr.link(\"/grafana/d/storage-pool-claim-dashboard/storage-pool-claim-dashboard?submenu&var-spc=\" + spcStr + \"&var-projectid=\" + projectIdStr + \"&var-groupid=\" + groupIdStr));\n//z+=getCell(\"Pool Name\", pools);\n//z+=getCell(\"No. of Replicas\", rc);\n//z+=getCell(\"\",\"\")\n\ndocument.getElementById(\"volume-info\").innerHTML = z;\n}\n</script>\n</head>\n\n<body>\n\n<div id=\"volume-info\" class=\"outlet-header-bar\"></div>\n\n</body>\n\n</html>",
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 44,
+      "links": [],
+      "mode": "html",
+      "title": "Pool information",
+      "transparent": false,
+      "type": "text"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 3,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 3
+      },
+      "id": 4,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "openebs_pool_status{cstor_pool=~\"$Pool\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "status",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Pool status",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "none",
+          "label": null,
+          "labelMappings": [
+            {
+              "label": "Offline",
+              "value": 0
+            },
+            {
+              "label": "Online",
+              "value": 1
+            },
+            {
+              "label": "Degraded",
+              "value": 2
+            },
+            {
+              "label": "Faulted",
+              "value": 3
+            },
+            {
+              "label": "Removed",
+              "value": 4
+            },
+            {
+              "label": "Unavail",
+              "value": 5
+            },
+            {
+              "label": "NoPoolsAvailable",
+              "value": 6
+            }
+          ],
+          "logBase": 1,
+          "mappedLabelOnly": true,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 3,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 3
+      },
+      "id": 48,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(openebs_pool_size{cstor_pool=~\"$Pool\"})/(1024*1024*1024)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "total size",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Size of  pool",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decgbytes",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 3,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 50,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "(openebs_used_pool_capacity{cstor_pool=~\"$Pool\"})/(1024*1024*1024)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "usage",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Used pool capacity",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decgbytes",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 3,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 52,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "(openebs_free_pool_capacity{cstor_pool=~\"$Pool\"})/(1024*1024*1024)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "free size",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Free pool capacity",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decgbytes",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 3,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 15
+      },
+      "id": 54,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(openebs_total_read_count{cstor_pool=~\"$Pool\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "read iops",
+          "refId": "A"
+        },
+        {
+          "expr": "",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "write iops",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Read IOPS",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "decimals": null,
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 3,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 15
+      },
+      "id": 56,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(openebs_total_write_count{cstor_pool=~\"$Pool\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "write iops",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Write IOPS",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "schemaVersion": 16,
+  "style": "light",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "DS_OPENEBS_PROMETHEUS",
+        "hide": 2,
+        "includeAll": false,
+        "label": "Pool",
+        "multi": false,
+        "name": "Pool",
+        "options": [],
+        "query": "label_values(openebs_pool_status{cstor_pool=~\"$pool\"},cstor_pool)",
+        "refresh": 2,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "DS_OPENEBS_PROMETHEUS",
+        "hide": 2,
+        "includeAll": false,
+        "label": "cluster",
+        "multi": false,
+        "name": "cluster",
+        "options": [],
+        "query": "label_values(openebs_pool_status{cstor_pool=~\"$Pool\"},job)",
+        "refresh": 2,
+        "regex": "/cluster_uuid_(.*)_.*/",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "DS_OPENEBS_PROMETHEUS",
+        "hide": 2,
+        "includeAll": false,
+        "label": "spc",
+        "multi": false,
+        "name": "spc",
+        "options": [],
+        "query": "label_values(openebs_pool_status{cstor_pool=~\"$Pool\"},storage_pool_claim)",
+        "refresh": 2,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "hide": 2,
+        "includeAll": false,
+        "label": "pool",
+        "multi": false,
+        "name": "pool",
+        "options": [
+          {
+            "selected": false,
+            "text": "",
+            "value": ""
+          }
+        ],
+        "query": "",
+        "type": "custom"
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "hide": 2,
+        "includeAll": false,
+        "label": "projectid",
+        "multi": false,
+        "name": "projectid",
+        "options": [
+          {
+            "selected": false,
+            "text": "",
+            "value": ""
+          }
+        ],
+        "query": "",
+        "type": "custom"
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "hide": 2,
+        "includeAll": false,
+        "label": "groupid",
+        "multi": false,
+        "name": "groupid",
+        "options": [
+          {
+            "selected": false,
+            "text": "",
+            "value": ""
+          }
+        ],
+        "query": "",
+        "type": "custom"
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "hide": 2,
+        "includeAll": false,
+        "label": "kind",
+        "multi": false,
+        "name": "kind",
+        "options": [
+          {
+            "selected": false,
+            "text": "",
+            "value": ""
+          }
+        ],
+        "query": "",
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Storage pool dashboard",
+  "uid": "5d86b1fd-b2e7-4bb2-befa-4dae5b6167d6",
+  "version": 1
+}

--- a/grafana-charts/clustervolumesdashboard.json
+++ b/grafana-charts/clustervolumesdashboard.json
@@ -1,1042 +1,912 @@
 {
-	"dashboard": {
-		"__inputs": [
-			{
-				"name": "DS_OPENEBS_PROMETHEUS",
-				"label": "openebs Prometheus",
-				"description": "",
-				"type": "datasource",
-				"pluginId": "prometheus",
-				"pluginName": "Prometheus"
-			}
-		],
-		"__requires": [
-			{
-				"type": "grafana",
-				"id": "grafana",
-				"name": "Grafana",
-				"version": "5.1.3"
-			},
-			{
-				"type": "panel",
-				"id": "graph",
-				"name": "Graph",
-				"version": ""
-			},
-			{
-				"type": "datasource",
-				"id": "prometheus",
-				"name": "Prometheus",
-				"version": "1.0.0"
-			},
-			{
-				"type": "panel",
-				"id": "singlestat",
-				"name": "Singlestat",
-				"version": ""
-			},
-			{
-				"type": "panel",
-				"id": "text",
-				"name": "Text",
-				"version": ""
-			}
-		],
-		"annotations": {
-			"list": [
-			]
-		},
-		"editable": true,
-		"gnetId": null,
-		"graphTooltip": 0,
-		"id": null,
-		"iteration": 1526476838500,
-		"links": [
-			{
-				"icon": "doc",
-				"includeVars": true,
-				"keepTime": true,
-				"tags": [
-				],
-				"targetBlank": true,
-				"title": "report",
-				"tooltip": "",
-				"type": "link",
-				"url": "${MAYA_URL}/reporter/?dashboard=cd9669c9-dc67-4c73-ac21-1c6486bb7cd9"
-			}
-		],
-		"panels": [
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fill": 3,
-				"gridPos": {
-					"h": 9,
-					"w": 24,
-					"x": 0,
-					"y": 0
-				},
-				"id": 24,
-				"legend": {
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"show": true,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 2,
-				"links": [
-				],
-				"nullPointMode": "null",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": false,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "openebs_actual_used{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
-						"format": "time_series",
-						"intervalFactor": 2,
-						"legendFormat": "{{openebs_pvc}}",
-						"refId": "A"
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "Storage Usage",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"format": "decgbytes",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": "0",
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": null,
-						"show": true
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"description": "IOPS",
-				"fill": 3,
-				"gridPos": {
-					"h": 8,
-					"w": 24,
-					"x": 0,
-					"y": 9
-				},
-				"id": 3,
-				"legend": {
-					"alignAsTable": false,
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"rightSide": false,
-					"show": true,
-					"sideWidth": 350,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 2,
-				"links": [
-				],
-				"nullPointMode": "connected",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": true,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "irate(openebs_reads{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m])",
-						"format": "time_series",
-						"hide": false,
-						"intervalFactor": 2,
-						"legendFormat": "{{openebs_pvc}}",
-						"refId": "A",
-						"step": 2
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "IOPS(Reads)",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"format": "none",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": "0",
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": null,
-						"show": false
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fill": 3,
-				"gridPos": {
-					"h": 8,
-					"w": 24,
-					"x": 0,
-					"y": 17
-				},
-				"id": 20,
-				"legend": {
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"show": true,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 2,
-				"links": [
-				],
-				"nullPointMode": "null",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": false,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "irate(openebs_writes{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m])",
-						"format": "time_series",
-						"intervalFactor": 2,
-						"legendFormat": "{{openebs_pvc}}",
-						"refId": "A"
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "IOPS(Writes)",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"format": "none",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": "0",
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": null,
-						"show": false
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"description": "Throughput",
-				"fill": 3,
-				"gridPos": {
-					"h": 8,
-					"w": 24,
-					"x": 0,
-					"y": 25
-				},
-				"id": 9,
-				"legend": {
-					"alignAsTable": false,
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"rightSide": false,
-					"show": true,
-					"sideWidth": 350,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 2,
-				"links": [
-				],
-				"nullPointMode": "connected",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": true,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "irate(openebs_read_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m])/(2048)",
-						"format": "time_series",
-						"hide": false,
-						"intervalFactor": 2,
-						"legendFormat": "{{openebs_pvc}}",
-						"refId": "A",
-						"step": 2
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "Throughput(Reads)",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"format": "MBs",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": "0",
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": null,
-						"show": false
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fill": 3,
-				"gridPos": {
-					"h": 8,
-					"w": 24,
-					"x": 0,
-					"y": 33
-				},
-				"id": 19,
-				"legend": {
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"show": true,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 2,
-				"links": [
-				],
-				"nullPointMode": "null",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": false,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "irate(openebs_write_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m])/(2048)",
-						"format": "time_series",
-						"intervalFactor": 2,
-						"legendFormat": "{{openebs_pvc}}",
-						"refId": "A"
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "Throughput(Writes)",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"format": "MBs",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": "0",
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": null,
-						"show": false
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"description": "Latency",
-				"fill": 3,
-				"gridPos": {
-					"h": 8,
-					"w": 24,
-					"x": 0,
-					"y": 41
-				},
-				"id": 5,
-				"legend": {
-					"alignAsTable": false,
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"rightSide": false,
-					"show": true,
-					"sideWidth": 350,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 2,
-				"links": [
-				],
-				"nullPointMode": "null as zero",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": true,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "((irate(openebs_read_time{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m]))/(irate(openebs_reads{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m])))/1000000",
-						"format": "time_series",
-						"hide": false,
-						"intervalFactor": 2,
-						"legendFormat": "{{openebs_pvc}}",
-						"refId": "A",
-						"step": 2
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "Latency(Reads)",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"format": "ms",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": "0",
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": null,
-						"show": false
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fill": 3,
-				"gridPos": {
-					"h": 8,
-					"w": 24,
-					"x": 0,
-					"y": 49
-				},
-				"id": 18,
-				"legend": {
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"show": true,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 2,
-				"links": [
-				],
-				"nullPointMode": "null as zero",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": false,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "((irate(openebs_write_time{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m]))/(irate(openebs_writes{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m])))/1000000",
-						"format": "time_series",
-						"intervalFactor": 2,
-						"legendFormat": "{{openebs_pvc}}",
-						"refId": "A"
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "Latency(Writes)",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"format": "ms",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": "0",
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": null,
-						"show": false
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fill": 3,
-				"gridPos": {
-					"h": 8,
-					"w": 24,
-					"x": 0,
-					"y": 57
-				},
-				"id": 25,
-				"legend": {
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"show": true,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 2,
-				"links": [
-				],
-				"nullPointMode": "null as zero",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": false,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "(irate(openebs_read_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m])/(1024))*512/(irate(openebs_reads{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m]))",
-						"format": "time_series",
-						"hide": false,
-						"intervalFactor": 2,
-						"legendFormat": "{{openebs_pvc}}",
-						"refId": "A"
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "Block Size(Reads)",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"format": "deckbytes",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": "0",
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": null,
-						"show": false
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fill": 3,
-				"gridPos": {
-					"h": 8,
-					"w": 24,
-					"x": 0,
-					"y": 65
-				},
-				"id": 27,
-				"legend": {
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"show": true,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 2,
-				"links": [
-				],
-				"nullPointMode": "null as zero",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": false,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "(irate(openebs_write_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m])/(1024))*512/(irate(openebs_writes{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m]))",
-						"format": "time_series",
-						"hide": false,
-						"intervalFactor": 2,
-						"legendFormat": "{{openebs_pvc}}",
-						"refId": "A"
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "Block Size(Writes)",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"format": "deckbytes",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": "0",
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": null,
-						"show": false
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			}
-		],
-		"refresh": "1m",
-		"schemaVersion": 16,
-		"style": "light",
-		"tags": [
-		],
-		"templating": {
-			"list": [
-				{
-					"allValue": null,
-					"current": {
-					},
-					"datasource": "DS_OPENEBS_PROMETHEUS",
-					"hide": 0,
-					"includeAll": false,
-					"label": "Cluster:",
-					"multi": false,
-					"name": "job",
-					"options": [
-					],
-					"query": "label_values(openebs_size_of_volume,job)",
-					"refresh": 2,
-					"regex": "/cluster_uuid_(.*)_.*/",
-					"sort": 0,
-					"tagValuesQuery": "",
-					"tags": [
-					],
-					"tagsQuery": "",
-					"type": "query",
-					"useTags": false
-				},
-				{
-					"allValue": null,
-					"current": {
-					},
-					"datasource": "DS_OPENEBS_PROMETHEUS",
-					"hide": 2,
-					"includeAll": true,
-					"label": "Volume",
-					"multi": true,
-					"name": "openebs_Volume",
-					"options": [
-					],
-					"query": "label_values(openebs_size_of_volume{job=~\".*$job.*\"},openebs_pv)",
-					"refresh": 2,
-					"regex": "",
-					"sort": 0,
-					"tagValuesQuery": "",
-					"tags": [
-					],
-					"tagsQuery": "",
-					"type": "query",
-					"useTags": false
-				},
-				{
-					"allValue": null,
-					"current": {
-					},
-					"datasource": "DS_OPENEBS_PROMETHEUS",
-					"hide": 0,
-					"includeAll": true,
-					"label": "OpenEBS pvc",
-					"multi": true,
-					"name": "openebs_pvc",
-					"options": [
-					],
-					"query": "label_values(openebs_size_of_volume{job=~\".*$job.*\",openebs_pv=~\"$openebs_Volume\"},openebs_pvc)",
-					"refresh": 2,
-					"regex": "",
-					"sort": 0,
-					"tagValuesQuery": "",
-					"tags": [
-					],
-					"tagsQuery": "",
-					"type": "query",
-					"useTags": false
-				},
-				{
-					"allValue": null,
-					"current": {
-					},
-					"hide": 2,
-					"includeAll": false,
-					"label": "projectid",
-					"multi": false,
-					"name": "projectid",
-					"options": [
-						{
-							"selected": false,
-							"text": "",
-							"value": ""
-						}
-					],
-					"query": "",
-					"type": "custom"
-				},
-				{
-					"allValue": null,
-					"current": {
-					},
-					"hide": 2,
-					"includeAll": false,
-					"label": "groupid",
-					"multi": false,
-					"name": "groupid",
-					"options": [
-						{
-							"selected": false,
-							"text": "",
-							"value": ""
-						}
-					],
-					"query": "",
-					"type": "custom"
-				}
-			]
-		},
-		"time": {
-			"from": "now-1h",
-			"to": "now"
-		},
-		"timepicker": {
-			"refresh_intervals": [
-				"5s",
-				"10s",
-				"30s",
-				"1m",
-				"5m",
-				"15m",
-				"30m",
-				"1h",
-				"2h",
-				"1d"
-			],
-			"time_options": [
-				"5m",
-				"15m",
-				"1h",
-				"6h",
-				"12h",
-				"24h",
-				"2d",
-				"7d",
-				"30d"
-			]
-		},
-		"timezone": "",
-		"title": "Cluster Volumes Dashboard",
-		"uid": "cd9669c9-dc67-4c73-ac21-1c6486bb7cd9",
-		"version": 3
-	},
-	"overwrite": true
+  "__inputs": [
+    {
+      "name": "DS_OPENEBS_PROMETHEUS",
+      "label": "openebs Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "5.1.3"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "singlestat",
+      "name": "Singlestat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "text",
+      "name": "Text",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "iteration": 1526476838500,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 3,
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 24,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "openebs_actual_used{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{openebs_pvc}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Storage Usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decgbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "description": "IOPS",
+      "fill": 3,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 3,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": 350,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "irate(openebs_reads{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m])",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{openebs_pvc}}",
+          "refId": "A",
+          "step": 2
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "IOPS(Reads)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 3,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 20,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "irate(openebs_writes{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m])",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{openebs_pvc}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "IOPS(Writes)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "description": "Throughput",
+      "fill": 3,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 25
+      },
+      "id": 9,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": 350,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "irate(openebs_read_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m])/(2048)",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{openebs_pvc}}",
+          "refId": "A",
+          "step": 2
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Throughput(Reads)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "MBs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 3,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 33
+      },
+      "id": 19,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "irate(openebs_write_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m])/(2048)",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{openebs_pvc}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Throughput(Writes)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "MBs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "description": "Latency",
+      "fill": 3,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 41
+      },
+      "id": 5,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": 350,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "((irate(openebs_read_time{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m]))/(irate(openebs_reads{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m])))/1000000",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{openebs_pvc}}",
+          "refId": "A",
+          "step": 2
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Latency(Reads)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 3,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 49
+      },
+      "id": 18,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "((irate(openebs_write_time{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m]))/(irate(openebs_writes{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m])))/1000000",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{openebs_pvc}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Latency(Writes)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 3,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 57
+      },
+      "id": 25,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "(irate(openebs_read_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m])/(1024))*512/(irate(openebs_reads{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m]))",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{openebs_pvc}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Block Size(Reads)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "deckbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 3,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 65
+      },
+      "id": 27,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "(irate(openebs_write_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m])/(1024))*512/(irate(openebs_writes{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m]))",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{openebs_pvc}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Block Size(Writes)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "deckbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 16,
+  "style": "light",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "DS_OPENEBS_PROMETHEUS",
+        "hide": 2,
+        "includeAll": true,
+        "label": "Volume",
+        "multi": true,
+        "name": "openebs_Volume",
+        "options": [],
+        "query": "label_values(openebs_size_of_volume, openebs_pv)",
+        "refresh": 2,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "DS_OPENEBS_PROMETHEUS",
+        "hide": 0,
+        "includeAll": true,
+        "label": "OpenEBS pvc",
+        "multi": true,
+        "name": "openebs_pvc",
+        "options": [],
+        "query": "label_values(openebs_size_of_volume{openebs_pv=~\"$openebs_Volume\"},openebs_pvc)",
+        "refresh": 2,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Cluster Volumes Dashboard",
+  "uid": "cd9669c9-dc67-4c73-ac21-1c6486bb7cd9",
+  "version": 3
 }

--- a/grafana-charts/clustervolumesdashboard.json
+++ b/grafana-charts/clustervolumesdashboard.json
@@ -1,0 +1,1042 @@
+{
+	"dashboard": {
+		"__inputs": [
+			{
+				"name": "DS_OPENEBS_PROMETHEUS",
+				"label": "openebs Prometheus",
+				"description": "",
+				"type": "datasource",
+				"pluginId": "prometheus",
+				"pluginName": "Prometheus"
+			}
+		],
+		"__requires": [
+			{
+				"type": "grafana",
+				"id": "grafana",
+				"name": "Grafana",
+				"version": "5.1.3"
+			},
+			{
+				"type": "panel",
+				"id": "graph",
+				"name": "Graph",
+				"version": ""
+			},
+			{
+				"type": "datasource",
+				"id": "prometheus",
+				"name": "Prometheus",
+				"version": "1.0.0"
+			},
+			{
+				"type": "panel",
+				"id": "singlestat",
+				"name": "Singlestat",
+				"version": ""
+			},
+			{
+				"type": "panel",
+				"id": "text",
+				"name": "Text",
+				"version": ""
+			}
+		],
+		"annotations": {
+			"list": [
+			]
+		},
+		"editable": true,
+		"gnetId": null,
+		"graphTooltip": 0,
+		"id": null,
+		"iteration": 1526476838500,
+		"links": [
+			{
+				"icon": "doc",
+				"includeVars": true,
+				"keepTime": true,
+				"tags": [
+				],
+				"targetBlank": true,
+				"title": "report",
+				"tooltip": "",
+				"type": "link",
+				"url": "${MAYA_URL}/reporter/?dashboard=cd9669c9-dc67-4c73-ac21-1c6486bb7cd9"
+			}
+		],
+		"panels": [
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fill": 3,
+				"gridPos": {
+					"h": 9,
+					"w": 24,
+					"x": 0,
+					"y": 0
+				},
+				"id": 24,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 2,
+				"links": [
+				],
+				"nullPointMode": "null",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "openebs_actual_used{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
+						"format": "time_series",
+						"intervalFactor": 2,
+						"legendFormat": "{{openebs_pvc}}",
+						"refId": "A"
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Storage Usage",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"format": "decgbytes",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": "0",
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": null,
+						"show": true
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"description": "IOPS",
+				"fill": 3,
+				"gridPos": {
+					"h": 8,
+					"w": 24,
+					"x": 0,
+					"y": 9
+				},
+				"id": 3,
+				"legend": {
+					"alignAsTable": false,
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"rightSide": false,
+					"show": true,
+					"sideWidth": 350,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 2,
+				"links": [
+				],
+				"nullPointMode": "connected",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": true,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "irate(openebs_reads{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m])",
+						"format": "time_series",
+						"hide": false,
+						"intervalFactor": 2,
+						"legendFormat": "{{openebs_pvc}}",
+						"refId": "A",
+						"step": 2
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "IOPS(Reads)",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"format": "none",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": "0",
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": null,
+						"show": false
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fill": 3,
+				"gridPos": {
+					"h": 8,
+					"w": 24,
+					"x": 0,
+					"y": 17
+				},
+				"id": 20,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 2,
+				"links": [
+				],
+				"nullPointMode": "null",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "irate(openebs_writes{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m])",
+						"format": "time_series",
+						"intervalFactor": 2,
+						"legendFormat": "{{openebs_pvc}}",
+						"refId": "A"
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "IOPS(Writes)",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"format": "none",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": "0",
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": null,
+						"show": false
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"description": "Throughput",
+				"fill": 3,
+				"gridPos": {
+					"h": 8,
+					"w": 24,
+					"x": 0,
+					"y": 25
+				},
+				"id": 9,
+				"legend": {
+					"alignAsTable": false,
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"rightSide": false,
+					"show": true,
+					"sideWidth": 350,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 2,
+				"links": [
+				],
+				"nullPointMode": "connected",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": true,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "irate(openebs_read_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m])/(2048)",
+						"format": "time_series",
+						"hide": false,
+						"intervalFactor": 2,
+						"legendFormat": "{{openebs_pvc}}",
+						"refId": "A",
+						"step": 2
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Throughput(Reads)",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"format": "MBs",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": "0",
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": null,
+						"show": false
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fill": 3,
+				"gridPos": {
+					"h": 8,
+					"w": 24,
+					"x": 0,
+					"y": 33
+				},
+				"id": 19,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 2,
+				"links": [
+				],
+				"nullPointMode": "null",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "irate(openebs_write_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m])/(2048)",
+						"format": "time_series",
+						"intervalFactor": 2,
+						"legendFormat": "{{openebs_pvc}}",
+						"refId": "A"
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Throughput(Writes)",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"format": "MBs",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": "0",
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": null,
+						"show": false
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"description": "Latency",
+				"fill": 3,
+				"gridPos": {
+					"h": 8,
+					"w": 24,
+					"x": 0,
+					"y": 41
+				},
+				"id": 5,
+				"legend": {
+					"alignAsTable": false,
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"rightSide": false,
+					"show": true,
+					"sideWidth": 350,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 2,
+				"links": [
+				],
+				"nullPointMode": "null as zero",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": true,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "((irate(openebs_read_time{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m]))/(irate(openebs_reads{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m])))/1000000",
+						"format": "time_series",
+						"hide": false,
+						"intervalFactor": 2,
+						"legendFormat": "{{openebs_pvc}}",
+						"refId": "A",
+						"step": 2
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Latency(Reads)",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"format": "ms",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": "0",
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": null,
+						"show": false
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fill": 3,
+				"gridPos": {
+					"h": 8,
+					"w": 24,
+					"x": 0,
+					"y": 49
+				},
+				"id": 18,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 2,
+				"links": [
+				],
+				"nullPointMode": "null as zero",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "((irate(openebs_write_time{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m]))/(irate(openebs_writes{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m])))/1000000",
+						"format": "time_series",
+						"intervalFactor": 2,
+						"legendFormat": "{{openebs_pvc}}",
+						"refId": "A"
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Latency(Writes)",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"format": "ms",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": "0",
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": null,
+						"show": false
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fill": 3,
+				"gridPos": {
+					"h": 8,
+					"w": 24,
+					"x": 0,
+					"y": 57
+				},
+				"id": 25,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 2,
+				"links": [
+				],
+				"nullPointMode": "null as zero",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "(irate(openebs_read_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m])/(1024))*512/(irate(openebs_reads{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m]))",
+						"format": "time_series",
+						"hide": false,
+						"intervalFactor": 2,
+						"legendFormat": "{{openebs_pvc}}",
+						"refId": "A"
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Block Size(Reads)",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"format": "deckbytes",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": "0",
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": null,
+						"show": false
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fill": 3,
+				"gridPos": {
+					"h": 8,
+					"w": 24,
+					"x": 0,
+					"y": 65
+				},
+				"id": 27,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 2,
+				"links": [
+				],
+				"nullPointMode": "null as zero",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "(irate(openebs_write_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m])/(1024))*512/(irate(openebs_writes{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m]))",
+						"format": "time_series",
+						"hide": false,
+						"intervalFactor": 2,
+						"legendFormat": "{{openebs_pvc}}",
+						"refId": "A"
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Block Size(Writes)",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"format": "deckbytes",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": "0",
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": null,
+						"show": false
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			}
+		],
+		"refresh": "1m",
+		"schemaVersion": 16,
+		"style": "light",
+		"tags": [
+		],
+		"templating": {
+			"list": [
+				{
+					"allValue": null,
+					"current": {
+					},
+					"datasource": "DS_OPENEBS_PROMETHEUS",
+					"hide": 0,
+					"includeAll": false,
+					"label": "Cluster:",
+					"multi": false,
+					"name": "job",
+					"options": [
+					],
+					"query": "label_values(openebs_size_of_volume,job)",
+					"refresh": 2,
+					"regex": "/cluster_uuid_(.*)_.*/",
+					"sort": 0,
+					"tagValuesQuery": "",
+					"tags": [
+					],
+					"tagsQuery": "",
+					"type": "query",
+					"useTags": false
+				},
+				{
+					"allValue": null,
+					"current": {
+					},
+					"datasource": "DS_OPENEBS_PROMETHEUS",
+					"hide": 2,
+					"includeAll": true,
+					"label": "Volume",
+					"multi": true,
+					"name": "openebs_Volume",
+					"options": [
+					],
+					"query": "label_values(openebs_size_of_volume{job=~\".*$job.*\"},openebs_pv)",
+					"refresh": 2,
+					"regex": "",
+					"sort": 0,
+					"tagValuesQuery": "",
+					"tags": [
+					],
+					"tagsQuery": "",
+					"type": "query",
+					"useTags": false
+				},
+				{
+					"allValue": null,
+					"current": {
+					},
+					"datasource": "DS_OPENEBS_PROMETHEUS",
+					"hide": 0,
+					"includeAll": true,
+					"label": "OpenEBS pvc",
+					"multi": true,
+					"name": "openebs_pvc",
+					"options": [
+					],
+					"query": "label_values(openebs_size_of_volume{job=~\".*$job.*\",openebs_pv=~\"$openebs_Volume\"},openebs_pvc)",
+					"refresh": 2,
+					"regex": "",
+					"sort": 0,
+					"tagValuesQuery": "",
+					"tags": [
+					],
+					"tagsQuery": "",
+					"type": "query",
+					"useTags": false
+				},
+				{
+					"allValue": null,
+					"current": {
+					},
+					"hide": 2,
+					"includeAll": false,
+					"label": "projectid",
+					"multi": false,
+					"name": "projectid",
+					"options": [
+						{
+							"selected": false,
+							"text": "",
+							"value": ""
+						}
+					],
+					"query": "",
+					"type": "custom"
+				},
+				{
+					"allValue": null,
+					"current": {
+					},
+					"hide": 2,
+					"includeAll": false,
+					"label": "groupid",
+					"multi": false,
+					"name": "groupid",
+					"options": [
+						{
+							"selected": false,
+							"text": "",
+							"value": ""
+						}
+					],
+					"query": "",
+					"type": "custom"
+				}
+			]
+		},
+		"time": {
+			"from": "now-1h",
+			"to": "now"
+		},
+		"timepicker": {
+			"refresh_intervals": [
+				"5s",
+				"10s",
+				"30s",
+				"1m",
+				"5m",
+				"15m",
+				"30m",
+				"1h",
+				"2h",
+				"1d"
+			],
+			"time_options": [
+				"5m",
+				"15m",
+				"1h",
+				"6h",
+				"12h",
+				"24h",
+				"2d",
+				"7d",
+				"30d"
+			]
+		},
+		"timezone": "",
+		"title": "Cluster Volumes Dashboard",
+		"uid": "cd9669c9-dc67-4c73-ac21-1c6486bb7cd9",
+		"version": 3
+	},
+	"overwrite": true
+}

--- a/grafana-charts/cstorvolumereplicasdashboard.json
+++ b/grafana-charts/cstorvolumereplicasdashboard.json
@@ -1,0 +1,1383 @@
+{
+	"dashboard": {
+		"__inputs": [
+			{
+				"name": "DS_OPENEBS_PROMETHEUS",
+				"label": "openebs Prometheus",
+				"description": "",
+				"type": "datasource",
+				"pluginId": "prometheus",
+				"pluginName": "Prometheus"
+			}
+		],
+		"__requires": [
+			{
+				"type": "grafana",
+				"id": "grafana",
+				"name": "Grafana",
+				"version": "5.1.3"
+			},
+			{
+				"type": "panel",
+				"id": "graph",
+				"name": "Graph",
+				"version": ""
+			},
+			{
+				"type": "datasource",
+				"id": "prometheus",
+				"name": "Prometheus",
+				"version": "1.0.0"
+			},
+			{
+				"type": "panel",
+				"id": "singlestat",
+				"name": "Singlestat",
+				"version": ""
+			},
+			{
+				"type": "panel",
+				"id": "text",
+				"name": "Text",
+				"version": ""
+			}
+		],
+		"annotations": {
+			"list": [
+			]
+		},
+		"editable": true,
+		"gnetId": null,
+		"graphTooltip": 0,
+		"id": null,
+		"iteration": 1542963642391,
+		"links": [
+			{
+				"icon": "doc",
+				"includeVars": true,
+				"keepTime": true,
+				"tags": [
+				],
+				"targetBlank": true,
+				"title": "report",
+				"tooltip": "",
+				"type": "link",
+				"url": "${MAYA_URL}/reporter/?dashboard=644d0435-03e1-4da3-b768-7968f526cf68"
+			}
+		],
+		"panels": [
+			{
+				"content": "<html>\n<head>\n\n<script>\nwindow.onload = load('$Pool', '$spc','$cluster');\n\nfunction getCell(name, value) {\n  return \"<div class=\\\"outlet-header-meta-bar_item\\\"><div class=\\\"outlet-header-meta-bar_title\\\"><span>\"+name+\"</span></div><div class=\\\"outlet-header-meta-bar_value\\\"><span>\"+value+\"</span></div></div>\";\n}\n\nfunction load(poolNameStr, spcStr,clusterNameStr) {\nvar poolNameStr = poolNameStr.replace( /[{}]/g, '' );\nvar spcStr = spcStr.replace( /[{}]/g, '' );\nvar clusterNameStr = clusterNameStr.replace( /[{}]/g, '' );\n// var pools = poolsStr.replace( /[{}]/g, '' );\n// var rc = replicaCount.replace( /[{}]/g, '' );\n// if(!rc) {\n//   rc = \"none\";\n// }\n// var uptimes = uptime.replace( /[{}]/g, '' );\n// if(uptimes) {\n// var seconds = parseInt(uptimes, 10);\n\n// var days = Math.floor(seconds / (3600*24));\n// seconds  -= days*3600*24;\n// var hrs   = Math.floor(seconds / 3600);\n// seconds  -= hrs*3600;\n// var mnts = Math.floor(seconds / 60);\n// seconds  -= mnts*60;\n// uptimes = days+\" days, \"+hrs+\" Hrs, \"+mnts+\" Mins, \"+seconds+\" Secs\";\n// }\n// else {\n//   uptimes = \"No Data\";\n// }\n\n\n\nz=\"\";\nz+=getCell(\"Pool Name\", poolNameStr);\nz+=getCell(\"Cluster\", clusterNameStr);\n//z+=getCell(\"Name\", volName);\nz+=getCell(\"SPC\", spcStr.link(\"/grafana/d/storage-pool-claim-dashboard/storage-pool-claim-dashboard?submenu&var-spc=\" + spcStr));\n//z+=getCell(\"Pool Name\", pools);\n//z+=getCell(\"No. of Replicas\", rc);\n//z+=getCell(\"\",\"\")\n\ndocument.getElementById(\"volume-info\").innerHTML = z;\n}\n</script>\n</head>\n\n<body>\n\n<div id=\"volume-info\" class=\"outlet-header-bar\"></div>\n\n</body>\n\n</html>",
+				"gridPos": {
+					"h": 3,
+					"w": 24,
+					"x": 0,
+					"y": 0
+				},
+				"id": 44,
+				"links": [
+				],
+				"mode": "html",
+				"title": "Pool information",
+				"transparent": false,
+				"type": "text"
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fill": 1,
+				"gridPos": {
+					"h": 7,
+					"w": 8,
+					"x": 0,
+					"y": 3
+				},
+				"id": 50,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 1,
+				"links": [
+				],
+				"nullPointMode": "null",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "openebs_replica_status{cstor_pool=~\"$Pool\", vol=~\"$Replicas\"}",
+						"format": "time_series",
+						"intervalFactor": 1,
+						"legendFormat": "{{vol}}",
+						"refId": "A"
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Replica status",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"decimals": 0,
+						"format": "short",
+						"label": null,
+						"labelMappings": [
+							{
+								"label": "Offline",
+								"value": 0
+							},
+							{
+								"label": "Healthy",
+								"value": 1
+							},
+							{
+								"label": "Degraded",
+								"value": 2
+							},
+							{
+								"label": "Rebuilding",
+								"value": 3
+							}
+						],
+						"logBase": 1,
+						"mappedLabelOnly": true,
+						"max": null,
+						"min": "0",
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"mappedLabelOnly": false,
+						"max": null,
+						"min": null,
+						"show": true
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fill": 1,
+				"gridPos": {
+					"h": 7,
+					"w": 8,
+					"x": 8,
+					"y": 3
+				},
+				"id": 52,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 1,
+				"links": [
+				],
+				"nullPointMode": "null",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "openebs_rebuild_status{cstor_pool=~\"$Pool\", vol=~\"$Replicas\"}",
+						"format": "time_series",
+						"intervalFactor": 1,
+						"legendFormat": "{{vol}}",
+						"refId": "A"
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Replica rebuilding status",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"decimals": 0,
+						"format": "short",
+						"label": null,
+						"labelMappings": [
+							{
+								"label": "Init",
+								"value": 0
+							},
+							{
+								"label": "Done",
+								"value": 1
+							},
+							{
+								"label": "Snap rebuild in progress",
+								"value": 2
+							},
+							{
+								"label": "Active dataset rebuild in progress",
+								"value": 3
+							},
+							{
+								"label": "Errored",
+								"value": 4
+							},
+							{
+								"label": "Failed",
+								"value": 5
+							},
+							{
+								"label": "Unknown",
+								"value": 6
+							}
+						],
+						"logBase": 1,
+						"mappedLabelOnly": true,
+						"max": null,
+						"min": "0",
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"mappedLabelOnly": false,
+						"max": null,
+						"min": null,
+						"show": true
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fill": 1,
+				"gridPos": {
+					"h": 7,
+					"w": 8,
+					"x": 16,
+					"y": 3
+				},
+				"id": 58,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 1,
+				"links": [
+				],
+				"nullPointMode": "null",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "openebs_rebuild_count{cstor_pool=~\"$Pool\", vol=~\"$Replicas\"}",
+						"format": "time_series",
+						"intervalFactor": 1,
+						"legendFormat": "{{vol}}",
+						"refId": "A"
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Replica rebuild count",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"decimals": 0,
+						"format": "short",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"mappedLabelOnly": false,
+						"max": null,
+						"min": "0",
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"mappedLabelOnly": false,
+						"max": null,
+						"min": null,
+						"show": true
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fill": 1,
+				"gridPos": {
+					"h": 8,
+					"w": 12,
+					"x": 0,
+					"y": 10
+				},
+				"id": 62,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 2,
+				"links": [
+				],
+				"nullPointMode": "null",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "increase(openebs_write_latency{cstor_pool=~\"$Pool\", vol=~\"$Replicas\"}[2m])",
+						"format": "time_series",
+						"intervalFactor": 1,
+						"legendFormat": "{{vol}}",
+						"refId": "A"
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Write latency",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"format": "ns",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"mappedLabelOnly": false,
+						"max": null,
+						"min": "0",
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"mappedLabelOnly": false,
+						"max": null,
+						"min": null,
+						"show": true
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fill": 1,
+				"gridPos": {
+					"h": 8,
+					"w": 12,
+					"x": 12,
+					"y": 10
+				},
+				"id": 46,
+				"legend": {
+					"alignAsTable": true,
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 2,
+				"links": [
+				],
+				"nullPointMode": "null",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "increase(openebs_sync_latency{cstor_pool=~\"$Pool\",vol=~\"$Replicas\"}[2m])",
+						"format": "time_series",
+						"intervalFactor": 1,
+						"legendFormat": "{{vol}}",
+						"refId": "A"
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Sync latency",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"decimals": null,
+						"format": "ns",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"mappedLabelOnly": false,
+						"max": null,
+						"min": "0",
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"mappedLabelOnly": false,
+						"max": null,
+						"min": null,
+						"show": true
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fill": 1,
+				"gridPos": {
+					"h": 7,
+					"w": 8,
+					"x": 0,
+					"y": 18
+				},
+				"id": 32,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 2,
+				"links": [
+				],
+				"nullPointMode": "null",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "openebs_total_read_count{cstor_pool=~\"$Pool\",vol=~\"$Replicas\"}",
+						"format": "time_series",
+						"intervalFactor": 1,
+						"legendFormat": "{{vol}}",
+						"refId": "A"
+					},
+					{
+						"expr": "",
+						"format": "time_series",
+						"interval": "",
+						"intervalFactor": 1,
+						"legendFormat": "Write IO",
+						"refId": "B"
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Read IO count",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"format": "short",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"mappedLabelOnly": false,
+						"max": null,
+						"min": "0",
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"mappedLabelOnly": false,
+						"max": null,
+						"min": null,
+						"show": true
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fill": 1,
+				"gridPos": {
+					"h": 7,
+					"w": 8,
+					"x": 8,
+					"y": 18
+				},
+				"id": 40,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 2,
+				"links": [
+				],
+				"nullPointMode": "null",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "openebs_total_read_bytes{cstor_pool=~\"$Pool\",vol=~\"$Replicas\"}",
+						"format": "time_series",
+						"intervalFactor": 1,
+						"legendFormat": "{{vol}}",
+						"refId": "A"
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Read IO in bytes",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"format": "bytes",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"mappedLabelOnly": false,
+						"max": null,
+						"min": "0",
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"mappedLabelOnly": false,
+						"max": null,
+						"min": null,
+						"show": true
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fill": 1,
+				"gridPos": {
+					"h": 7,
+					"w": 8,
+					"x": 16,
+					"y": 18
+				},
+				"id": 48,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 2,
+				"links": [
+				],
+				"nullPointMode": "null",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "increase(openebs_read_latency{cstor_pool=~\"$Pool\", vol=~\"$Replicas\"}[2m])",
+						"format": "time_series",
+						"intervalFactor": 1,
+						"legendFormat": "{{vol}}",
+						"refId": "A"
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Read latency",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"format": "ns",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"mappedLabelOnly": false,
+						"max": null,
+						"min": "0",
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"mappedLabelOnly": false,
+						"max": null,
+						"min": null,
+						"show": true
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fill": 1,
+				"gridPos": {
+					"h": 7,
+					"w": 8,
+					"x": 0,
+					"y": 25
+				},
+				"id": 64,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 2,
+				"links": [
+				],
+				"nullPointMode": "null",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "openebs_total_write_count{cstor_pool=~\"$Pool\",vol=~\"$Replicas\"}",
+						"format": "time_series",
+						"intervalFactor": 1,
+						"legendFormat": "{{vol}}",
+						"refId": "A"
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Write IO count",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"format": "short",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"mappedLabelOnly": false,
+						"max": null,
+						"min": "0",
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"mappedLabelOnly": false,
+						"max": null,
+						"min": null,
+						"show": true
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fill": 1,
+				"gridPos": {
+					"h": 7,
+					"w": 8,
+					"x": 8,
+					"y": 25
+				},
+				"id": 60,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 2,
+				"links": [
+				],
+				"nullPointMode": "null",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "openebs_total_write_bytes{cstor_pool=~\"$Pool\",vol=~\"$Replicas\"}",
+						"format": "time_series",
+						"intervalFactor": 1,
+						"legendFormat": "{{vol}}",
+						"refId": "A"
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Write IO in bytes",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"decimals": null,
+						"format": "short",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"mappedLabelOnly": false,
+						"max": null,
+						"min": "0",
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"mappedLabelOnly": false,
+						"max": null,
+						"min": null,
+						"show": true
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fill": 1,
+				"gridPos": {
+					"h": 7,
+					"w": 8,
+					"x": 16,
+					"y": 25
+				},
+				"id": 34,
+				"legend": {
+					"alignAsTable": true,
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 2,
+				"links": [
+				],
+				"nullPointMode": "null",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "openebs_sync_count{cstor_pool=~\"$Pool\",vol=~\"$Replicas\"}",
+						"format": "time_series",
+						"intervalFactor": 1,
+						"legendFormat": "{{vol}}",
+						"refId": "A"
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Sync count",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"format": "short",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"mappedLabelOnly": false,
+						"max": null,
+						"min": "0",
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"mappedLabelOnly": false,
+						"max": null,
+						"min": null,
+						"show": true
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			}
+		],
+		"refresh": false,
+		"schemaVersion": 16,
+		"style": "light",
+		"tags": [
+		],
+		"templating": {
+			"list": [
+				{
+					"allValue": null,
+					"current": {
+					},
+					"datasource": "DS_OPENEBS_PROMETHEUS",
+					"hide": 2,
+					"includeAll": false,
+					"label": "Pool",
+					"multi": false,
+					"name": "Pool",
+					"options": [
+					],
+					"query": "label_values(openebs_pool_status{cstor_pool=~\"$pool\"},cstor_pool)",
+					"refresh": 2,
+					"regex": "",
+					"sort": 0,
+					"tagValuesQuery": "",
+					"tags": [
+					],
+					"tagsQuery": "",
+					"type": "query",
+					"useTags": false
+				},
+				{
+					"allValue": null,
+					"current": {
+					},
+					"datasource": "DS_OPENEBS_PROMETHEUS",
+					"hide": 2,
+					"includeAll": false,
+					"label": "cluster",
+					"multi": false,
+					"name": "cluster",
+					"options": [
+					],
+					"query": "label_values(openebs_pool_status{cstor_pool=~\"$Pool\"},job)",
+					"refresh": 2,
+					"regex": "/cluster_uuid_(.*)_.*/",
+					"sort": 0,
+					"tagValuesQuery": "",
+					"tags": [
+					],
+					"tagsQuery": "",
+					"type": "query",
+					"useTags": false
+				},
+				{
+					"allValue": null,
+					"current": {
+					},
+					"hide": 2,
+					"includeAll": false,
+					"label": "pool",
+					"multi": false,
+					"name": "pool",
+					"options": [
+						{
+							"selected": false,
+							"text": "",
+							"value": ""
+						}
+					],
+					"query": "",
+					"type": "custom"
+				},
+				{
+					"allValue": null,
+					"current": {
+					},
+					"datasource": "DS_OPENEBS_PROMETHEUS",
+					"hide": 0,
+					"includeAll": true,
+					"label": "Volume replicas in pool",
+					"multi": true,
+					"name": "Replicas",
+					"options": [
+					],
+					"query": "label_values(openebs_replica_status{cstor_pool=~\"$Pool\"}, vol)",
+					"refresh": 2,
+					"regex": "",
+					"sort": 0,
+					"tagValuesQuery": "",
+					"tags": [
+					],
+					"tagsQuery": "",
+					"type": "query",
+					"useTags": false
+				},
+				{
+					"allValue": null,
+					"current": {
+					},
+					"datasource": "DS_OPENEBS_PROMETHEUS",
+					"hide": 2,
+					"includeAll": false,
+					"label": "spc",
+					"multi": false,
+					"name": "spc",
+					"options": [
+					],
+					"query": "label_values(openebs_pool_status{cstor_pool=~\"$Pool\"},storage_pool_claim)",
+					"refresh": 2,
+					"regex": "",
+					"sort": 0,
+					"tagValuesQuery": "",
+					"tags": [
+					],
+					"tagsQuery": "",
+					"type": "query",
+					"useTags": false
+				},
+				{
+					"allValue": null,
+					"current": {
+					},
+					"hide": 2,
+					"includeAll": false,
+					"label": "projectid",
+					"multi": false,
+					"name": "projectid",
+					"options": [
+						{
+							"selected": false,
+							"text": "",
+							"value": ""
+						}
+					],
+					"query": "",
+					"type": "custom"
+				},
+				{
+					"allValue": null,
+					"current": {
+					},
+					"hide": 2,
+					"includeAll": false,
+					"label": "groupid",
+					"multi": false,
+					"name": "groupid",
+					"options": [
+						{
+							"selected": false,
+							"text": "",
+							"value": ""
+						}
+					],
+					"query": "",
+					"type": "custom"
+				}
+			]
+		},
+		"time": {
+			"from": "now-1h",
+			"to": "now"
+		},
+		"timepicker": {
+			"refresh_intervals": [
+				"5s",
+				"10s",
+				"30s",
+				"1m",
+				"5m",
+				"15m",
+				"30m",
+				"1h",
+				"2h",
+				"1d"
+			],
+			"time_options": [
+				"5m",
+				"15m",
+				"1h",
+				"6h",
+				"12h",
+				"24h",
+				"2d",
+				"7d",
+				"30d"
+			]
+		},
+		"timezone": "",
+		"title": "cStor volume replicas dashboard",
+		"uid": "644d0435-03e1-4da3-b768-7968f526cf68",
+		"version": 3
+	},
+	"overwrite": true
+}

--- a/grafana-charts/cstorvolumereplicasdashboard.json
+++ b/grafana-charts/cstorvolumereplicasdashboard.json
@@ -1,1383 +1,1217 @@
 {
-	"dashboard": {
-		"__inputs": [
-			{
-				"name": "DS_OPENEBS_PROMETHEUS",
-				"label": "openebs Prometheus",
-				"description": "",
-				"type": "datasource",
-				"pluginId": "prometheus",
-				"pluginName": "Prometheus"
-			}
-		],
-		"__requires": [
-			{
-				"type": "grafana",
-				"id": "grafana",
-				"name": "Grafana",
-				"version": "5.1.3"
-			},
-			{
-				"type": "panel",
-				"id": "graph",
-				"name": "Graph",
-				"version": ""
-			},
-			{
-				"type": "datasource",
-				"id": "prometheus",
-				"name": "Prometheus",
-				"version": "1.0.0"
-			},
-			{
-				"type": "panel",
-				"id": "singlestat",
-				"name": "Singlestat",
-				"version": ""
-			},
-			{
-				"type": "panel",
-				"id": "text",
-				"name": "Text",
-				"version": ""
-			}
-		],
-		"annotations": {
-			"list": [
-			]
-		},
-		"editable": true,
-		"gnetId": null,
-		"graphTooltip": 0,
-		"id": null,
-		"iteration": 1542963642391,
-		"links": [
-			{
-				"icon": "doc",
-				"includeVars": true,
-				"keepTime": true,
-				"tags": [
-				],
-				"targetBlank": true,
-				"title": "report",
-				"tooltip": "",
-				"type": "link",
-				"url": "${MAYA_URL}/reporter/?dashboard=644d0435-03e1-4da3-b768-7968f526cf68"
-			}
-		],
-		"panels": [
-			{
-				"content": "<html>\n<head>\n\n<script>\nwindow.onload = load('$Pool', '$spc','$cluster');\n\nfunction getCell(name, value) {\n  return \"<div class=\\\"outlet-header-meta-bar_item\\\"><div class=\\\"outlet-header-meta-bar_title\\\"><span>\"+name+\"</span></div><div class=\\\"outlet-header-meta-bar_value\\\"><span>\"+value+\"</span></div></div>\";\n}\n\nfunction load(poolNameStr, spcStr,clusterNameStr) {\nvar poolNameStr = poolNameStr.replace( /[{}]/g, '' );\nvar spcStr = spcStr.replace( /[{}]/g, '' );\nvar clusterNameStr = clusterNameStr.replace( /[{}]/g, '' );\n// var pools = poolsStr.replace( /[{}]/g, '' );\n// var rc = replicaCount.replace( /[{}]/g, '' );\n// if(!rc) {\n//   rc = \"none\";\n// }\n// var uptimes = uptime.replace( /[{}]/g, '' );\n// if(uptimes) {\n// var seconds = parseInt(uptimes, 10);\n\n// var days = Math.floor(seconds / (3600*24));\n// seconds  -= days*3600*24;\n// var hrs   = Math.floor(seconds / 3600);\n// seconds  -= hrs*3600;\n// var mnts = Math.floor(seconds / 60);\n// seconds  -= mnts*60;\n// uptimes = days+\" days, \"+hrs+\" Hrs, \"+mnts+\" Mins, \"+seconds+\" Secs\";\n// }\n// else {\n//   uptimes = \"No Data\";\n// }\n\n\n\nz=\"\";\nz+=getCell(\"Pool Name\", poolNameStr);\nz+=getCell(\"Cluster\", clusterNameStr);\n//z+=getCell(\"Name\", volName);\nz+=getCell(\"SPC\", spcStr.link(\"/grafana/d/storage-pool-claim-dashboard/storage-pool-claim-dashboard?submenu&var-spc=\" + spcStr));\n//z+=getCell(\"Pool Name\", pools);\n//z+=getCell(\"No. of Replicas\", rc);\n//z+=getCell(\"\",\"\")\n\ndocument.getElementById(\"volume-info\").innerHTML = z;\n}\n</script>\n</head>\n\n<body>\n\n<div id=\"volume-info\" class=\"outlet-header-bar\"></div>\n\n</body>\n\n</html>",
-				"gridPos": {
-					"h": 3,
-					"w": 24,
-					"x": 0,
-					"y": 0
-				},
-				"id": 44,
-				"links": [
-				],
-				"mode": "html",
-				"title": "Pool information",
-				"transparent": false,
-				"type": "text"
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fill": 1,
-				"gridPos": {
-					"h": 7,
-					"w": 8,
-					"x": 0,
-					"y": 3
-				},
-				"id": 50,
-				"legend": {
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"show": true,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 1,
-				"links": [
-				],
-				"nullPointMode": "null",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": false,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "openebs_replica_status{cstor_pool=~\"$Pool\", vol=~\"$Replicas\"}",
-						"format": "time_series",
-						"intervalFactor": 1,
-						"legendFormat": "{{vol}}",
-						"refId": "A"
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "Replica status",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"decimals": 0,
-						"format": "short",
-						"label": null,
-						"labelMappings": [
-							{
-								"label": "Offline",
-								"value": 0
-							},
-							{
-								"label": "Healthy",
-								"value": 1
-							},
-							{
-								"label": "Degraded",
-								"value": 2
-							},
-							{
-								"label": "Rebuilding",
-								"value": 3
-							}
-						],
-						"logBase": 1,
-						"mappedLabelOnly": true,
-						"max": null,
-						"min": "0",
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"mappedLabelOnly": false,
-						"max": null,
-						"min": null,
-						"show": true
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fill": 1,
-				"gridPos": {
-					"h": 7,
-					"w": 8,
-					"x": 8,
-					"y": 3
-				},
-				"id": 52,
-				"legend": {
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"show": true,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 1,
-				"links": [
-				],
-				"nullPointMode": "null",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": false,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "openebs_rebuild_status{cstor_pool=~\"$Pool\", vol=~\"$Replicas\"}",
-						"format": "time_series",
-						"intervalFactor": 1,
-						"legendFormat": "{{vol}}",
-						"refId": "A"
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "Replica rebuilding status",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"decimals": 0,
-						"format": "short",
-						"label": null,
-						"labelMappings": [
-							{
-								"label": "Init",
-								"value": 0
-							},
-							{
-								"label": "Done",
-								"value": 1
-							},
-							{
-								"label": "Snap rebuild in progress",
-								"value": 2
-							},
-							{
-								"label": "Active dataset rebuild in progress",
-								"value": 3
-							},
-							{
-								"label": "Errored",
-								"value": 4
-							},
-							{
-								"label": "Failed",
-								"value": 5
-							},
-							{
-								"label": "Unknown",
-								"value": 6
-							}
-						],
-						"logBase": 1,
-						"mappedLabelOnly": true,
-						"max": null,
-						"min": "0",
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"mappedLabelOnly": false,
-						"max": null,
-						"min": null,
-						"show": true
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fill": 1,
-				"gridPos": {
-					"h": 7,
-					"w": 8,
-					"x": 16,
-					"y": 3
-				},
-				"id": 58,
-				"legend": {
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"show": true,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 1,
-				"links": [
-				],
-				"nullPointMode": "null",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": false,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "openebs_rebuild_count{cstor_pool=~\"$Pool\", vol=~\"$Replicas\"}",
-						"format": "time_series",
-						"intervalFactor": 1,
-						"legendFormat": "{{vol}}",
-						"refId": "A"
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "Replica rebuild count",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"decimals": 0,
-						"format": "short",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"mappedLabelOnly": false,
-						"max": null,
-						"min": "0",
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"mappedLabelOnly": false,
-						"max": null,
-						"min": null,
-						"show": true
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fill": 1,
-				"gridPos": {
-					"h": 8,
-					"w": 12,
-					"x": 0,
-					"y": 10
-				},
-				"id": 62,
-				"legend": {
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"show": true,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 2,
-				"links": [
-				],
-				"nullPointMode": "null",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": false,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "increase(openebs_write_latency{cstor_pool=~\"$Pool\", vol=~\"$Replicas\"}[2m])",
-						"format": "time_series",
-						"intervalFactor": 1,
-						"legendFormat": "{{vol}}",
-						"refId": "A"
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "Write latency",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"format": "ns",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"mappedLabelOnly": false,
-						"max": null,
-						"min": "0",
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"mappedLabelOnly": false,
-						"max": null,
-						"min": null,
-						"show": true
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fill": 1,
-				"gridPos": {
-					"h": 8,
-					"w": 12,
-					"x": 12,
-					"y": 10
-				},
-				"id": 46,
-				"legend": {
-					"alignAsTable": true,
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"show": true,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 2,
-				"links": [
-				],
-				"nullPointMode": "null",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": false,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "increase(openebs_sync_latency{cstor_pool=~\"$Pool\",vol=~\"$Replicas\"}[2m])",
-						"format": "time_series",
-						"intervalFactor": 1,
-						"legendFormat": "{{vol}}",
-						"refId": "A"
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "Sync latency",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"decimals": null,
-						"format": "ns",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"mappedLabelOnly": false,
-						"max": null,
-						"min": "0",
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"mappedLabelOnly": false,
-						"max": null,
-						"min": null,
-						"show": true
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fill": 1,
-				"gridPos": {
-					"h": 7,
-					"w": 8,
-					"x": 0,
-					"y": 18
-				},
-				"id": 32,
-				"legend": {
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"show": true,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 2,
-				"links": [
-				],
-				"nullPointMode": "null",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": false,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "openebs_total_read_count{cstor_pool=~\"$Pool\",vol=~\"$Replicas\"}",
-						"format": "time_series",
-						"intervalFactor": 1,
-						"legendFormat": "{{vol}}",
-						"refId": "A"
-					},
-					{
-						"expr": "",
-						"format": "time_series",
-						"interval": "",
-						"intervalFactor": 1,
-						"legendFormat": "Write IO",
-						"refId": "B"
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "Read IO count",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"format": "short",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"mappedLabelOnly": false,
-						"max": null,
-						"min": "0",
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"mappedLabelOnly": false,
-						"max": null,
-						"min": null,
-						"show": true
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fill": 1,
-				"gridPos": {
-					"h": 7,
-					"w": 8,
-					"x": 8,
-					"y": 18
-				},
-				"id": 40,
-				"legend": {
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"show": true,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 2,
-				"links": [
-				],
-				"nullPointMode": "null",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": false,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "openebs_total_read_bytes{cstor_pool=~\"$Pool\",vol=~\"$Replicas\"}",
-						"format": "time_series",
-						"intervalFactor": 1,
-						"legendFormat": "{{vol}}",
-						"refId": "A"
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "Read IO in bytes",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"format": "bytes",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"mappedLabelOnly": false,
-						"max": null,
-						"min": "0",
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"mappedLabelOnly": false,
-						"max": null,
-						"min": null,
-						"show": true
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fill": 1,
-				"gridPos": {
-					"h": 7,
-					"w": 8,
-					"x": 16,
-					"y": 18
-				},
-				"id": 48,
-				"legend": {
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"show": true,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 2,
-				"links": [
-				],
-				"nullPointMode": "null",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": false,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "increase(openebs_read_latency{cstor_pool=~\"$Pool\", vol=~\"$Replicas\"}[2m])",
-						"format": "time_series",
-						"intervalFactor": 1,
-						"legendFormat": "{{vol}}",
-						"refId": "A"
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "Read latency",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"format": "ns",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"mappedLabelOnly": false,
-						"max": null,
-						"min": "0",
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"mappedLabelOnly": false,
-						"max": null,
-						"min": null,
-						"show": true
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fill": 1,
-				"gridPos": {
-					"h": 7,
-					"w": 8,
-					"x": 0,
-					"y": 25
-				},
-				"id": 64,
-				"legend": {
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"show": true,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 2,
-				"links": [
-				],
-				"nullPointMode": "null",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": false,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "openebs_total_write_count{cstor_pool=~\"$Pool\",vol=~\"$Replicas\"}",
-						"format": "time_series",
-						"intervalFactor": 1,
-						"legendFormat": "{{vol}}",
-						"refId": "A"
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "Write IO count",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"format": "short",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"mappedLabelOnly": false,
-						"max": null,
-						"min": "0",
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"mappedLabelOnly": false,
-						"max": null,
-						"min": null,
-						"show": true
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fill": 1,
-				"gridPos": {
-					"h": 7,
-					"w": 8,
-					"x": 8,
-					"y": 25
-				},
-				"id": 60,
-				"legend": {
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"show": true,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 2,
-				"links": [
-				],
-				"nullPointMode": "null",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": false,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "openebs_total_write_bytes{cstor_pool=~\"$Pool\",vol=~\"$Replicas\"}",
-						"format": "time_series",
-						"intervalFactor": 1,
-						"legendFormat": "{{vol}}",
-						"refId": "A"
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "Write IO in bytes",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"decimals": null,
-						"format": "short",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"mappedLabelOnly": false,
-						"max": null,
-						"min": "0",
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"mappedLabelOnly": false,
-						"max": null,
-						"min": null,
-						"show": true
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fill": 1,
-				"gridPos": {
-					"h": 7,
-					"w": 8,
-					"x": 16,
-					"y": 25
-				},
-				"id": 34,
-				"legend": {
-					"alignAsTable": true,
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"show": true,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 2,
-				"links": [
-				],
-				"nullPointMode": "null",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": false,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "openebs_sync_count{cstor_pool=~\"$Pool\",vol=~\"$Replicas\"}",
-						"format": "time_series",
-						"intervalFactor": 1,
-						"legendFormat": "{{vol}}",
-						"refId": "A"
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "Sync count",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"format": "short",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"mappedLabelOnly": false,
-						"max": null,
-						"min": "0",
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"mappedLabelOnly": false,
-						"max": null,
-						"min": null,
-						"show": true
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			}
-		],
-		"refresh": false,
-		"schemaVersion": 16,
-		"style": "light",
-		"tags": [
-		],
-		"templating": {
-			"list": [
-				{
-					"allValue": null,
-					"current": {
-					},
-					"datasource": "DS_OPENEBS_PROMETHEUS",
-					"hide": 2,
-					"includeAll": false,
-					"label": "Pool",
-					"multi": false,
-					"name": "Pool",
-					"options": [
-					],
-					"query": "label_values(openebs_pool_status{cstor_pool=~\"$pool\"},cstor_pool)",
-					"refresh": 2,
-					"regex": "",
-					"sort": 0,
-					"tagValuesQuery": "",
-					"tags": [
-					],
-					"tagsQuery": "",
-					"type": "query",
-					"useTags": false
-				},
-				{
-					"allValue": null,
-					"current": {
-					},
-					"datasource": "DS_OPENEBS_PROMETHEUS",
-					"hide": 2,
-					"includeAll": false,
-					"label": "cluster",
-					"multi": false,
-					"name": "cluster",
-					"options": [
-					],
-					"query": "label_values(openebs_pool_status{cstor_pool=~\"$Pool\"},job)",
-					"refresh": 2,
-					"regex": "/cluster_uuid_(.*)_.*/",
-					"sort": 0,
-					"tagValuesQuery": "",
-					"tags": [
-					],
-					"tagsQuery": "",
-					"type": "query",
-					"useTags": false
-				},
-				{
-					"allValue": null,
-					"current": {
-					},
-					"hide": 2,
-					"includeAll": false,
-					"label": "pool",
-					"multi": false,
-					"name": "pool",
-					"options": [
-						{
-							"selected": false,
-							"text": "",
-							"value": ""
-						}
-					],
-					"query": "",
-					"type": "custom"
-				},
-				{
-					"allValue": null,
-					"current": {
-					},
-					"datasource": "DS_OPENEBS_PROMETHEUS",
-					"hide": 0,
-					"includeAll": true,
-					"label": "Volume replicas in pool",
-					"multi": true,
-					"name": "Replicas",
-					"options": [
-					],
-					"query": "label_values(openebs_replica_status{cstor_pool=~\"$Pool\"}, vol)",
-					"refresh": 2,
-					"regex": "",
-					"sort": 0,
-					"tagValuesQuery": "",
-					"tags": [
-					],
-					"tagsQuery": "",
-					"type": "query",
-					"useTags": false
-				},
-				{
-					"allValue": null,
-					"current": {
-					},
-					"datasource": "DS_OPENEBS_PROMETHEUS",
-					"hide": 2,
-					"includeAll": false,
-					"label": "spc",
-					"multi": false,
-					"name": "spc",
-					"options": [
-					],
-					"query": "label_values(openebs_pool_status{cstor_pool=~\"$Pool\"},storage_pool_claim)",
-					"refresh": 2,
-					"regex": "",
-					"sort": 0,
-					"tagValuesQuery": "",
-					"tags": [
-					],
-					"tagsQuery": "",
-					"type": "query",
-					"useTags": false
-				},
-				{
-					"allValue": null,
-					"current": {
-					},
-					"hide": 2,
-					"includeAll": false,
-					"label": "projectid",
-					"multi": false,
-					"name": "projectid",
-					"options": [
-						{
-							"selected": false,
-							"text": "",
-							"value": ""
-						}
-					],
-					"query": "",
-					"type": "custom"
-				},
-				{
-					"allValue": null,
-					"current": {
-					},
-					"hide": 2,
-					"includeAll": false,
-					"label": "groupid",
-					"multi": false,
-					"name": "groupid",
-					"options": [
-						{
-							"selected": false,
-							"text": "",
-							"value": ""
-						}
-					],
-					"query": "",
-					"type": "custom"
-				}
-			]
-		},
-		"time": {
-			"from": "now-1h",
-			"to": "now"
-		},
-		"timepicker": {
-			"refresh_intervals": [
-				"5s",
-				"10s",
-				"30s",
-				"1m",
-				"5m",
-				"15m",
-				"30m",
-				"1h",
-				"2h",
-				"1d"
-			],
-			"time_options": [
-				"5m",
-				"15m",
-				"1h",
-				"6h",
-				"12h",
-				"24h",
-				"2d",
-				"7d",
-				"30d"
-			]
-		},
-		"timezone": "",
-		"title": "cStor volume replicas dashboard",
-		"uid": "644d0435-03e1-4da3-b768-7968f526cf68",
-		"version": 3
-	},
-	"overwrite": true
+  "__inputs": [
+    {
+      "name": "DS_OPENEBS_PROMETHEUS",
+      "label": "openebs Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "5.1.3"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "singlestat",
+      "name": "Singlestat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "text",
+      "name": "Text",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "iteration": 1542963642391,
+  "panels": [
+    {
+      "content": "<html>\n<head>\n\n<script>\nwindow.onload = load('$Pool', '$spc');\n\nfunction getCell(name, value) {\n  return \"<div class=\\\"outlet-header-meta-bar_item\\\"><div class=\\\"outlet-header-meta-bar_title\\\"><span>\"+name+\"</span></div><div class=\\\"outlet-header-meta-bar_value\\\"><span>\"+value+\"</span></div></div>\";\n}\n\nfunction load(poolNameStr, spcStr) {\nvar poolNameStr = poolNameStr.replace( /[{}]/g, '' );\nvar spcStr = spcStr.replace( /[{}]/g, '' );\n// var pools = poolsStr.replace( /[{}]/g, '' );\n// var rc = replicaCount.replace( /[{}]/g, '' );\n// if(!rc) {\n//   rc = \"none\";\n// }\n// var uptimes = uptime.replace( /[{}]/g, '' );\n// if(uptimes) {\n// var seconds = parseInt(uptimes, 10);\n\n// var days = Math.floor(seconds / (3600*24));\n// seconds  -= days*3600*24;\n// var hrs   = Math.floor(seconds / 3600);\n// seconds  -= hrs*3600;\n// var mnts = Math.floor(seconds / 60);\n// seconds  -= mnts*60;\n// uptimes = days+\" days, \"+hrs+\" Hrs, \"+mnts+\" Mins, \"+seconds+\" Secs\";\n// }\n// else {\n//   uptimes = \"No Data\";\n// }\n\n\n\nz=\"\";\nz+=getCell(\"Pool Name\", poolNameStr);\n//z+=getCell(\"Name\", volName);\nz+=getCell(\"SPC\",spcStr);\n//z+=getCell(\"Pool Name\", pools);\n//z+=getCell(\"No. of Replicas\", rc);\n//z+=getCell(\"\",\"\")\n\ndocument.getElementById(\"volume-info\").innerHTML = z;\n}\n</script>\n</head>\n\n<body>\n\n<div id=\"volume-info\" class=\"outlet-header-bar\"></div>\n\n</body>\n\n</html>",
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 44,
+      "links": [],
+      "mode": "html",
+      "title": "Pool information",
+      "transparent": false,
+      "type": "text"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 3
+      },
+      "id": 50,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "openebs_replica_status{cstor_pool=~\"$Pool\", vol=~\"$Replicas\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{vol}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Replica status",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "short",
+          "label": null,
+          "labelMappings": [
+            {
+              "label": "Offline",
+              "value": 0
+            },
+            {
+              "label": "Healthy",
+              "value": 1
+            },
+            {
+              "label": "Degraded",
+              "value": 2
+            },
+            {
+              "label": "Rebuilding",
+              "value": 3
+            }
+          ],
+          "logBase": 1,
+          "mappedLabelOnly": true,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 3
+      },
+      "id": 52,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "openebs_rebuild_status{cstor_pool=~\"$Pool\", vol=~\"$Replicas\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{vol}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Replica rebuilding status",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "short",
+          "label": null,
+          "labelMappings": [
+            {
+              "label": "Init",
+              "value": 0
+            },
+            {
+              "label": "Done",
+              "value": 1
+            },
+            {
+              "label": "Snap rebuild in progress",
+              "value": 2
+            },
+            {
+              "label": "Active dataset rebuild in progress",
+              "value": 3
+            },
+            {
+              "label": "Errored",
+              "value": 4
+            },
+            {
+              "label": "Failed",
+              "value": 5
+            },
+            {
+              "label": "Unknown",
+              "value": 6
+            }
+          ],
+          "logBase": 1,
+          "mappedLabelOnly": true,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 3
+      },
+      "id": 58,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "openebs_rebuild_count{cstor_pool=~\"$Pool\", vol=~\"$Replicas\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{vol}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Replica rebuild count",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 10
+      },
+      "id": 62,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "increase(openebs_write_latency{cstor_pool=~\"$Pool\", vol=~\"$Replicas\"}[2m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{vol}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Write latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ns",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 10
+      },
+      "id": 46,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "increase(openebs_sync_latency{cstor_pool=~\"$Pool\",vol=~\"$Replicas\"}[2m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{vol}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Sync latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "ns",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 18
+      },
+      "id": 32,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "openebs_total_read_count{cstor_pool=~\"$Pool\",vol=~\"$Replicas\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{vol}}",
+          "refId": "A"
+        },
+        {
+          "expr": "",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Write IO",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Read IO count",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 18
+      },
+      "id": 40,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "openebs_total_read_bytes{cstor_pool=~\"$Pool\",vol=~\"$Replicas\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{vol}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Read IO in bytes",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "bytes",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 18
+      },
+      "id": 48,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "increase(openebs_read_latency{cstor_pool=~\"$Pool\", vol=~\"$Replicas\"}[2m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{vol}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Read latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ns",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 25
+      },
+      "id": 64,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "openebs_total_write_count{cstor_pool=~\"$Pool\",vol=~\"$Replicas\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{vol}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Write IO count",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 25
+      },
+      "id": 60,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "openebs_total_write_bytes{cstor_pool=~\"$Pool\",vol=~\"$Replicas\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{vol}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Write IO in bytes",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 25
+      },
+      "id": 34,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "openebs_sync_count{cstor_pool=~\"$Pool\",vol=~\"$Replicas\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{vol}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Sync count",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 16,
+  "style": "light",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "DS_OPENEBS_PROMETHEUS",
+        "hide": 2,
+        "includeAll": false,
+        "label": "Pool",
+        "multi": false,
+        "name": "Pool",
+        "options": [],
+        "query": "label_values(openebs_pool_status,cstor_pool)",
+        "refresh": 2,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "hide": 2,
+        "includeAll": false,
+        "label": "pool",
+        "multi": false,
+        "name": "pool",
+        "options": [
+          {
+            "selected": false,
+            "text": "",
+            "value": ""
+          }
+        ],
+        "query": "",
+        "type": "custom"
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "DS_OPENEBS_PROMETHEUS",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Volume replicas in pool",
+        "multi": true,
+        "name": "Replicas",
+        "options": [],
+        "query": "label_values(openebs_replica_status{cstor_pool=~\"$Pool\"}, vol)",
+        "refresh": 2,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "DS_OPENEBS_PROMETHEUS",
+        "hide": 2,
+        "includeAll": false,
+        "label": "spc",
+        "multi": false,
+        "name": "spc",
+        "options": [],
+        "query": "label_values(openebs_pool_status{cstor_pool=~\"$Pool\"},storage_pool_claim)",
+        "refresh": 2,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "cStor volume replicas dashboard",
+  "uid": "644d0435-03e1-4da3-b768-7968f526cf68",
+  "version": 3
 }

--- a/grafana-charts/localpvdashboard.json
+++ b/grafana-charts/localpvdashboard.json
@@ -1,494 +1,375 @@
 {
-	"dashboard": {
-		"__inputs": [
-			{
-				"name": "DS_OPENEBS_PROMETHEUS",
-				"label": "openebs Prometheus",
-				"description": "",
-				"type": "datasource",
-				"pluginId": "prometheus",
-				"pluginName": "Prometheus"
-			}
-		],
-		"__requires": [
-			{
-				"type": "grafana",
-				"id": "grafana",
-				"name": "Grafana",
-				"version": "5.1.3"
-			},
-			{
-				"type": "panel",
-				"id": "graph",
-				"name": "Graph",
-				"version": ""
-			},
-			{
-				"type": "datasource",
-				"id": "prometheus",
-				"name": "Prometheus",
-				"version": "1.0.0"
-			},
-			{
-				"type": "panel",
-				"id": "singlestat",
-				"name": "Singlestat",
-				"version": ""
-			},
-			{
-				"type": "panel",
-				"id": "text",
-				"name": "Text",
-				"version": ""
-			}
-		],
-		"annotations": {
-			"list": [
-			]
-		},
-		"editable": true,
-		"gnetId": null,
-		"graphTooltip": 0,
-		"id": null,
-		"iteration": 1542985639100,
-		"links": [
-			{
-				"icon": "doc",
-				"includeVars": true,
-				"keepTime": true,
-				"tags": [
-				],
-				"targetBlank": true,
-				"title": "report",
-				"tooltip": "",
-				"type": "link",
-				"url": "${MAYA_URL}/reporter/?dashboard=2e59785a-af05-465e-b9a3-fca65a0e8572"
-			}
-		],
-		"panels": [
-			{
-				"content": "<html>\n<head>\n\n<script>\nwindow.onload = load('$openebs_volume','$cluster','$projectid','$groupid','$pvcname','$namespace','$storageclass','$type');\n\nfunction getCell(name, value) {\n  return \"<div class=\\\"outlet-header-meta-bar_item\\\"><div class=\\\"outlet-header-meta-bar_title\\\"><span>\"+name+\"</span></div><div class=\\\"outlet-header-meta-bar_value\\\"><span>\"+value+\"</span></div></div>\";\n}\n\nfunction load(volumeStr,clusterNameStr,projectIdStr,groupIdStr,pvcNameStr,namespaceStr,storageClassStr,typeStr) {\nvar volumeStr = volumeStr.replace( /[{}]/g, '' );\nvar clusterNameStr = clusterNameStr.replace( /[{}]/g, '' );\nvar projectIdStr = projectIdStr.replace( /[{}]/g, '' );\nvar groupIdStr = groupIdStr.replace( /[{}]/g, '' );\nvar pvcNameStr = pvcNameStr.replace( /[{}]/g, '' );\nvar namespaceStr = namespaceStr.replace( /[{}]/g, '' );\nvar storageClassStr = storageClassStr.replace( /[{}]/g, '' );\nvar typeStr = typeStr.replace( /[{}]/g, '' );\n// var pools = poolsStr.replace( /[{}]/g, '' );\n// var rc = replicaCount.replace( /[{}]/g, '' );\n// if(!rc) {\n//   rc = \"none\";\n// }\n// var uptimes = uptime.replace( /[{}]/g, '' );\n// if(uptimes) {\n// var seconds = parseInt(uptimes, 10);\n\n// var days = Math.floor(seconds / (3600*24));\n// seconds  -= days*3600*24;\n// var hrs   = Math.floor(seconds / 3600);\n// seconds  -= hrs*3600;\n// var mnts = Math.floor(seconds / 60);\n// seconds  -= mnts*60;\n// uptimes = days+\" days, \"+hrs+\" Hrs, \"+mnts+\" Mins, \"+seconds+\" Secs\";\n// }\n// else {\n//   uptimes = \"No Data\";\n// }\n\n\n\nz=\"\";\nz+=getCell(\"PVC\", pvcNameStr);\nz+=getCell(\"Cluster\", clusterNameStr);\nz+=getCell(\"Namespace\", namespaceStr);\nz+=getCell(\"CAS Type\", typeStr);\nz+=getCell(\"Storage Class\", storageClassStr);\n//z+=getCell(\"Name\", volName);\n//z+=getCell(\"Pool Name\", pools);\n//z+=getCell(\"No. of Replicas\", rc);\n//z+=getCell(\"\",\"\")\n\ndocument.getElementById(\"volume-info\").innerHTML = z;\n}\n</script>\n</head>\n\n<body>\n\n<div id=\"volume-info\" class=\"outlet-header-bar\"></div>\n\n</body>\n\n</html>",
-				"gridPos": {
-					"h": 3,
-					"w": 24,
-					"x": 0,
-					"y": 0
-				},
-				"id": 52,
-				"links": [
-				],
-				"mode": "html",
-				"title": "Volume information",
-				"type": "text"
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fill": 3,
-				"gridPos": {
-					"h": 6,
-					"w": 12,
-					"x": 0,
-					"y": 3
-				},
-				"id": 50,
-				"legend": {
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"show": true,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 2,
-				"links": [
-				],
-				"nullPointMode": "null",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": false,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "(pv_utilization_bytes{job=~\".*$cluster_uuid.*\",openebs_pv=~\"$openebs_volume\"})/(1024*1024*1024)",
-						"format": "time_series",
-						"intervalFactor": 1,
-						"legendFormat": "Usage",
-						"refId": "A"
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "Used capacity",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"format": "decgbytes",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"mappedLabelOnly": false,
-						"max": null,
-						"min": null,
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"mappedLabelOnly": false,
-						"max": null,
-						"min": null,
-						"show": true
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fill": 3,
-				"gridPos": {
-					"h": 6,
-					"w": 12,
-					"x": 12,
-					"y": 3
-				},
-				"id": 48,
-				"legend": {
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"show": true,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 2,
-				"links": [
-				],
-				"nullPointMode": "null",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": false,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "(pv_capacity_bytes{job=~\".*$cluster_uuid.*\",openebs_pv=~\"$openebs_volume\"})/(1024*1024*1024)",
-						"format": "time_series",
-						"intervalFactor": 1,
-						"legendFormat": "Total size",
-						"refId": "A"
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "Total capacity",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"format": "decgbytes",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"mappedLabelOnly": false,
-						"max": null,
-						"min": null,
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"mappedLabelOnly": false,
-						"max": null,
-						"min": null,
-						"show": true
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			}
-		],
-		"refresh": "1m",
-		"schemaVersion": 16,
-		"style": "light",
-		"tags": [
-		],
-		"templating": {
-			"list": [
-				{
-					"allValue": null,
-					"current": {
-					},
-					"datasource": "DS_OPENEBS_PROMETHEUS",
-					"hide": 2,
-					"includeAll": false,
-					"label": "cluster",
-					"multi": false,
-					"name": "cluster",
-					"options": [
-					],
-					"query": "label_values(pv_utilization_bytes{openebs_pv=~\"$openebs_volume\"},job)",
-					"refresh": 2,
-					"regex": "/cluster_uuid_(.*)_.*/",
-					"sort": 0,
-					"tagValuesQuery": "",
-					"tags": [
-					],
-					"tagsQuery": "",
-					"type": "query",
-					"useTags": false
-				},
-				{
-					"allValue": null,
-					"current": {
-					},
-					"hide": 2,
-					"includeAll": false,
-					"label": "openebs_volume",
-					"multi": false,
-					"name": "openebs_volume",
-					"options": [
-						{
-							"selected": false,
-							"text": "",
-							"value": ""
-						}
-					],
-					"query": "",
-					"type": "custom"
-				},
-				{
-					"allValue": null,
-					"current": {
-					},
-					"hide": 2,
-					"includeAll": false,
-					"label": "projectid",
-					"multi": false,
-					"name": "projectid",
-					"options": [
-						{
-							"selected": false,
-							"text": "",
-							"value": ""
-						}
-					],
-					"query": "",
-					"type": "custom"
-				},
-				{
-					"allValue": null,
-					"current": {
-					},
-					"hide": 2,
-					"includeAll": false,
-					"label": "groupid",
-					"multi": false,
-					"name": "groupid",
-					"options": [
-						{
-							"selected": false,
-							"text": "",
-							"value": ""
-						}
-					],
-					"query": "",
-					"type": "custom"
-				},
-				{
-					"allValue": null,
-					"current": {
-					},
-					"hide": 2,
-					"includeAll": false,
-					"label": "pvcname",
-					"multi": false,
-					"name": "pvcname",
-					"options": [
-						{
-							"selected": false,
-							"text": "",
-							"value": ""
-						}
-					],
-					"query": "",
-					"type": "custom"
-				},
-				{
-					"allValue": null,
-					"current": {
-					},
-					"hide": 2,
-					"includeAll": false,
-					"label": "cluster_uuid",
-					"multi": false,
-					"name": "cluster_uuid",
-					"options": [
-						{
-							"selected": false,
-							"text": "",
-							"value": ""
-						}
-					],
-					"query": "",
-					"type": "custom"
-				},
-				{
-					"allValue": null,
-					"current": {
-					},
-					"hide": 2,
-					"includeAll": false,
-					"label": "namespace",
-					"multi": false,
-					"name": "namespace",
-					"options": [
-						{
-							"selected": false,
-							"text": "",
-							"value": ""
-						}
-					],
-					"query": "",
-					"type": "custom"
-				},
-				{
-					"allValue": null,
-					"current": {
-					},
-					"hide": 2,
-					"includeAll": false,
-					"label": "storageclass",
-					"multi": false,
-					"name": "storageclass",
-					"options": [
-						{
-							"selected": false,
-							"text": "",
-							"value": ""
-						}
-					],
-					"query": "",
-					"type": "custom"
-				},
-				{
-					"allValue": null,
-					"current": {
-					},
-					"hide": 2,
-					"includeAll": false,
-					"label": "type",
-					"multi": false,
-					"name": "type",
-					"options": [
-						{
-							"selected": false,
-							"text": "",
-							"value": ""
-						}
-					],
-					"query": "",
-					"type": "custom"
-				}
-			]
-		},
-		"time": {
-			"from": "now-1h",
-			"to": "now"
-		},
-		"timepicker": {
-			"refresh_intervals": [
-				"5s",
-				"10s",
-				"30s",
-				"1m",
-				"5m",
-				"15m",
-				"30m",
-				"1h",
-				"2h",
-				"1d"
-			],
-			"time_options": [
-				"5m",
-				"15m",
-				"1h",
-				"6h",
-				"12h",
-				"24h",
-				"2d",
-				"7d",
-				"30d"
-			]
-		},
-		"timezone": "",
-		"title": "LocalPV dashboard",
-		"uid": "2e59785a-af05-465e-b9a3-fca65a0e8572",
-		"version": 5
-	},
-	"overwrite": true
+  "__inputs": [
+    {
+      "name": "DS_OPENEBS_PROMETHEUS",
+      "label": "openebs Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "6.3.0"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "prometheus",
+      "version": "2.11.0"
+    },
+    {
+      "type": "panel",
+      "id": "singlestat",
+      "name": "Singlestat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "text",
+      "name": "Text",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "iteration": 1542985639100,
+  "panels": [
+    {
+      "content": "<html>\n<head>\n\n<script>\nwindow.onload = load('$openebs_volume','$pvcname','$namespace','$storageclass','$type');\n\nfunction getCell(name, value) {\n  return \"<div class=\\\"outlet-header-meta-bar_item\\\"><div class=\\\"outlet-header-meta-bar_title\\\"><span>\"+name+\"</span></div><div class=\\\"outlet-header-meta-bar_value\\\"><span>\"+value+\"</span></div></div>\";\n}\n\nfunction load(volumeStr,pvcNameStr,namespaceStr,storageClassStr,typeStr) {\nvar volumeStr = volumeStr.replace( /[{}]/g, '' );\nvar pvcNameStr = pvcNameStr.replace( /[{}]/g, '' );\nvar namespaceStr = namespaceStr.replace( /[{}]/g, '' );\nvar storageClassStr = storageClassStr.replace( /[{}]/g, '' );\nvar typeStr = typeStr.replace( /[{}]/g, '' );\n// var pools = poolsStr.replace( /[{}]/g, '' );\n// var rc = replicaCount.replace( /[{}]/g, '' );\n// if(!rc) {\n//   rc = \"none\";\n// }\n// var uptimes = uptime.replace( /[{}]/g, '' );\n// if(uptimes) {\n// var seconds = parseInt(uptimes, 10);\n\n// var days = Math.floor(seconds / (3600*24));\n// seconds  -= days*3600*24;\n// var hrs   = Math.floor(seconds / 3600);\n// seconds  -= hrs*3600;\n// var mnts = Math.floor(seconds / 60);\n// seconds  -= mnts*60;\n// uptimes = days+\" days, \"+hrs+\" Hrs, \"+mnts+\" Mins, \"+seconds+\" Secs\";\n// }\n// else {\n//   uptimes = \"No Data\";\n// }\n\n\n\nz=\"\";\nz+=getCell(\"PVC\", pvcNameStr);\nz+=getCell(\"Namespace\", namespaceStr);\nz+=getCell(\"CAS Type\", typeStr);\nz+=getCell(\"Storage Class\", storageClassStr);\n//z+=getCell(\"Name\", volName);\n//z+=getCell(\"Pool Name\", pools);\n//z+=getCell(\"No. of Replicas\", rc);\n//z+=getCell(\"\",\"\")\n\ndocument.getElementById(\"volume-info\").innerHTML = z;\n}\n</script>\n</head>\n\n<body>\n\n<div id=\"volume-info\" class=\"outlet-header-bar\"></div>\n\n</body>\n\n</html>",
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 52,
+      "links": [],
+      "mode": "html",
+      "title": "Volume information",
+      "type": "text"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 3,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 3
+      },
+      "id": 50,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "(pv_utilization_bytes{openebs_pv=~\"$openebs_volume\"})/(1024*1024*1024)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Usage",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Used capacity",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decgbytes",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 3,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 3
+      },
+      "id": 48,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "(pv_capacity_bytes{openebs_pv=~\"$openebs_volume\"})/(1024*1024*1024)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Total size",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Total capacity",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decgbytes",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 16,
+  "style": "light",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {},
+        "hide": 2,
+        "includeAll": false,
+        "label": "openebs_volume",
+        "multi": false,
+        "name": "openebs_volume",
+        "options": [
+          {
+            "selected": false,
+            "text": "",
+            "value": ""
+          }
+        ],
+        "query": "",
+        "type": "custom"
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "hide": 2,
+        "includeAll": false,
+        "label": "pvcname",
+        "multi": false,
+        "name": "pvcname",
+        "options": [
+          {
+            "selected": false,
+            "text": "",
+            "value": ""
+          }
+        ],
+        "query": "",
+        "type": "custom"
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "hide": 2,
+        "includeAll": false,
+        "label": "namespace",
+        "multi": false,
+        "name": "namespace",
+        "options": [
+          {
+            "selected": false,
+            "text": "",
+            "value": ""
+          }
+        ],
+        "query": "",
+        "type": "custom"
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "hide": 2,
+        "includeAll": false,
+        "label": "storageclass",
+        "multi": false,
+        "name": "storageclass",
+        "options": [
+          {
+            "selected": false,
+            "text": "",
+            "value": ""
+          }
+        ],
+        "query": "",
+        "type": "custom"
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "hide": 2,
+        "includeAll": false,
+        "label": "type",
+        "multi": false,
+        "name": "type",
+        "options": [
+          {
+            "selected": false,
+            "text": "",
+            "value": ""
+          }
+        ],
+        "query": "",
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "LocalPV dashboard",
+  "uid": "2e59785a-af05-465e-b9a3-fca65a0e8572",
+  "version": 5
 }

--- a/grafana-charts/localpvdashboard.json
+++ b/grafana-charts/localpvdashboard.json
@@ -1,0 +1,494 @@
+{
+	"dashboard": {
+		"__inputs": [
+			{
+				"name": "DS_OPENEBS_PROMETHEUS",
+				"label": "openebs Prometheus",
+				"description": "",
+				"type": "datasource",
+				"pluginId": "prometheus",
+				"pluginName": "Prometheus"
+			}
+		],
+		"__requires": [
+			{
+				"type": "grafana",
+				"id": "grafana",
+				"name": "Grafana",
+				"version": "5.1.3"
+			},
+			{
+				"type": "panel",
+				"id": "graph",
+				"name": "Graph",
+				"version": ""
+			},
+			{
+				"type": "datasource",
+				"id": "prometheus",
+				"name": "Prometheus",
+				"version": "1.0.0"
+			},
+			{
+				"type": "panel",
+				"id": "singlestat",
+				"name": "Singlestat",
+				"version": ""
+			},
+			{
+				"type": "panel",
+				"id": "text",
+				"name": "Text",
+				"version": ""
+			}
+		],
+		"annotations": {
+			"list": [
+			]
+		},
+		"editable": true,
+		"gnetId": null,
+		"graphTooltip": 0,
+		"id": null,
+		"iteration": 1542985639100,
+		"links": [
+			{
+				"icon": "doc",
+				"includeVars": true,
+				"keepTime": true,
+				"tags": [
+				],
+				"targetBlank": true,
+				"title": "report",
+				"tooltip": "",
+				"type": "link",
+				"url": "${MAYA_URL}/reporter/?dashboard=2e59785a-af05-465e-b9a3-fca65a0e8572"
+			}
+		],
+		"panels": [
+			{
+				"content": "<html>\n<head>\n\n<script>\nwindow.onload = load('$openebs_volume','$cluster','$projectid','$groupid','$pvcname','$namespace','$storageclass','$type');\n\nfunction getCell(name, value) {\n  return \"<div class=\\\"outlet-header-meta-bar_item\\\"><div class=\\\"outlet-header-meta-bar_title\\\"><span>\"+name+\"</span></div><div class=\\\"outlet-header-meta-bar_value\\\"><span>\"+value+\"</span></div></div>\";\n}\n\nfunction load(volumeStr,clusterNameStr,projectIdStr,groupIdStr,pvcNameStr,namespaceStr,storageClassStr,typeStr) {\nvar volumeStr = volumeStr.replace( /[{}]/g, '' );\nvar clusterNameStr = clusterNameStr.replace( /[{}]/g, '' );\nvar projectIdStr = projectIdStr.replace( /[{}]/g, '' );\nvar groupIdStr = groupIdStr.replace( /[{}]/g, '' );\nvar pvcNameStr = pvcNameStr.replace( /[{}]/g, '' );\nvar namespaceStr = namespaceStr.replace( /[{}]/g, '' );\nvar storageClassStr = storageClassStr.replace( /[{}]/g, '' );\nvar typeStr = typeStr.replace( /[{}]/g, '' );\n// var pools = poolsStr.replace( /[{}]/g, '' );\n// var rc = replicaCount.replace( /[{}]/g, '' );\n// if(!rc) {\n//   rc = \"none\";\n// }\n// var uptimes = uptime.replace( /[{}]/g, '' );\n// if(uptimes) {\n// var seconds = parseInt(uptimes, 10);\n\n// var days = Math.floor(seconds / (3600*24));\n// seconds  -= days*3600*24;\n// var hrs   = Math.floor(seconds / 3600);\n// seconds  -= hrs*3600;\n// var mnts = Math.floor(seconds / 60);\n// seconds  -= mnts*60;\n// uptimes = days+\" days, \"+hrs+\" Hrs, \"+mnts+\" Mins, \"+seconds+\" Secs\";\n// }\n// else {\n//   uptimes = \"No Data\";\n// }\n\n\n\nz=\"\";\nz+=getCell(\"PVC\", pvcNameStr);\nz+=getCell(\"Cluster\", clusterNameStr);\nz+=getCell(\"Namespace\", namespaceStr);\nz+=getCell(\"CAS Type\", typeStr);\nz+=getCell(\"Storage Class\", storageClassStr);\n//z+=getCell(\"Name\", volName);\n//z+=getCell(\"Pool Name\", pools);\n//z+=getCell(\"No. of Replicas\", rc);\n//z+=getCell(\"\",\"\")\n\ndocument.getElementById(\"volume-info\").innerHTML = z;\n}\n</script>\n</head>\n\n<body>\n\n<div id=\"volume-info\" class=\"outlet-header-bar\"></div>\n\n</body>\n\n</html>",
+				"gridPos": {
+					"h": 3,
+					"w": 24,
+					"x": 0,
+					"y": 0
+				},
+				"id": 52,
+				"links": [
+				],
+				"mode": "html",
+				"title": "Volume information",
+				"type": "text"
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fill": 3,
+				"gridPos": {
+					"h": 6,
+					"w": 12,
+					"x": 0,
+					"y": 3
+				},
+				"id": 50,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 2,
+				"links": [
+				],
+				"nullPointMode": "null",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "(pv_utilization_bytes{job=~\".*$cluster_uuid.*\",openebs_pv=~\"$openebs_volume\"})/(1024*1024*1024)",
+						"format": "time_series",
+						"intervalFactor": 1,
+						"legendFormat": "Usage",
+						"refId": "A"
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Used capacity",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"format": "decgbytes",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"mappedLabelOnly": false,
+						"max": null,
+						"min": null,
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"mappedLabelOnly": false,
+						"max": null,
+						"min": null,
+						"show": true
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fill": 3,
+				"gridPos": {
+					"h": 6,
+					"w": 12,
+					"x": 12,
+					"y": 3
+				},
+				"id": 48,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 2,
+				"links": [
+				],
+				"nullPointMode": "null",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "(pv_capacity_bytes{job=~\".*$cluster_uuid.*\",openebs_pv=~\"$openebs_volume\"})/(1024*1024*1024)",
+						"format": "time_series",
+						"intervalFactor": 1,
+						"legendFormat": "Total size",
+						"refId": "A"
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Total capacity",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"format": "decgbytes",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"mappedLabelOnly": false,
+						"max": null,
+						"min": null,
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"mappedLabelOnly": false,
+						"max": null,
+						"min": null,
+						"show": true
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			}
+		],
+		"refresh": "1m",
+		"schemaVersion": 16,
+		"style": "light",
+		"tags": [
+		],
+		"templating": {
+			"list": [
+				{
+					"allValue": null,
+					"current": {
+					},
+					"datasource": "DS_OPENEBS_PROMETHEUS",
+					"hide": 2,
+					"includeAll": false,
+					"label": "cluster",
+					"multi": false,
+					"name": "cluster",
+					"options": [
+					],
+					"query": "label_values(pv_utilization_bytes{openebs_pv=~\"$openebs_volume\"},job)",
+					"refresh": 2,
+					"regex": "/cluster_uuid_(.*)_.*/",
+					"sort": 0,
+					"tagValuesQuery": "",
+					"tags": [
+					],
+					"tagsQuery": "",
+					"type": "query",
+					"useTags": false
+				},
+				{
+					"allValue": null,
+					"current": {
+					},
+					"hide": 2,
+					"includeAll": false,
+					"label": "openebs_volume",
+					"multi": false,
+					"name": "openebs_volume",
+					"options": [
+						{
+							"selected": false,
+							"text": "",
+							"value": ""
+						}
+					],
+					"query": "",
+					"type": "custom"
+				},
+				{
+					"allValue": null,
+					"current": {
+					},
+					"hide": 2,
+					"includeAll": false,
+					"label": "projectid",
+					"multi": false,
+					"name": "projectid",
+					"options": [
+						{
+							"selected": false,
+							"text": "",
+							"value": ""
+						}
+					],
+					"query": "",
+					"type": "custom"
+				},
+				{
+					"allValue": null,
+					"current": {
+					},
+					"hide": 2,
+					"includeAll": false,
+					"label": "groupid",
+					"multi": false,
+					"name": "groupid",
+					"options": [
+						{
+							"selected": false,
+							"text": "",
+							"value": ""
+						}
+					],
+					"query": "",
+					"type": "custom"
+				},
+				{
+					"allValue": null,
+					"current": {
+					},
+					"hide": 2,
+					"includeAll": false,
+					"label": "pvcname",
+					"multi": false,
+					"name": "pvcname",
+					"options": [
+						{
+							"selected": false,
+							"text": "",
+							"value": ""
+						}
+					],
+					"query": "",
+					"type": "custom"
+				},
+				{
+					"allValue": null,
+					"current": {
+					},
+					"hide": 2,
+					"includeAll": false,
+					"label": "cluster_uuid",
+					"multi": false,
+					"name": "cluster_uuid",
+					"options": [
+						{
+							"selected": false,
+							"text": "",
+							"value": ""
+						}
+					],
+					"query": "",
+					"type": "custom"
+				},
+				{
+					"allValue": null,
+					"current": {
+					},
+					"hide": 2,
+					"includeAll": false,
+					"label": "namespace",
+					"multi": false,
+					"name": "namespace",
+					"options": [
+						{
+							"selected": false,
+							"text": "",
+							"value": ""
+						}
+					],
+					"query": "",
+					"type": "custom"
+				},
+				{
+					"allValue": null,
+					"current": {
+					},
+					"hide": 2,
+					"includeAll": false,
+					"label": "storageclass",
+					"multi": false,
+					"name": "storageclass",
+					"options": [
+						{
+							"selected": false,
+							"text": "",
+							"value": ""
+						}
+					],
+					"query": "",
+					"type": "custom"
+				},
+				{
+					"allValue": null,
+					"current": {
+					},
+					"hide": 2,
+					"includeAll": false,
+					"label": "type",
+					"multi": false,
+					"name": "type",
+					"options": [
+						{
+							"selected": false,
+							"text": "",
+							"value": ""
+						}
+					],
+					"query": "",
+					"type": "custom"
+				}
+			]
+		},
+		"time": {
+			"from": "now-1h",
+			"to": "now"
+		},
+		"timepicker": {
+			"refresh_intervals": [
+				"5s",
+				"10s",
+				"30s",
+				"1m",
+				"5m",
+				"15m",
+				"30m",
+				"1h",
+				"2h",
+				"1d"
+			],
+			"time_options": [
+				"5m",
+				"15m",
+				"1h",
+				"6h",
+				"12h",
+				"24h",
+				"2d",
+				"7d",
+				"30d"
+			]
+		},
+		"timezone": "",
+		"title": "LocalPV dashboard",
+		"uid": "2e59785a-af05-465e-b9a3-fca65a0e8572",
+		"version": 5
+	},
+	"overwrite": true
+}

--- a/grafana-charts/storageclassvolumedashboard.json
+++ b/grafana-charts/storageclassvolumedashboard.json
@@ -1,1081 +1,981 @@
 {
-	"dashboard": {
-		"__inputs": [
-			{
-				"name": "DS_OPENEBS_PROMETHEUS",
-				"label": "openebs Prometheus",
-				"description": "",
-				"type": "datasource",
-				"pluginId": "prometheus",
-				"pluginName": "Prometheus"
-			}
-		],
-		"__requires": [
-			{
-				"type": "grafana",
-				"id": "grafana",
-				"name": "Grafana",
-				"version": "5.1.3"
-			},
-			{
-				"type": "panel",
-				"id": "graph",
-				"name": "Graph",
-				"version": ""
-			},
-			{
-				"type": "datasource",
-				"id": "prometheus",
-				"name": "Prometheus",
-				"version": "1.0.0"
-			},
-			{
-				"type": "panel",
-				"id": "singlestat",
-				"name": "Singlestat",
-				"version": ""
-			},
-			{
-				"type": "panel",
-				"id": "text",
-				"name": "Text",
-				"version": ""
-			}
-		],
-		"annotations": {
-			"list": [
-			]
-		},
-		"editable": true,
-		"gnetId": null,
-		"graphTooltip": 0,
-		"id": null,
-		"iteration": 1542985639100,
-		"links": [
-		],
-		"panels": [
-			{
-				"aliasColors": {
-				},
-				"breakPoint": "50%",
-				"cacheTimeout": null,
-				"combine": {
-					"label": "Others",
-					"threshold": 0
-				},
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fontSize": "80%",
-				"format": "short",
-				"gridPos": {
-					"h": 9,
-					"w": 12,
-					"x": 0,
-					"y": 0
-				},
-				"id": 32,
-				"interval": null,
-				"legend": {
-					"show": true,
-					"values": true
-				},
-				"legendType": "Under graph",
-				"links": [
-				],
-				"maxDataPoints": 3,
-				"nullPointMode": "connected",
-				"pieType": "pie",
-				"strokeWidth": 1,
-				"targets": [
-					{
-						"expr": "(sum(openebs_size_of_volume{storage_class=~\"$storage_class\",openebs_pv=~\"$openebs_Volume\"}))-(sum(openebs_actual_used{storage_class=~\"$storage_class\",openebs_pv=~\"$openebs_Volume\"}))",
-						"format": "time_series",
-						"intervalFactor": 1,
-						"legendFormat": "Free",
-						"refId": "A"
-					},
-					{
-						"expr": "sum(openebs_actual_used{storage_class=~\"$storage_class\",openebs_pv=~\"$openebs_Volume\"})",
-						"format": "time_series",
-						"intervalFactor": 1,
-						"legendFormat": "Used",
-						"refId": "B"
-					}
-				],
-				"title": "Capacity",
-				"type": "grafana-piechart-panel",
-				"valueName": "current"
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fill": 1,
-				"gridPos": {
-					"h": 9,
-					"w": 12,
-					"x": 12,
-					"y": 0
-				},
-				"id": 24,
-				"legend": {
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"show": true,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 1,
-				"links": [
-				],
-				"nullPointMode": "null",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": false,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "openebs_actual_used{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
-						"format": "time_series",
-						"intervalFactor": 2,
-						"legendFormat": "{{openebs_pvc}}",
-						"refId": "A"
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "Storage Usage",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"format": "decgbytes",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": "0",
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": null,
-						"show": true
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"description": "IOPS",
-				"fill": 1,
-				"gridPos": {
-					"h": 8,
-					"w": 24,
-					"x": 0,
-					"y": 9
-				},
-				"id": 3,
-				"legend": {
-					"alignAsTable": false,
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"rightSide": false,
-					"show": true,
-					"sideWidth": 350,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 1,
-				"links": [
-				],
-				"nullPointMode": "connected",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": true,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "irate(openebs_reads{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])",
-						"format": "time_series",
-						"hide": false,
-						"intervalFactor": 2,
-						"legendFormat": "{{openebs_pvc}}",
-						"refId": "A",
-						"step": 2
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "IOPS(Reads)",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"format": "none",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": "0",
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": null,
-						"show": false
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fill": 1,
-				"gridPos": {
-					"h": 8,
-					"w": 24,
-					"x": 0,
-					"y": 17
-				},
-				"id": 20,
-				"legend": {
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"show": true,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 1,
-				"links": [
-				],
-				"nullPointMode": "null",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": false,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "irate(openebs_writes{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])",
-						"format": "time_series",
-						"intervalFactor": 2,
-						"legendFormat": "{{openebs_pvc}}",
-						"refId": "A"
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "IOPS(Writes)",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"format": "none",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": "0",
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": null,
-						"show": false
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"description": "Throughput",
-				"fill": 1,
-				"gridPos": {
-					"h": 8,
-					"w": 24,
-					"x": 0,
-					"y": 25
-				},
-				"id": 9,
-				"legend": {
-					"alignAsTable": false,
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"rightSide": false,
-					"show": true,
-					"sideWidth": 350,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 1,
-				"links": [
-				],
-				"nullPointMode": "connected",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": true,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "irate(openebs_read_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])/(2048)",
-						"format": "time_series",
-						"hide": false,
-						"intervalFactor": 2,
-						"legendFormat": "{{openebs_pvc}}",
-						"refId": "A",
-						"step": 2
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "Throughput(Reads)",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"format": "MBs",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": "0",
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": null,
-						"show": false
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fill": 1,
-				"gridPos": {
-					"h": 8,
-					"w": 24,
-					"x": 0,
-					"y": 33
-				},
-				"id": 19,
-				"legend": {
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"show": true,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 1,
-				"links": [
-				],
-				"nullPointMode": "null",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": false,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "irate(openebs_write_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])/(2048)",
-						"format": "time_series",
-						"intervalFactor": 2,
-						"legendFormat": "{{openebs_pvc}}",
-						"refId": "A"
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "Throughput(Writes)",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"format": "MBs",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": "0",
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": null,
-						"show": false
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"description": "Latency",
-				"fill": 1,
-				"gridPos": {
-					"h": 8,
-					"w": 24,
-					"x": 0,
-					"y": 41
-				},
-				"id": 5,
-				"legend": {
-					"alignAsTable": false,
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"rightSide": false,
-					"show": true,
-					"sideWidth": 350,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 1,
-				"links": [
-				],
-				"nullPointMode": "null as zero",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": true,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "((irate(openebs_read_time{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m]))/(irate(openebs_reads{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])))/1000000",
-						"format": "time_series",
-						"hide": false,
-						"intervalFactor": 2,
-						"legendFormat": "{{openebs_pvc}}",
-						"refId": "A",
-						"step": 2
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "Latency(Reads)",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"format": "ms",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": "0",
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": null,
-						"show": false
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fill": 1,
-				"gridPos": {
-					"h": 8,
-					"w": 24,
-					"x": 0,
-					"y": 49
-				},
-				"id": 18,
-				"legend": {
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"show": true,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 1,
-				"links": [
-				],
-				"nullPointMode": "null as zero",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": false,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "((irate(openebs_write_time{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m]))/(irate(openebs_writes{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])))/1000000",
-						"format": "time_series",
-						"intervalFactor": 2,
-						"legendFormat": "{{openebs_pvc}}",
-						"refId": "A"
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "Latency(Writes)",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"format": "ms",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": "0",
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": null,
-						"show": false
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fill": 1,
-				"gridPos": {
-					"h": 8,
-					"w": 24,
-					"x": 0,
-					"y": 57
-				},
-				"id": 25,
-				"legend": {
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"show": true,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 1,
-				"links": [
-				],
-				"nullPointMode": "null as zero",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": false,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "(irate(openebs_read_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])/(1024))*512/(irate(openebs_reads{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m]))",
-						"format": "time_series",
-						"hide": false,
-						"intervalFactor": 2,
-						"legendFormat": "{{openebs_pvc}}",
-						"refId": "A"
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "Block Size(Reads)",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"format": "deckbytes",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": "0",
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": null,
-						"show": false
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fill": 1,
-				"gridPos": {
-					"h": 8,
-					"w": 24,
-					"x": 0,
-					"y": 65
-				},
-				"id": 27,
-				"legend": {
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"show": true,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 1,
-				"links": [
-				],
-				"nullPointMode": "null as zero",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": false,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "(irate(openebs_write_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])/(1024))*512/(irate(openebs_writes{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m]))",
-						"format": "time_series",
-						"hide": false,
-						"intervalFactor": 2,
-						"legendFormat": "{{openebs_pvc}}",
-						"refId": "A"
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "Block Size(Writes)",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"format": "deckbytes",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": "0",
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": null,
-						"show": false
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			}
-		],
-		"refresh": "1m",
-		"schemaVersion": 16,
-		"style": "light",
-		"tags": [
-		],
-		"templating": {
-			"list": [
-				{
-					"allValue": null,
-					"current": {
-					},
-					"datasource": "DS_OPENEBS_PROMETHEUS",
-					"hide": 0,
-					"includeAll": false,
-					"label": "Storage class",
-					"multi": false,
-					"name": "storage_class",
-					"options": [
-					],
-					"query": "label_values(openebs_size_of_volume,storage_class)",
-					"refresh": 2,
-					"regex": "",
-					"sort": 0,
-					"tagValuesQuery": "",
-					"tags": [
-					],
-					"tagsQuery": "",
-					"type": "query",
-					"useTags": false
-				},
-				{
-					"allValue": null,
-					"current": {
-					},
-					"datasource": "DS_OPENEBS_PROMETHEUS",
-					"hide": 2,
-					"includeAll": true,
-					"label": "Volume",
-					"multi": true,
-					"name": "openebs_Volume",
-					"options": [
-					],
-					"query": "label_values(openebs_size_of_volume{storage_class=~\"$storage_class\"},openebs_pv)",
-					"refresh": 2,
-					"regex": "",
-					"sort": 0,
-					"tagValuesQuery": "",
-					"tags": [
-					],
-					"tagsQuery": "",
-					"type": "query",
-					"useTags": false
-				},
-				{
-					"allValue": null,
-					"current": {
-					},
-					"datasource": "DS_OPENEBS_PROMETHEUS",
-					"hide": 0,
-					"includeAll": true,
-					"label": "OpenEBS pvc",
-					"multi": true,
-					"name": "openebs_pvc",
-					"options": [
-					],
-					"query": "label_values(openebs_size_of_volume{storage_class=~\"$storage_class\",openebs_pv=~\"$openebs_Volume\"},openebs_pvc)",
-					"refresh": 2,
-					"regex": "",
-					"sort": 0,
-					"tagValuesQuery": "",
-					"tags": [
-					],
-					"tagsQuery": "",
-					"type": "query",
-					"useTags": false
-				},
-				{
-					"allValue": null,
-					"current": {
-					},
-					"hide": 2,
-					"includeAll": false,
-					"label": "projectid",
-					"multi": false,
-					"name": "projectid",
-					"options": [
-						{
-							"selected": false,
-							"text": "",
-							"value": ""
-						}
-					],
-					"query": "",
-					"type": "custom"
-				},
-				{
-					"allValue": null,
-					"current": {
-					},
-					"hide": 2,
-					"includeAll": false,
-					"label": "groupid",
-					"multi": false,
-					"name": "groupid",
-					"options": [
-						{
-							"selected": false,
-							"text": "",
-							"value": ""
-						}
-					],
-					"query": "",
-					"type": "custom"
-				}
-			]
-		},
-		"time": {
-			"from": "now-1h",
-			"to": "now"
-		},
-		"timepicker": {
-			"refresh_intervals": [
-				"5s",
-				"10s",
-				"30s",
-				"1m",
-				"5m",
-				"15m",
-				"30m",
-				"1h",
-				"2h",
-				"1d"
-			],
-			"time_options": [
-				"5m",
-				"15m",
-				"1h",
-				"6h",
-				"12h",
-				"24h",
-				"2d",
-				"7d",
-				"30d"
-			]
-		},
-		"timezone": "",
-		"title": "Storage class volume dashboard",
-		"uid": "2795676f-d98f-4ba5-b424-b8b0e98ad7bd",
-		"version": 2
-	},
-	"overwrite": true
+  "__inputs": [
+    {
+      "name": "DS_OPENEBS_PROMETHEUS",
+      "label": "openebs Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "5.1.3"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "singlestat",
+      "name": "Singlestat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "text",
+      "name": "Text",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "iteration": 1542985639100,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "breakPoint": "50%",
+      "cacheTimeout": null,
+      "combine": {
+        "label": "Others",
+        "threshold": 0
+      },
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fontSize": "80%",
+      "format": "short",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 32,
+      "interval": null,
+      "legend": {
+        "show": true,
+        "values": true
+      },
+      "legendType": "Under graph",
+      "links": [],
+      "maxDataPoints": 3,
+      "nullPointMode": "connected",
+      "pieType": "pie",
+      "strokeWidth": 1,
+      "targets": [
+        {
+          "expr": "(sum(openebs_size_of_volume{storage_class=~\"$storage_class\",openebs_pv=~\"$openebs_Volume\"}))-(sum(openebs_actual_used{storage_class=~\"$storage_class\",openebs_pv=~\"$openebs_Volume\"}))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Free",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(openebs_actual_used{storage_class=~\"$storage_class\",openebs_pv=~\"$openebs_Volume\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Used",
+          "refId": "B"
+        }
+      ],
+      "title": "Capacity",
+      "type": "grafana-piechart-panel",
+      "valueName": "current"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 24,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "openebs_actual_used{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{openebs_pvc}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Storage Usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decgbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "description": "IOPS",
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 3,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": 350,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "irate(openebs_reads{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{openebs_pvc}}",
+          "refId": "A",
+          "step": 2
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "IOPS(Reads)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 20,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "irate(openebs_writes{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{openebs_pvc}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "IOPS(Writes)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "description": "Throughput",
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 25
+      },
+      "id": 9,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": 350,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "irate(openebs_read_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])/(2048)",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{openebs_pvc}}",
+          "refId": "A",
+          "step": 2
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Throughput(Reads)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "MBs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 33
+      },
+      "id": 19,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "irate(openebs_write_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])/(2048)",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{openebs_pvc}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Throughput(Writes)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "MBs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "description": "Latency",
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 41
+      },
+      "id": 5,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": 350,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "((irate(openebs_read_time{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m]))/(irate(openebs_reads{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])))/1000000",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{openebs_pvc}}",
+          "refId": "A",
+          "step": 2
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Latency(Reads)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 49
+      },
+      "id": 18,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "((irate(openebs_write_time{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m]))/(irate(openebs_writes{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])))/1000000",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{openebs_pvc}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Latency(Writes)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 57
+      },
+      "id": 25,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "(irate(openebs_read_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])/(1024))*512/(irate(openebs_reads{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m]))",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{openebs_pvc}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Block Size(Reads)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "deckbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 65
+      },
+      "id": 27,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "(irate(openebs_write_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])/(1024))*512/(irate(openebs_writes{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m]))",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{openebs_pvc}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Block Size(Writes)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "deckbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 16,
+  "style": "light",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "DS_OPENEBS_PROMETHEUS",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Storage class",
+        "multi": false,
+        "name": "storage_class",
+        "options": [],
+        "query": "label_values(openebs_size_of_volume, storage_class)",
+        "refresh": 2,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "DS_OPENEBS_PROMETHEUS",
+        "hide": 2,
+        "includeAll": true,
+        "label": "Volume",
+        "multi": true,
+        "name": "openebs_Volume",
+        "options": [],
+        "query": "label_values(openebs_size_of_volume{storage_class=~\"$storage_class\"},openebs_pv)",
+        "refresh": 2,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "DS_OPENEBS_PROMETHEUS",
+        "hide": 0,
+        "includeAll": true,
+        "label": "OpenEBS pvc",
+        "multi": true,
+        "name": "openebs_pvc",
+        "options": [],
+        "query": "label_values(openebs_size_of_volume{storage_class=~\"$storage_class\",openebs_pv=~\"$openebs_Volume\"},openebs_pvc)",
+        "refresh": 2,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Storage class volume dashboard",
+  "uid": "2795676f-d98f-4ba5-b424-b8b0e98ad7bd",
+  "version": 2
 }

--- a/grafana-charts/storageclassvolumedashboard.json
+++ b/grafana-charts/storageclassvolumedashboard.json
@@ -1,0 +1,1081 @@
+{
+	"dashboard": {
+		"__inputs": [
+			{
+				"name": "DS_OPENEBS_PROMETHEUS",
+				"label": "openebs Prometheus",
+				"description": "",
+				"type": "datasource",
+				"pluginId": "prometheus",
+				"pluginName": "Prometheus"
+			}
+		],
+		"__requires": [
+			{
+				"type": "grafana",
+				"id": "grafana",
+				"name": "Grafana",
+				"version": "5.1.3"
+			},
+			{
+				"type": "panel",
+				"id": "graph",
+				"name": "Graph",
+				"version": ""
+			},
+			{
+				"type": "datasource",
+				"id": "prometheus",
+				"name": "Prometheus",
+				"version": "1.0.0"
+			},
+			{
+				"type": "panel",
+				"id": "singlestat",
+				"name": "Singlestat",
+				"version": ""
+			},
+			{
+				"type": "panel",
+				"id": "text",
+				"name": "Text",
+				"version": ""
+			}
+		],
+		"annotations": {
+			"list": [
+			]
+		},
+		"editable": true,
+		"gnetId": null,
+		"graphTooltip": 0,
+		"id": null,
+		"iteration": 1542985639100,
+		"links": [
+		],
+		"panels": [
+			{
+				"aliasColors": {
+				},
+				"breakPoint": "50%",
+				"cacheTimeout": null,
+				"combine": {
+					"label": "Others",
+					"threshold": 0
+				},
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fontSize": "80%",
+				"format": "short",
+				"gridPos": {
+					"h": 9,
+					"w": 12,
+					"x": 0,
+					"y": 0
+				},
+				"id": 32,
+				"interval": null,
+				"legend": {
+					"show": true,
+					"values": true
+				},
+				"legendType": "Under graph",
+				"links": [
+				],
+				"maxDataPoints": 3,
+				"nullPointMode": "connected",
+				"pieType": "pie",
+				"strokeWidth": 1,
+				"targets": [
+					{
+						"expr": "(sum(openebs_size_of_volume{storage_class=~\"$storage_class\",openebs_pv=~\"$openebs_Volume\"}))-(sum(openebs_actual_used{storage_class=~\"$storage_class\",openebs_pv=~\"$openebs_Volume\"}))",
+						"format": "time_series",
+						"intervalFactor": 1,
+						"legendFormat": "Free",
+						"refId": "A"
+					},
+					{
+						"expr": "sum(openebs_actual_used{storage_class=~\"$storage_class\",openebs_pv=~\"$openebs_Volume\"})",
+						"format": "time_series",
+						"intervalFactor": 1,
+						"legendFormat": "Used",
+						"refId": "B"
+					}
+				],
+				"title": "Capacity",
+				"type": "grafana-piechart-panel",
+				"valueName": "current"
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fill": 1,
+				"gridPos": {
+					"h": 9,
+					"w": 12,
+					"x": 12,
+					"y": 0
+				},
+				"id": 24,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 1,
+				"links": [
+				],
+				"nullPointMode": "null",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "openebs_actual_used{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
+						"format": "time_series",
+						"intervalFactor": 2,
+						"legendFormat": "{{openebs_pvc}}",
+						"refId": "A"
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Storage Usage",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"format": "decgbytes",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": "0",
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": null,
+						"show": true
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"description": "IOPS",
+				"fill": 1,
+				"gridPos": {
+					"h": 8,
+					"w": 24,
+					"x": 0,
+					"y": 9
+				},
+				"id": 3,
+				"legend": {
+					"alignAsTable": false,
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"rightSide": false,
+					"show": true,
+					"sideWidth": 350,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 1,
+				"links": [
+				],
+				"nullPointMode": "connected",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": true,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "irate(openebs_reads{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])",
+						"format": "time_series",
+						"hide": false,
+						"intervalFactor": 2,
+						"legendFormat": "{{openebs_pvc}}",
+						"refId": "A",
+						"step": 2
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "IOPS(Reads)",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"format": "none",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": "0",
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": null,
+						"show": false
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fill": 1,
+				"gridPos": {
+					"h": 8,
+					"w": 24,
+					"x": 0,
+					"y": 17
+				},
+				"id": 20,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 1,
+				"links": [
+				],
+				"nullPointMode": "null",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "irate(openebs_writes{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])",
+						"format": "time_series",
+						"intervalFactor": 2,
+						"legendFormat": "{{openebs_pvc}}",
+						"refId": "A"
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "IOPS(Writes)",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"format": "none",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": "0",
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": null,
+						"show": false
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"description": "Throughput",
+				"fill": 1,
+				"gridPos": {
+					"h": 8,
+					"w": 24,
+					"x": 0,
+					"y": 25
+				},
+				"id": 9,
+				"legend": {
+					"alignAsTable": false,
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"rightSide": false,
+					"show": true,
+					"sideWidth": 350,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 1,
+				"links": [
+				],
+				"nullPointMode": "connected",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": true,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "irate(openebs_read_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])/(2048)",
+						"format": "time_series",
+						"hide": false,
+						"intervalFactor": 2,
+						"legendFormat": "{{openebs_pvc}}",
+						"refId": "A",
+						"step": 2
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Throughput(Reads)",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"format": "MBs",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": "0",
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": null,
+						"show": false
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fill": 1,
+				"gridPos": {
+					"h": 8,
+					"w": 24,
+					"x": 0,
+					"y": 33
+				},
+				"id": 19,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 1,
+				"links": [
+				],
+				"nullPointMode": "null",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "irate(openebs_write_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])/(2048)",
+						"format": "time_series",
+						"intervalFactor": 2,
+						"legendFormat": "{{openebs_pvc}}",
+						"refId": "A"
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Throughput(Writes)",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"format": "MBs",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": "0",
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": null,
+						"show": false
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"description": "Latency",
+				"fill": 1,
+				"gridPos": {
+					"h": 8,
+					"w": 24,
+					"x": 0,
+					"y": 41
+				},
+				"id": 5,
+				"legend": {
+					"alignAsTable": false,
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"rightSide": false,
+					"show": true,
+					"sideWidth": 350,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 1,
+				"links": [
+				],
+				"nullPointMode": "null as zero",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": true,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "((irate(openebs_read_time{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m]))/(irate(openebs_reads{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])))/1000000",
+						"format": "time_series",
+						"hide": false,
+						"intervalFactor": 2,
+						"legendFormat": "{{openebs_pvc}}",
+						"refId": "A",
+						"step": 2
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Latency(Reads)",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"format": "ms",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": "0",
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": null,
+						"show": false
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fill": 1,
+				"gridPos": {
+					"h": 8,
+					"w": 24,
+					"x": 0,
+					"y": 49
+				},
+				"id": 18,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 1,
+				"links": [
+				],
+				"nullPointMode": "null as zero",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "((irate(openebs_write_time{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m]))/(irate(openebs_writes{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])))/1000000",
+						"format": "time_series",
+						"intervalFactor": 2,
+						"legendFormat": "{{openebs_pvc}}",
+						"refId": "A"
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Latency(Writes)",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"format": "ms",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": "0",
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": null,
+						"show": false
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fill": 1,
+				"gridPos": {
+					"h": 8,
+					"w": 24,
+					"x": 0,
+					"y": 57
+				},
+				"id": 25,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 1,
+				"links": [
+				],
+				"nullPointMode": "null as zero",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "(irate(openebs_read_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])/(1024))*512/(irate(openebs_reads{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m]))",
+						"format": "time_series",
+						"hide": false,
+						"intervalFactor": 2,
+						"legendFormat": "{{openebs_pvc}}",
+						"refId": "A"
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Block Size(Reads)",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"format": "deckbytes",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": "0",
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": null,
+						"show": false
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fill": 1,
+				"gridPos": {
+					"h": 8,
+					"w": 24,
+					"x": 0,
+					"y": 65
+				},
+				"id": 27,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 1,
+				"links": [
+				],
+				"nullPointMode": "null as zero",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "(irate(openebs_write_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])/(1024))*512/(irate(openebs_writes{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m]))",
+						"format": "time_series",
+						"hide": false,
+						"intervalFactor": 2,
+						"legendFormat": "{{openebs_pvc}}",
+						"refId": "A"
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Block Size(Writes)",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"format": "deckbytes",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": "0",
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": null,
+						"show": false
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			}
+		],
+		"refresh": "1m",
+		"schemaVersion": 16,
+		"style": "light",
+		"tags": [
+		],
+		"templating": {
+			"list": [
+				{
+					"allValue": null,
+					"current": {
+					},
+					"datasource": "DS_OPENEBS_PROMETHEUS",
+					"hide": 0,
+					"includeAll": false,
+					"label": "Storage class",
+					"multi": false,
+					"name": "storage_class",
+					"options": [
+					],
+					"query": "label_values(openebs_size_of_volume,storage_class)",
+					"refresh": 2,
+					"regex": "",
+					"sort": 0,
+					"tagValuesQuery": "",
+					"tags": [
+					],
+					"tagsQuery": "",
+					"type": "query",
+					"useTags": false
+				},
+				{
+					"allValue": null,
+					"current": {
+					},
+					"datasource": "DS_OPENEBS_PROMETHEUS",
+					"hide": 2,
+					"includeAll": true,
+					"label": "Volume",
+					"multi": true,
+					"name": "openebs_Volume",
+					"options": [
+					],
+					"query": "label_values(openebs_size_of_volume{storage_class=~\"$storage_class\"},openebs_pv)",
+					"refresh": 2,
+					"regex": "",
+					"sort": 0,
+					"tagValuesQuery": "",
+					"tags": [
+					],
+					"tagsQuery": "",
+					"type": "query",
+					"useTags": false
+				},
+				{
+					"allValue": null,
+					"current": {
+					},
+					"datasource": "DS_OPENEBS_PROMETHEUS",
+					"hide": 0,
+					"includeAll": true,
+					"label": "OpenEBS pvc",
+					"multi": true,
+					"name": "openebs_pvc",
+					"options": [
+					],
+					"query": "label_values(openebs_size_of_volume{storage_class=~\"$storage_class\",openebs_pv=~\"$openebs_Volume\"},openebs_pvc)",
+					"refresh": 2,
+					"regex": "",
+					"sort": 0,
+					"tagValuesQuery": "",
+					"tags": [
+					],
+					"tagsQuery": "",
+					"type": "query",
+					"useTags": false
+				},
+				{
+					"allValue": null,
+					"current": {
+					},
+					"hide": 2,
+					"includeAll": false,
+					"label": "projectid",
+					"multi": false,
+					"name": "projectid",
+					"options": [
+						{
+							"selected": false,
+							"text": "",
+							"value": ""
+						}
+					],
+					"query": "",
+					"type": "custom"
+				},
+				{
+					"allValue": null,
+					"current": {
+					},
+					"hide": 2,
+					"includeAll": false,
+					"label": "groupid",
+					"multi": false,
+					"name": "groupid",
+					"options": [
+						{
+							"selected": false,
+							"text": "",
+							"value": ""
+						}
+					],
+					"query": "",
+					"type": "custom"
+				}
+			]
+		},
+		"time": {
+			"from": "now-1h",
+			"to": "now"
+		},
+		"timepicker": {
+			"refresh_intervals": [
+				"5s",
+				"10s",
+				"30s",
+				"1m",
+				"5m",
+				"15m",
+				"30m",
+				"1h",
+				"2h",
+				"1d"
+			],
+			"time_options": [
+				"5m",
+				"15m",
+				"1h",
+				"6h",
+				"12h",
+				"24h",
+				"2d",
+				"7d",
+				"30d"
+			]
+		},
+		"timezone": "",
+		"title": "Storage class volume dashboard",
+		"uid": "2795676f-d98f-4ba5-b424-b8b0e98ad7bd",
+		"version": 2
+	},
+	"overwrite": true
+}

--- a/grafana-charts/storagepoolclaimdashboard.json
+++ b/grafana-charts/storagepoolclaimdashboard.json
@@ -1,805 +1,714 @@
 {
-	"dashboard": {
-		"__inputs": [
-			{
-				"name": "DS_OPENEBS_PROMETHEUS",
-				"label": "openebs Prometheus",
-				"description": "",
-				"type": "datasource",
-				"pluginId": "prometheus",
-				"pluginName": "Prometheus"
-			}
-		],
-		"__requires": [
-			{
-				"type": "grafana",
-				"id": "grafana",
-				"name": "Grafana",
-				"version": "5.1.3"
-			},
-			{
-				"type": "panel",
-				"id": "graph",
-				"name": "Graph",
-				"version": ""
-			},
-			{
-				"type": "datasource",
-				"id": "prometheus",
-				"name": "Prometheus",
-				"version": "1.0.0"
-			},
-			{
-				"type": "panel",
-				"id": "singlestat",
-				"name": "Singlestat",
-				"version": ""
-			},
-			{
-				"type": "panel",
-				"id": "text",
-				"name": "Text",
-				"version": ""
-			}
-		],
-		"annotations": {
-			"list": [
-			]
-		},
-		"editable": true,
-		"gnetId": null,
-		"graphTooltip": 0,
-		"id": null,
-		"iteration": 1542963642391,
-		"links": [
-			{
-				"icon": "doc",
-				"includeVars": true,
-				"keepTime": true,
-				"tags": [
-				],
-				"targetBlank": true,
-				"title": "report",
-				"tooltip": "",
-				"type": "link",
-				"url": "${MAYA_URL}/reporter/?dashboard=23c14553-6c62-41b6-9eb3-c0e75531e617"
-			}
-		],
-		"panels": [
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fill": 1,
-				"gridPos": {
-					"h": 6,
-					"w": 12,
-					"x": 0,
-					"y": 0
-				},
-				"id": 4,
-				"legend": {
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"show": true,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 2,
-				"links": [
-				],
-				"nullPointMode": "null",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": false,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "openebs_pool_status{cstor_pool=~\"$Pool\"}",
-						"format": "time_series",
-						"intervalFactor": 1,
-						"legendFormat": "{{cstor_pool}}",
-						"refId": "A"
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "Pool status",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"decimals": 0,
-						"format": "none",
-						"label": null,
-						"labelMappings": [
-							{
-								"label": "Offline",
-								"value": 0
-							},
-							{
-								"label": "Online",
-								"value": 1
-							},
-							{
-								"label": "Degraded",
-								"value": 2
-							},
-							{
-								"label": "Faulted",
-								"value": 3
-							},
-							{
-								"label": "Removed",
-								"value": 4
-							},
-							{
-								"label": "Unavail",
-								"value": 5
-							},
-							{
-								"label": "NoPoolsAvailable",
-								"value": 6
-							}
-						],
-						"logBase": 1,
-						"mappedLabelOnly": true,
-						"max": null,
-						"min": null,
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"mappedLabelOnly": false,
-						"max": null,
-						"min": null,
-						"show": true
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fill": 1,
-				"gridPos": {
-					"h": 6,
-					"w": 12,
-					"x": 12,
-					"y": 0
-				},
-				"id": 48,
-				"legend": {
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"show": true,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 2,
-				"links": [
-				],
-				"nullPointMode": "null",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": false,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "openebs_pool_size{cstor_pool=~\"$Pool\"}/(1024*1024*1024)",
-						"format": "time_series",
-						"intervalFactor": 1,
-						"legendFormat": "{{cstor_pool}}",
-						"refId": "A"
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "Size of  pool",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"format": "decgbytes",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"mappedLabelOnly": false,
-						"max": null,
-						"min": null,
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"mappedLabelOnly": false,
-						"max": null,
-						"min": null,
-						"show": true
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fill": 1,
-				"gridPos": {
-					"h": 6,
-					"w": 12,
-					"x": 0,
-					"y": 6
-				},
-				"id": 50,
-				"legend": {
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"show": true,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 2,
-				"links": [
-				],
-				"nullPointMode": "null",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": false,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "(openebs_used_pool_capacity{cstor_pool=~\"$Pool\"})/(1024*1024*1024)",
-						"format": "time_series",
-						"intervalFactor": 1,
-						"legendFormat": "{{cstor_pool}}",
-						"refId": "A"
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "Used pool capacity",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"format": "decgbytes",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"mappedLabelOnly": false,
-						"max": null,
-						"min": null,
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"mappedLabelOnly": false,
-						"max": null,
-						"min": null,
-						"show": true
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fill": 1,
-				"gridPos": {
-					"h": 6,
-					"w": 12,
-					"x": 12,
-					"y": 6
-				},
-				"id": 52,
-				"legend": {
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"show": true,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 2,
-				"links": [
-				],
-				"nullPointMode": "null",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": false,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "(openebs_free_pool_capacity{cstor_pool=~\"$Pool\"})/(1024*1024*1024)",
-						"format": "time_series",
-						"intervalFactor": 1,
-						"legendFormat": "{{cstor_pool}}",
-						"refId": "A"
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "Free pool capacity",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"format": "decgbytes",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"mappedLabelOnly": false,
-						"max": null,
-						"min": null,
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"mappedLabelOnly": false,
-						"max": null,
-						"min": null,
-						"show": true
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fill": 1,
-				"gridPos": {
-					"h": 6,
-					"w": 12,
-					"x": 0,
-					"y": 12
-				},
-				"id": 54,
-				"legend": {
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"show": true,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 2,
-				"links": [
-				],
-				"nullPointMode": "null",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": false,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "sum(openebs_total_read_count{cstor_pool=~\"$Pool\"}) by (cstor_pool)",
-						"format": "time_series",
-						"intervalFactor": 1,
-						"legendFormat": "{{cstor_pool}}",
-						"refId": "A"
-					},
-					{
-						"expr": "",
-						"format": "time_series",
-						"intervalFactor": 1,
-						"legendFormat": "write iops",
-						"refId": "B"
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "Read IOPS",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"decimals": null,
-						"format": "short",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"mappedLabelOnly": false,
-						"max": null,
-						"min": null,
-						"show": true
-					},
-					{
-						"decimals": null,
-						"format": "short",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"mappedLabelOnly": false,
-						"max": null,
-						"min": null,
-						"show": true
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fill": 1,
-				"gridPos": {
-					"h": 6,
-					"w": 12,
-					"x": 12,
-					"y": 12
-				},
-				"id": 56,
-				"legend": {
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"show": true,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 2,
-				"links": [
-				],
-				"nullPointMode": "null",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": false,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "sum(openebs_total_write_count{cstor_pool=~\"$Pool\"}) by (cstor_pool)",
-						"format": "time_series",
-						"intervalFactor": 1,
-						"legendFormat": "{{cstor_pool}}",
-						"refId": "A"
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "Write IOPS",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"format": "short",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"mappedLabelOnly": false,
-						"max": null,
-						"min": null,
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"mappedLabelOnly": false,
-						"max": null,
-						"min": null,
-						"show": true
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			}
-		],
-		"schemaVersion": 16,
-		"style": "light",
-		"tags": [
-		],
-		"templating": {
-			"list": [
-				{
-					"allValue": null,
-					"current": {
-					},
-					"datasource": "DS_OPENEBS_PROMETHEUS",
-					"hide": 0,
-					"includeAll": false,
-					"label": "Storage pool",
-					"multi": false,
-					"name": "spc",
-					"options": [
-					],
-					"query": "label_values(openebs_pool_status,storage_pool_claim)",
-					"refresh": 2,
-					"regex": "",
-					"sort": 0,
-					"tagValuesQuery": "",
-					"tags": [
-					],
-					"tagsQuery": "",
-					"type": "query",
-					"useTags": false
-				},
-				{
-					"allValue": null,
-					"current": {
-					},
-					"datasource": "DS_OPENEBS_PROMETHEUS",
-					"hide": 0,
-					"includeAll": false,
-					"label": "Pool",
-					"multi": true,
-					"name": "Pool",
-					"options": [
-					],
-					"query": "label_values(openebs_pool_status{storage_pool_claim=~\"$spc\"},cstor_pool)",
-					"refresh": 2,
-					"regex": "",
-					"sort": 0,
-					"tagValuesQuery": "",
-					"tags": [
-					],
-					"tagsQuery": "",
-					"type": "query",
-					"useTags": false
-				},
-				{
-					"allValue": null,
-					"current": {
-					},
-					"hide": 2,
-					"includeAll": false,
-					"label": "projectid",
-					"multi": false,
-					"name": "projectid",
-					"options": [
-						{
-							"selected": false,
-							"text": "",
-							"value": ""
-						}
-					],
-					"query": "",
-					"type": "custom"
-				},
-				{
-					"allValue": null,
-					"current": {
-					},
-					"hide": 2,
-					"includeAll": false,
-					"label": "groupid",
-					"multi": false,
-					"name": "groupid",
-					"options": [
-						{
-							"selected": false,
-							"text": "",
-							"value": ""
-						}
-					],
-					"query": "",
-					"type": "custom"
-				}
-			]
-		},
-		"time": {
-			"from": "now-1h",
-			"to": "now"
-		},
-		"timepicker": {
-			"refresh_intervals": [
-				"5s",
-				"10s",
-				"30s",
-				"1m",
-				"5m",
-				"15m",
-				"30m",
-				"1h",
-				"2h",
-				"1d"
-			],
-			"time_options": [
-				"5m",
-				"15m",
-				"1h",
-				"6h",
-				"12h",
-				"24h",
-				"2d",
-				"7d",
-				"30d"
-			]
-		},
-		"timezone": "",
-		"title": "Storage pool claim dashboard",
-		"uid": "23c14553-6c62-41b6-9eb3-c0e75531e617",
-		"version": 3
-	},
-	"overwrite": true
+  "__inputs": [
+    {
+      "name": "DS_OPENEBS_PROMETHEUS",
+      "label": "openebs Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "5.1.3"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "singlestat",
+      "name": "Singlestat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "text",
+      "name": "Text",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "iteration": 1542963642391,
+  "links": [
+    {
+      "icon": "doc",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": true,
+      "title": "report",
+      "tooltip": "",
+      "type": "link",
+      "url": "${MAYA_URL}/reporter/?dashboard=23c14553-6c62-41b6-9eb3-c0e75531e617"
+    }
+  ],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 1,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 4,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "openebs_pool_status{cstor_pool=~\"$Pool\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{cstor_pool}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Pool status",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "none",
+          "label": null,
+          "labelMappings": [
+            {
+              "label": "Offline",
+              "value": 0
+            },
+            {
+              "label": "Online",
+              "value": 1
+            },
+            {
+              "label": "Degraded",
+              "value": 2
+            },
+            {
+              "label": "Faulted",
+              "value": 3
+            },
+            {
+              "label": "Removed",
+              "value": 4
+            },
+            {
+              "label": "Unavail",
+              "value": 5
+            },
+            {
+              "label": "NoPoolsAvailable",
+              "value": 6
+            }
+          ],
+          "logBase": 1,
+          "mappedLabelOnly": true,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 1,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 48,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "openebs_pool_size{cstor_pool=~\"$Pool\"}/(1024*1024*1024)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{cstor_pool}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Size of  pool",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decgbytes",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 1,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "id": 50,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "(openebs_used_pool_capacity{cstor_pool=~\"$Pool\"})/(1024*1024*1024)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{cstor_pool}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Used pool capacity",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decgbytes",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 1,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "id": 52,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "(openebs_free_pool_capacity{cstor_pool=~\"$Pool\"})/(1024*1024*1024)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{cstor_pool}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Free pool capacity",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decgbytes",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 1,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "id": 54,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(openebs_total_read_count{cstor_pool=~\"$Pool\"}) by (cstor_pool)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{cstor_pool}}",
+          "refId": "A"
+        },
+        {
+          "expr": "",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "write iops",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Read IOPS",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "decimals": null,
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 1,
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "id": 56,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(openebs_total_write_count{cstor_pool=~\"$Pool\"}) by (cstor_pool)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{cstor_pool}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Write IOPS",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "schemaVersion": 16,
+  "style": "light",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "DS_OPENEBS_PROMETHEUS",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Storage pool",
+        "multi": false,
+        "name": "spc",
+        "options": [],
+        "query": "label_values(openebs_pool_status,storage_pool_claim)",
+        "refresh": 2,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "DS_OPENEBS_PROMETHEUS",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Pool",
+        "multi": true,
+        "name": "Pool",
+        "options": [],
+        "query": "label_values(openebs_pool_status{storage_pool_claim=~\"$spc\"},cstor_pool)",
+        "refresh": 2,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Storage pool claim dashboard",
+  "uid": "23c14553-6c62-41b6-9eb3-c0e75531e617",
+  "version": 3
 }

--- a/grafana-charts/storagepoolclaimdashboard.json
+++ b/grafana-charts/storagepoolclaimdashboard.json
@@ -1,0 +1,805 @@
+{
+	"dashboard": {
+		"__inputs": [
+			{
+				"name": "DS_OPENEBS_PROMETHEUS",
+				"label": "openebs Prometheus",
+				"description": "",
+				"type": "datasource",
+				"pluginId": "prometheus",
+				"pluginName": "Prometheus"
+			}
+		],
+		"__requires": [
+			{
+				"type": "grafana",
+				"id": "grafana",
+				"name": "Grafana",
+				"version": "5.1.3"
+			},
+			{
+				"type": "panel",
+				"id": "graph",
+				"name": "Graph",
+				"version": ""
+			},
+			{
+				"type": "datasource",
+				"id": "prometheus",
+				"name": "Prometheus",
+				"version": "1.0.0"
+			},
+			{
+				"type": "panel",
+				"id": "singlestat",
+				"name": "Singlestat",
+				"version": ""
+			},
+			{
+				"type": "panel",
+				"id": "text",
+				"name": "Text",
+				"version": ""
+			}
+		],
+		"annotations": {
+			"list": [
+			]
+		},
+		"editable": true,
+		"gnetId": null,
+		"graphTooltip": 0,
+		"id": null,
+		"iteration": 1542963642391,
+		"links": [
+			{
+				"icon": "doc",
+				"includeVars": true,
+				"keepTime": true,
+				"tags": [
+				],
+				"targetBlank": true,
+				"title": "report",
+				"tooltip": "",
+				"type": "link",
+				"url": "${MAYA_URL}/reporter/?dashboard=23c14553-6c62-41b6-9eb3-c0e75531e617"
+			}
+		],
+		"panels": [
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fill": 1,
+				"gridPos": {
+					"h": 6,
+					"w": 12,
+					"x": 0,
+					"y": 0
+				},
+				"id": 4,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 2,
+				"links": [
+				],
+				"nullPointMode": "null",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "openebs_pool_status{cstor_pool=~\"$Pool\"}",
+						"format": "time_series",
+						"intervalFactor": 1,
+						"legendFormat": "{{cstor_pool}}",
+						"refId": "A"
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Pool status",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"decimals": 0,
+						"format": "none",
+						"label": null,
+						"labelMappings": [
+							{
+								"label": "Offline",
+								"value": 0
+							},
+							{
+								"label": "Online",
+								"value": 1
+							},
+							{
+								"label": "Degraded",
+								"value": 2
+							},
+							{
+								"label": "Faulted",
+								"value": 3
+							},
+							{
+								"label": "Removed",
+								"value": 4
+							},
+							{
+								"label": "Unavail",
+								"value": 5
+							},
+							{
+								"label": "NoPoolsAvailable",
+								"value": 6
+							}
+						],
+						"logBase": 1,
+						"mappedLabelOnly": true,
+						"max": null,
+						"min": null,
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"mappedLabelOnly": false,
+						"max": null,
+						"min": null,
+						"show": true
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fill": 1,
+				"gridPos": {
+					"h": 6,
+					"w": 12,
+					"x": 12,
+					"y": 0
+				},
+				"id": 48,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 2,
+				"links": [
+				],
+				"nullPointMode": "null",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "openebs_pool_size{cstor_pool=~\"$Pool\"}/(1024*1024*1024)",
+						"format": "time_series",
+						"intervalFactor": 1,
+						"legendFormat": "{{cstor_pool}}",
+						"refId": "A"
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Size of  pool",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"format": "decgbytes",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"mappedLabelOnly": false,
+						"max": null,
+						"min": null,
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"mappedLabelOnly": false,
+						"max": null,
+						"min": null,
+						"show": true
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fill": 1,
+				"gridPos": {
+					"h": 6,
+					"w": 12,
+					"x": 0,
+					"y": 6
+				},
+				"id": 50,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 2,
+				"links": [
+				],
+				"nullPointMode": "null",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "(openebs_used_pool_capacity{cstor_pool=~\"$Pool\"})/(1024*1024*1024)",
+						"format": "time_series",
+						"intervalFactor": 1,
+						"legendFormat": "{{cstor_pool}}",
+						"refId": "A"
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Used pool capacity",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"format": "decgbytes",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"mappedLabelOnly": false,
+						"max": null,
+						"min": null,
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"mappedLabelOnly": false,
+						"max": null,
+						"min": null,
+						"show": true
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fill": 1,
+				"gridPos": {
+					"h": 6,
+					"w": 12,
+					"x": 12,
+					"y": 6
+				},
+				"id": 52,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 2,
+				"links": [
+				],
+				"nullPointMode": "null",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "(openebs_free_pool_capacity{cstor_pool=~\"$Pool\"})/(1024*1024*1024)",
+						"format": "time_series",
+						"intervalFactor": 1,
+						"legendFormat": "{{cstor_pool}}",
+						"refId": "A"
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Free pool capacity",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"format": "decgbytes",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"mappedLabelOnly": false,
+						"max": null,
+						"min": null,
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"mappedLabelOnly": false,
+						"max": null,
+						"min": null,
+						"show": true
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fill": 1,
+				"gridPos": {
+					"h": 6,
+					"w": 12,
+					"x": 0,
+					"y": 12
+				},
+				"id": 54,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 2,
+				"links": [
+				],
+				"nullPointMode": "null",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "sum(openebs_total_read_count{cstor_pool=~\"$Pool\"}) by (cstor_pool)",
+						"format": "time_series",
+						"intervalFactor": 1,
+						"legendFormat": "{{cstor_pool}}",
+						"refId": "A"
+					},
+					{
+						"expr": "",
+						"format": "time_series",
+						"intervalFactor": 1,
+						"legendFormat": "write iops",
+						"refId": "B"
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Read IOPS",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"decimals": null,
+						"format": "short",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"mappedLabelOnly": false,
+						"max": null,
+						"min": null,
+						"show": true
+					},
+					{
+						"decimals": null,
+						"format": "short",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"mappedLabelOnly": false,
+						"max": null,
+						"min": null,
+						"show": true
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fill": 1,
+				"gridPos": {
+					"h": 6,
+					"w": 12,
+					"x": 12,
+					"y": 12
+				},
+				"id": 56,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 2,
+				"links": [
+				],
+				"nullPointMode": "null",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "sum(openebs_total_write_count{cstor_pool=~\"$Pool\"}) by (cstor_pool)",
+						"format": "time_series",
+						"intervalFactor": 1,
+						"legendFormat": "{{cstor_pool}}",
+						"refId": "A"
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Write IOPS",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"format": "short",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"mappedLabelOnly": false,
+						"max": null,
+						"min": null,
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"mappedLabelOnly": false,
+						"max": null,
+						"min": null,
+						"show": true
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			}
+		],
+		"schemaVersion": 16,
+		"style": "light",
+		"tags": [
+		],
+		"templating": {
+			"list": [
+				{
+					"allValue": null,
+					"current": {
+					},
+					"datasource": "DS_OPENEBS_PROMETHEUS",
+					"hide": 0,
+					"includeAll": false,
+					"label": "Storage pool",
+					"multi": false,
+					"name": "spc",
+					"options": [
+					],
+					"query": "label_values(openebs_pool_status,storage_pool_claim)",
+					"refresh": 2,
+					"regex": "",
+					"sort": 0,
+					"tagValuesQuery": "",
+					"tags": [
+					],
+					"tagsQuery": "",
+					"type": "query",
+					"useTags": false
+				},
+				{
+					"allValue": null,
+					"current": {
+					},
+					"datasource": "DS_OPENEBS_PROMETHEUS",
+					"hide": 0,
+					"includeAll": false,
+					"label": "Pool",
+					"multi": true,
+					"name": "Pool",
+					"options": [
+					],
+					"query": "label_values(openebs_pool_status{storage_pool_claim=~\"$spc\"},cstor_pool)",
+					"refresh": 2,
+					"regex": "",
+					"sort": 0,
+					"tagValuesQuery": "",
+					"tags": [
+					],
+					"tagsQuery": "",
+					"type": "query",
+					"useTags": false
+				},
+				{
+					"allValue": null,
+					"current": {
+					},
+					"hide": 2,
+					"includeAll": false,
+					"label": "projectid",
+					"multi": false,
+					"name": "projectid",
+					"options": [
+						{
+							"selected": false,
+							"text": "",
+							"value": ""
+						}
+					],
+					"query": "",
+					"type": "custom"
+				},
+				{
+					"allValue": null,
+					"current": {
+					},
+					"hide": 2,
+					"includeAll": false,
+					"label": "groupid",
+					"multi": false,
+					"name": "groupid",
+					"options": [
+						{
+							"selected": false,
+							"text": "",
+							"value": ""
+						}
+					],
+					"query": "",
+					"type": "custom"
+				}
+			]
+		},
+		"time": {
+			"from": "now-1h",
+			"to": "now"
+		},
+		"timepicker": {
+			"refresh_intervals": [
+				"5s",
+				"10s",
+				"30s",
+				"1m",
+				"5m",
+				"15m",
+				"30m",
+				"1h",
+				"2h",
+				"1d"
+			],
+			"time_options": [
+				"5m",
+				"15m",
+				"1h",
+				"6h",
+				"12h",
+				"24h",
+				"2d",
+				"7d",
+				"30d"
+			]
+		},
+		"timezone": "",
+		"title": "Storage pool claim dashboard",
+		"uid": "23c14553-6c62-41b6-9eb3-c0e75531e617",
+		"version": 3
+	},
+	"overwrite": true
+}

--- a/grafana-charts/storagepooldashboard.json
+++ b/grafana-charts/storagepooldashboard.json
@@ -1,48 +1,57 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_OPENEBS_PROMETHEUS",
+      "label": "OpenEBS Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "5.2.0"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": "5.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "prometheus",
+      "version": "5.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "singlestat",
+      "name": "Singlestat",
+      "version": "5.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "text",
+      "name": "Text",
+      "version": "5.0.0"
+    }
+  ],
   "annotations": {
-    "list": [
-      {
-        "$$hashKey": "object:277",
-        "builtIn": 1,
-        "datasource": "-- Grafana --",
-        "enable": true,
-        "hide": true,
-        "iconColor": "rgba(0, 211, 255, 1)",
-        "name": "Annotations & Alerts",
-        "type": "dashboard"
-      }
-    ]
+    "list": []
   },
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
   "id": 103496,
   "iteration": 1612454983940,
-  "links": [
-    {
-      "icon": "external link",
-      "includeVars": true,
-      "tags": [],
-      "targetBlank": true,
-      "title": "cStor volume replica dashboard",
-      "type": "link",
-      "url": "/grafana/d/644d0435-03e1-4da3-b768-7968f526cf68/cstor-volume-replicas-dashboard?submenu"
-    },
-    {
-      "icon": "doc",
-      "includeVars": true,
-      "keepTime": true,
-      "tags": [],
-      "targetBlank": true,
-      "title": "report",
-      "tooltip": "",
-      "type": "link",
-      "url": "https://director.mayadata.io/reporter/?dashboard=5d86b1fd-b2e7-4bb2-befa-4dae5b6167d6"
-    }
-  ],
   "panels": [
     {
-      "content": "<html>\n<head>\n\n<script>\nwindow.onload = load('$Pool', '$spc','$cluster','$projectid','$groupid','$kind');\n\nfunction getCell(name, value) {\n  return \"<div class=\\\"outlet-header-meta-bar_item\\\"><div class=\\\"outlet-header-meta-bar_title\\\"><span>\"+name+\"</span></div><div class=\\\"outlet-header-meta-bar_value\\\"><span>\"+value+\"</span></div></div>\";\n}\n\nfunction load(poolNameStr, spcStr,clusterNameStr,projectIdStr,groupIdStr,kindStr) {\nvar poolNameStr = poolNameStr.replace( /[{}]/g, '' );\nvar spcStr = spcStr.replace( /[{}]/g, '' );\nvar clusterNameStr = clusterNameStr.replace( /[{}]/g, '' );\nvar projectIdStr = projectIdStr.replace( /[{}]/g, '' );\nvar groupIdStr = groupIdStr.replace( /[{}]/g, '' );\nvar kindStr = kindStr.replace( /[{}]/g, '' );\n// var pools = poolsStr.replace( /[{}]/g, '' );\n// var rc = replicaCount.replace( /[{}]/g, '' );\n// if(!rc) {\n//   rc = \"none\";\n// }\n// var uptimes = uptime.replace( /[{}]/g, '' );\n// if(uptimes) {\n// var seconds = parseInt(uptimes, 10);\n\n// var days = Math.floor(seconds / (3600*24));\n// seconds  -= days*3600*24;\n// var hrs   = Math.floor(seconds / 3600);\n// seconds  -= hrs*3600;\n// var mnts = Math.floor(seconds / 60);\n// seconds  -= mnts*60;\n// uptimes = days+\" days, \"+hrs+\" Hrs, \"+mnts+\" Mins, \"+seconds+\" Secs\";\n// }\n// else {\n//   uptimes = \"No Data\";\n// }\n\n\n\nz=\"\";\nz+=getCell(\"Pool Name\", poolNameStr);\nz+=getCell(\"Cluster\", clusterNameStr);\n//z+=getCell(\"Name\", volName);\nz+=getCell(kindStr, spcStr.link(\"/grafana/d/storage-pool-claim-dashboard/storage-pool-claim-dashboard?submenu&var-spc=\" + spcStr + \"&var-projectid=\" + projectIdStr + \"&var-groupid=\" + groupIdStr));\n//z+=getCell(\"Pool Name\", pools);\n//z+=getCell(\"No. of Replicas\", rc);\n//z+=getCell(\"\",\"\")\n\ndocument.getElementById(\"volume-info\").innerHTML = z;\n}\n</script>\n</head>\n\n<body>\n\n<div id=\"volume-info\" class=\"outlet-header-bar\"></div>\n\n</body>\n\n</html>",
+      "content": "<html>\n<head>\n\n<script>\nwindow.onload = load('$Pool', '$spc','$kind');\n\nfunction getCell(name, value) {\n  return \"<div class=\\\"outlet-header-meta-bar_item\\\"><div class=\\\"outlet-header-meta-bar_title\\\"><span>\"+name+\"</span></div><div class=\\\"outlet-header-meta-bar_value\\\"><span>\"+value+\"</span></div></div>\";\n}\n\nfunction load(poolNameStr, spcStr,kindStr) {\nvar poolNameStr = poolNameStr.replace( /[{}]/g, '' );\nvar spcStr = spcStr.replace( /[{}]/g, '' );\nvar kindStr = kindStr.replace( /[{}]/g, '' );\n// var pools = poolsStr.replace( /[{}]/g, '' );\n// var rc = replicaCount.replace( /[{}]/g, '' );\n// if(!rc) {\n//   rc = \"none\";\n// }\n// var uptimes = uptime.replace( /[{}]/g, '' );\n// if(uptimes) {\n// var seconds = parseInt(uptimes, 10);\n\n// var days = Math.floor(seconds / (3600*24));\n// seconds  -= days*3600*24;\n// var hrs   = Math.floor(seconds / 3600);\n// seconds  -= hrs*3600;\n// var mnts = Math.floor(seconds / 60);\n// seconds  -= mnts*60;\n// uptimes = days+\" days, \"+hrs+\" Hrs, \"+mnts+\" Mins, \"+seconds+\" Secs\";\n// }\n// else {\n//   uptimes = \"No Data\";\n// }\n\n\n\nz=\"\";\nz+=getCell(\"Pool Name\", poolNameStr);\n//z+=getCell(\"Name\", volName);\nz+=getCell(\"Pool Name\", pools);\n//z+=getCell(\"No. of Replicas\", rc);\n//z+=getCell(\"\",\"\")\n\ndocument.getElementById(\"volume-info\").innerHTML = z;\n}\n</script>\n</head>\n\n<body>\n\n<div id=\"volume-info\" class=\"outlet-header-bar\"></div>\n\n</body>\n\n</html>",
       "gridPos": {
         "h": 3,
         "w": 24,
@@ -655,26 +664,6 @@
         "datasource": "DS_OPENEBS_PROMETHEUS",
         "hide": 2,
         "includeAll": false,
-        "label": "cluster",
-        "multi": false,
-        "name": "cluster",
-        "options": [],
-        "query": "label_values(openebs_pool_status{cstor_pool=~\"$Pool\"},job)",
-        "refresh": 2,
-        "regex": "/cluster_uuid_(.*)_.*/",
-        "sort": 0,
-        "tagValuesQuery": "",
-        "tags": [],
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
-      },
-      {
-        "allValue": null,
-        "current": {},
-        "datasource": "DS_OPENEBS_PROMETHEUS",
-        "hide": 2,
-        "includeAll": false,
         "label": "spc",
         "multi": false,
         "name": "spc",
@@ -697,42 +686,6 @@
         "label": "pool",
         "multi": false,
         "name": "pool",
-        "options": [
-          {
-            "selected": false,
-            "text": "",
-            "value": ""
-          }
-        ],
-        "query": "",
-        "type": "custom"
-      },
-      {
-        "allValue": null,
-        "current": {},
-        "hide": 2,
-        "includeAll": false,
-        "label": "projectid",
-        "multi": false,
-        "name": "projectid",
-        "options": [
-          {
-            "selected": false,
-            "text": "",
-            "value": ""
-          }
-        ],
-        "query": "",
-        "type": "custom"
-      },
-      {
-        "allValue": null,
-        "current": {},
-        "hide": 2,
-        "includeAll": false,
-        "label": "groupid",
-        "multi": false,
-        "name": "groupid",
         "options": [
           {
             "selected": false,

--- a/grafana-charts/volumetiledviewdashboard.json
+++ b/grafana-charts/volumetiledviewdashboard.json
@@ -1,1254 +1,1086 @@
 {
-	"dashboard": {
-		"__inputs": [
-			{
-				"name": "DS_OPENEBS_PROMETHEUS",
-				"label": "openebs Prometheus",
-				"description": "",
-				"type": "datasource",
-				"pluginId": "prometheus",
-				"pluginName": "Prometheus"
-			}
-		],
-		"__requires": [
-			{
-				"type": "grafana",
-				"id": "grafana",
-				"name": "Grafana",
-				"version": "5.1.3"
-			},
-			{
-				"type": "panel",
-				"id": "graph",
-				"name": "Graph",
-				"version": ""
-			},
-			{
-				"type": "datasource",
-				"id": "prometheus",
-				"name": "Prometheus",
-				"version": "1.0.0"
-			},
-			{
-				"type": "panel",
-				"id": "singlestat",
-				"name": "Singlestat",
-				"version": ""
-			},
-			{
-				"type": "panel",
-				"id": "text",
-				"name": "Text",
-				"version": ""
-			}
-		],
-		"annotations": {
-			"list": [
-			]
-		},
-		"editable": true,
-		"gnetId": null,
-		"graphTooltip": 0,
-		"id": null,
-		"iteration": 1542985639100,
-		"links": [
-			{
-				"icon": "doc",
-				"includeVars": true,
-				"keepTime": true,
-				"tags": [
-				],
-				"targetBlank": true,
-				"title": "report",
-				"tooltip": "",
-				"type": "link",
-				"url": "${MAYA_URL}/reporter/?dashboard=f46a2d03-c2af-4954-b2b3-307c4d77bcaf"
-			}
-		],
-		"panels": [
-			{
-				"content": "<html>\n<head>\n\n<script>\nwindow.onload = load('$openebs_pvc', '$vol','$cluster_name', '$pool', '$replica_count', '$uptime');\n\nfunction getCell(name, value) {\n  return \"<div class=\\\"outlet-header-meta-bar_item\\\"><div class=\\\"outlet-header-meta-bar_title\\\"><span>\"+name+\"</span></div><div class=\\\"outlet-header-meta-bar_value\\\"><span>\"+value+\"</span></div></div>\";\n}\n\nfunction load(volClaimStr, volNameStr,clusterNameStr, poolsStr, replicaCount, uptime) {\nvar volClaim = volClaimStr.replace( /[{}]/g, '' );\nvar volName = volNameStr.replace( /[{}]/g, '' );\nvar clusterName = clusterNameStr.replace( /[{}]/g, '' );\nvar pools = poolsStr.replace( /[{}]/g, '' );\nvar rc = replicaCount.replace( /[{}]/g, '' );\nif(!rc) {\n  rc = \"none\";\n}\nvar uptimes = uptime.replace( /[{}]/g, '' );\nif(uptimes) {\nvar seconds = parseInt(uptimes, 10);\n\nvar days = Math.floor(seconds / (3600*24));\nseconds  -= days*3600*24;\nvar hrs   = Math.floor(seconds / 3600);\nseconds  -= hrs*3600;\nvar mnts = Math.floor(seconds / 60);\nseconds  -= mnts*60;\nuptimes = days+\" days, \"+hrs+\" Hrs, \"+mnts+\" Mins\";\n}\nelse {\n  uptimes = \"No Data\";\n}\n\n\n\nz=\"\";\nz+=getCell(\"PVC\", volClaim);\n//z+=getCell(\"Name\", volName);\nz+=getCell(\"Cluster Name\", clusterName);\n//z+=getCell(\"Pool Name\", pools);\nz+=getCell(\"No. of Replicas\", rc);\nz+=getCell(\"Uptime\", uptimes);\n//z+=getCell(\"\",\"\")\n\ndocument.getElementById(\"volume-info\").innerHTML = z;\n}\n</script>\n</head>\n\n<body>\n\n<div id=\"volume-info\" class=\"outlet-header-bar\"></div>\n\n</body>\n\n</html>",
-				"gridPos": {
-					"h": 3,
-					"w": 24,
-					"x": 0,
-					"y": 0
-				},
-				"id": 55,
-				"links": [
-				],
-				"mode": "html",
-				"title": "Volume information",
-				"transparent": false,
-				"type": "text"
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fill": 3,
-				"gridPos": {
-					"h": 8,
-					"w": 8,
-					"x": 0,
-					"y": 3
-				},
-				"id": 35,
-				"legend": {
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"show": true,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 2,
-				"links": [
-				],
-				"nullPointMode": "null",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": false,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "openebs_volume_status{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
-						"format": "time_series",
-						"intervalFactor": 1,
-						"legendFormat": "volume status",
-						"refId": "A"
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "Volume status",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"decimals": 0,
-						"format": "none",
-						"label": null,
-						"labelMappings": [
-							{
-								"label": "Offline",
-								"value": 1
-							},
-							{
-								"label": "Degraded",
-								"value": 2
-							},
-							{
-								"label": "Healthy",
-								"value": 3
-							},
-							{
-								"label": "Unknown",
-								"value": 4
-							}
-						],
-						"logBase": 1,
-						"mappedLabelOnly": true,
-						"max": "4",
-						"min": "1",
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"mappedLabelOnly": false,
-						"max": null,
-						"min": null,
-						"show": true
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fill": 3,
-				"gridPos": {
-					"h": 8,
-					"w": 8,
-					"x": 8,
-					"y": 3
-				},
-				"id": 39,
-				"legend": {
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"show": true,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 2,
-				"links": [
-				],
-				"nullPointMode": "null",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": false,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "openebs_total_replica_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
-						"format": "time_series",
-						"hide": false,
-						"intervalFactor": 1,
-						"legendFormat": "total",
-						"refId": "A"
-					},
-					{
-						"expr": "openebs_healthy_replica_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
-						"format": "time_series",
-						"intervalFactor": 1,
-						"legendFormat": "healthy",
-						"refId": "B"
-					},
-					{
-						"expr": "openebs_degraded_replica_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
-						"format": "time_series",
-						"intervalFactor": 1,
-						"legendFormat": "degraded",
-						"refId": "C"
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "Replica count",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"decimals": 0,
-						"format": "none",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"mappedLabelOnly": false,
-						"max": null,
-						"min": "0",
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"mappedLabelOnly": false,
-						"max": null,
-						"min": null,
-						"show": true
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fill": 3,
-				"gridPos": {
-					"h": 8,
-					"w": 8,
-					"x": 16,
-					"y": 3
-				},
-				"id": 53,
-				"legend": {
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"show": true,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 2,
-				"links": [
-				],
-				"nullPointMode": "null",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": false,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "openebs_parse_error_total{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
-						"format": "time_series",
-						"intervalFactor": 1,
-						"legendFormat": "total parse error",
-						"refId": "A"
-					},
-					{
-						"expr": "openebs_connection_retry_total{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
-						"format": "time_series",
-						"intervalFactor": 1,
-						"legendFormat": "total connection retry",
-						"refId": "B"
-					},
-					{
-						"expr": "openebs_connection_error_total{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
-						"format": "time_series",
-						"intervalFactor": 1,
-						"legendFormat": "total connection error",
-						"refId": "C"
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "Errors",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"format": "short",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"mappedLabelOnly": false,
-						"max": null,
-						"min": "0",
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"mappedLabelOnly": false,
-						"max": null,
-						"min": null,
-						"show": true
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fill": 3,
-				"gridPos": {
-					"h": 8,
-					"w": 8,
-					"x": 0,
-					"y": 11
-				},
-				"id": 22,
-				"legend": {
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"show": true,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 2,
-				"links": [
-				],
-				"nullPointMode": "null",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": false,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "irate(openebs_reads{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])",
-						"format": "time_series",
-						"hide": false,
-						"interval": "",
-						"intervalFactor": 2,
-						"legendFormat": "Reads",
-						"refId": "A"
-					},
-					{
-						"expr": "irate(openebs_writes{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])",
-						"format": "time_series",
-						"intervalFactor": 1,
-						"legendFormat": "Writes",
-						"refId": "B"
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "IOPS",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"transparent": false,
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"format": "short",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": "0",
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": null,
-						"show": false
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fill": 3,
-				"gridPos": {
-					"h": 8,
-					"w": 8,
-					"x": 8,
-					"y": 11
-				},
-				"id": 23,
-				"legend": {
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"show": true,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 2,
-				"links": [
-				],
-				"nullPointMode": "null as zero",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": false,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "((irate(openebs_read_time{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m]))/(irate(openebs_reads{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])))/1000000",
-						"format": "time_series",
-						"intervalFactor": 2,
-						"legendFormat": "Read latency",
-						"refId": "A"
-					},
-					{
-						"expr": "((irate(openebs_write_time{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m]))/(irate(openebs_writes{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])))/1000000",
-						"format": "time_series",
-						"intervalFactor": 2,
-						"legendFormat": "Write  latency",
-						"refId": "B"
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "Latency",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"transparent": false,
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"format": "ms",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": "0",
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": null,
-						"show": false
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fill": 1,
-				"gridPos": {
-					"h": 8,
-					"w": 8,
-					"x": 16,
-					"y": 11
-				},
-				"id": 57,
-				"legend": {
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"show": true,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 1,
-				"links": [
-				],
-				"nullPointMode": "null",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": false,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "openebs_size_of_volume{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
-						"format": "time_series",
-						"intervalFactor": 1,
-						"legendFormat": "Total size",
-						"refId": "A"
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "Total capacity",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"format": "decgbytes",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"mappedLabelOnly": false,
-						"max": null,
-						"min": null,
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"mappedLabelOnly": false,
-						"max": null,
-						"min": null,
-						"show": true
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fill": 3,
-				"gridPos": {
-					"h": 8,
-					"w": 8,
-					"x": 0,
-					"y": 19
-				},
-				"id": 28,
-				"legend": {
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"show": true,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 2,
-				"links": [
-				],
-				"nullPointMode": "null",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": false,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "openebs_actual_used{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
-						"format": "time_series",
-						"intervalFactor": 2,
-						"legendFormat": "used",
-						"refId": "A"
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "Storage usage",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"format": "decgbytes",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"max": null,
-						"min": "0",
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"labelMappings": [
-						],
-						"logBase": 1,
-						"max": null,
-						"min": null,
-						"show": false
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fill": 3,
-				"gridPos": {
-					"h": 8,
-					"w": 8,
-					"x": 8,
-					"y": 19
-				},
-				"id": 31,
-				"legend": {
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"show": true,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 2,
-				"links": [
-				],
-				"nullPointMode": "null",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": false,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "irate(openebs_read_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])/(2048)",
-						"format": "time_series",
-						"intervalFactor": 2,
-						"legendFormat": "Read Throughput",
-						"refId": "A"
-					},
-					{
-						"expr": "irate(openebs_write_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])/(2048)",
-						"format": "time_series",
-						"intervalFactor": 2,
-						"legendFormat": "Write Throughput",
-						"refId": "B"
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "Throughput",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"format": "MBs",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": "0",
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": null,
-						"show": false
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			},
-			{
-				"aliasColors": {
-				},
-				"bars": false,
-				"dashLength": 10,
-				"dashes": false,
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fill": 3,
-				"gridPos": {
-					"h": 8,
-					"w": 8,
-					"x": 16,
-					"y": 19
-				},
-				"id": 26,
-				"legend": {
-					"avg": false,
-					"current": false,
-					"max": false,
-					"min": false,
-					"show": true,
-					"total": false,
-					"values": false
-				},
-				"lines": true,
-				"linewidth": 2,
-				"links": [
-				],
-				"nullPointMode": "null as zero",
-				"percentage": false,
-				"pointradius": 5,
-				"points": false,
-				"renderer": "flot",
-				"seriesOverrides": [
-				],
-				"spaceLength": 10,
-				"stack": false,
-				"steppedLine": false,
-				"targets": [
-					{
-						"expr": "(irate(openebs_read_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])/(1024))*512/(irate(openebs_reads{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m]))",
-						"format": "time_series",
-						"hide": false,
-						"intervalFactor": 2,
-						"legendFormat": "Read block size",
-						"refId": "A"
-					},
-					{
-						"expr": "(irate(openebs_write_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])/(1024))*512/(irate(openebs_writes{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m]))",
-						"format": "time_series",
-						"intervalFactor": 2,
-						"legendFormat": "Write block size",
-						"refId": "B"
-					}
-				],
-				"thresholds": [
-				],
-				"timeFrom": null,
-				"timeShift": null,
-				"title": "Block size",
-				"tooltip": {
-					"shared": true,
-					"sort": 0,
-					"value_type": "individual"
-				},
-				"transparent": false,
-				"type": "graph",
-				"xaxis": {
-					"buckets": null,
-					"mode": "time",
-					"name": null,
-					"show": true,
-					"values": [
-					]
-				},
-				"yaxes": [
-					{
-						"format": "deckbytes",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": "0",
-						"show": true
-					},
-					{
-						"format": "short",
-						"label": null,
-						"logBase": 1,
-						"max": null,
-						"min": null,
-						"show": false
-					}
-				],
-				"yaxis": {
-					"align": false,
-					"alignLevel": null
-				}
-			}
-		],
-		"refresh": "1m",
-		"schemaVersion": 16,
-		"style": "light",
-		"tags": [
-		],
-		"templating": {
-			"list": [
-				{
-					"allValue": null,
-					"current": {
-					},
-					"hide": 2,
-					"includeAll": false,
-					"label": "Cluster:",
-					"multi": false,
-					"name": "Cluster_uuid",
-					"options": [
-						{
-							"selected": false,
-							"text": "",
-							"value": ""
-						}
-					],
-					"query": "",
-					"type": "custom"
-				},
-				{
-					"allValue": null,
-					"current": {
-					},
-					"hide": 2,
-					"includeAll": false,
-					"label": "Volume:",
-					"multi": false,
-					"name": "openebs_Volume",
-					"options": [
-						{
-							"selected": false,
-							"text": "",
-							"value": ""
-						}
-					],
-					"query": "",
-					"type": "custom"
-				},
-				{
-					"allValue": null,
-					"current": {
-					},
-					"datasource": "DS_OPENEBS_PROMETHEUS",
-					"hide": 2,
-					"includeAll": false,
-					"label": "Cluster",
-					"multi": false,
-					"name": "cluster_name",
-					"options": [
-					],
-					"query": "label_values(openebs_actual_used{openebs_pv=~\"$openebs_Volume\"},job)",
-					"refresh": 2,
-					"regex": "/cluster_uuid_(.*)_.*/",
-					"sort": 0,
-					"tagValuesQuery": "",
-					"tags": [
-					],
-					"tagsQuery": "",
-					"type": "query",
-					"useTags": false
-				},
-				{
-					"allValue": null,
-					"current": {
-					},
-					"datasource": "DS_OPENEBS_PROMETHEUS",
-					"hide": 2,
-					"includeAll": false,
-					"label": "Openebs pvc",
-					"multi": false,
-					"name": "openebs_pvc",
-					"options": [
-					],
-					"query": "label_values(openebs_size_of_volume{job=~\".*$Cluster_uuid.*\",openebs_pv=~\"$openebs_Volume\"},openebs_pvc)",
-					"refresh": 2,
-					"regex": "",
-					"sort": 0,
-					"tagValuesQuery": "",
-					"tags": [
-					],
-					"tagsQuery": "",
-					"type": "query",
-					"useTags": false
-				},
-				{
-					"allValue": null,
-					"current": {
-					},
-					"datasource": "DS_OPENEBS_PROMETHEUS",
-					"hide": 2,
-					"includeAll": false,
-					"label": "pool",
-					"multi": false,
-					"name": "pool",
-					"options": [
-					],
-					"query": "label_values(openebs_replica_status{vol=~\"$openebs_Volume\"},pool)",
-					"refresh": 2,
-					"regex": "",
-					"sort": 0,
-					"tagValuesQuery": "",
-					"tags": [
-					],
-					"tagsQuery": "",
-					"type": "query",
-					"useTags": false
-				},
-				{
-					"allValue": null,
-					"current": {
-					},
-					"datasource": "DS_OPENEBS_PROMETHEUS",
-					"hide": 2,
-					"includeAll": false,
-					"label": "replica_count",
-					"multi": false,
-					"name": "replica_count",
-					"options": [
-					],
-					"query": "query_result(openebs_total_replica_count{openebs_pv=~\"$openebs_Volume\"})",
-					"refresh": 2,
-					"regex": "/.*}(.*) .*/",
-					"sort": 0,
-					"tagValuesQuery": "",
-					"tags": [
-					],
-					"tagsQuery": "",
-					"type": "query",
-					"useTags": false
-				},
-				{
-					"allValue": null,
-					"current": {
-					},
-					"datasource": "DS_OPENEBS_PROMETHEUS",
-					"hide": 2,
-					"includeAll": false,
-					"label": "uptime",
-					"multi": false,
-					"name": "uptime",
-					"options": [
-					],
-					"query": "query_result(openebs_volume_uptime{openebs_pv=~\"$openebs_Volume\"})",
-					"refresh": 2,
-					"regex": "/.*}(.*) .*/",
-					"sort": 0,
-					"tagValuesQuery": "",
-					"tags": [
-					],
-					"tagsQuery": "",
-					"type": "query",
-					"useTags": false
-				},
-				{
-					"allValue": null,
-					"current": {
-					},
-					"datasource": "DS_OPENEBS_PROMETHEUS",
-					"hide": 2,
-					"includeAll": false,
-					"label": "vol",
-					"multi": false,
-					"name": "vol",
-					"options": [
-					],
-					"query": "label_values(openebs_size_of_volume{openebs_pvc=~\"$openebs_pvc\"},openebs_pv)",
-					"refresh": 2,
-					"regex": "",
-					"sort": 0,
-					"tagValuesQuery": "",
-					"tags": [
-					],
-					"tagsQuery": "",
-					"type": "query",
-					"useTags": false
-				},
-				{
-					"allValue": null,
-					"current": {
-					},
-					"hide": 2,
-					"includeAll": false,
-					"label": "projectid",
-					"multi": false,
-					"name": "projectid",
-					"options": [
-						{
-							"selected": false,
-							"text": "",
-							"value": ""
-						}
-					],
-					"query": "",
-					"type": "custom"
-				},
-				{
-					"allValue": null,
-					"current": {
-					},
-					"hide": 2,
-					"includeAll": false,
-					"label": "groupid",
-					"multi": false,
-					"name": "groupid",
-					"options": [
-						{
-							"selected": false,
-							"text": "",
-							"value": ""
-						}
-					],
-					"query": "",
-					"type": "custom"
-				}
-			]
-		},
-		"time": {
-			"from": "now-1h",
-			"to": "now"
-		},
-		"timepicker": {
-			"refresh_intervals": [
-				"5s",
-				"10s",
-				"30s",
-				"1m",
-				"5m",
-				"15m",
-				"30m",
-				"1h",
-				"2h",
-				"1d"
-			],
-			"time_options": [
-				"5m",
-				"15m",
-				"1h",
-				"6h",
-				"12h",
-				"24h",
-				"2d",
-				"7d",
-				"30d"
-			]
-		},
-		"timezone": "",
-		"title": "Volume tiled view dashboard",
-		"uid": "f46a2d03-c2af-4954-b2b3-307c4d77bcaf",
-		"version": 3
-	},
-	"overwrite": true
+  "__inputs": [
+    {
+      "name": "DS_OPENEBS_PROMETHEUS",
+      "label": "openebs Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "5.1.3"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "singlestat",
+      "name": "Singlestat",
+      "version": ""
+    },
+    {
+      "type": "panel",	
+      "id": "text",
+      "name": "Text",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "iteration": 1542985639100,
+  "panels": [
+    {
+      "content": "<html>\n<head>\n\n<script>\nwindow.onload = load('$openebs_pvc', '$vol', '$pool', '$replica_count', '$uptime');\n\nfunction getCell(name, value) {\n  return \"<div class=\\\"outlet-header-meta-bar_item\\\"><div class=\\\"outlet-header-meta-bar_title\\\"><span>\"+name+\"</span></div><div class=\\\"outlet-header-meta-bar_value\\\"><span>\"+value+\"</span></div></div>\";\n}\n\nfunction load(volClaimStr, volNameStr,poolsStr, replicaCount, uptime) {\nvar volClaim = volClaimStr.replace( /[{}]/g, '' );\nvar volName = volNameStr.replace( /[{}]/g, '' );\nvar pools = poolsStr.replace( /[{}]/g, '' );\nvar rc = replicaCount.replace( /[{}]/g, '' );\nif(!rc) {\n  rc = \"none\";\n}\nvar uptimes = uptime.replace( /[{}]/g, '' );\nif(uptimes) {\nvar seconds = parseInt(uptimes, 10);\n\nvar days = Math.floor(seconds / (3600*24));\nseconds  -= days*3600*24;\nvar hrs   = Math.floor(seconds / 3600);\nseconds  -= hrs*3600;\nvar mnts = Math.floor(seconds / 60);\nseconds  -= mnts*60;\nuptimes = days+\" days, \"+hrs+\" Hrs, \"+mnts+\" Mins\";\n}\nelse {\n  uptimes = \"No Data\";\n}\n\n\n\nz=\"\";\nz+=getCell(\"PVC\", volClaim);\n//z+=getCell(\"Name\", volName);\nz+=getCell(\"Pool Name\", pools);\nz+=getCell(\"No. of Replicas\", rc);\nz+=getCell(\"Uptime\", uptimes);\n//z+=getCell(\"\",\"\")\n\ndocument.getElementById(\"volume-info\").innerHTML = z;\n}\n</script>\n</head>\n\n<body>\n\n<div id=\"volume-info\" class=\"outlet-header-bar\"></div>\n\n</body>\n\n</html>",
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 55,
+      "links": [],
+      "mode": "html",
+      "title": "Volume information",
+      "transparent": false,
+      "type": "text"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 3,
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 3
+      },
+      "id": 35,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "openebs_volume_status{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "volume status",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Volume status",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "none",
+          "label": null,
+          "labelMappings": [
+            {
+              "label": "Offline",
+              "value": 1
+            },
+            {
+              "label": "Degraded",
+              "value": 2
+            },
+            {
+              "label": "Healthy",
+              "value": 3
+            },
+            {
+              "label": "Unknown",
+              "value": 4
+            }
+          ],
+          "logBase": 1,
+          "mappedLabelOnly": true,
+          "max": "4",
+          "min": "1",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 3,
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 3
+      },
+      "id": 39,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "openebs_total_replica_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "total",
+          "refId": "A"
+        },
+        {
+          "expr": "openebs_healthy_replica_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "healthy",
+          "refId": "B"
+        },
+        {
+          "expr": "openebs_degraded_replica_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "degraded",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Replica count",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "none",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 3,
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 3
+      },
+      "id": 53,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "openebs_parse_error_total{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "total parse error",
+          "refId": "A"
+        },
+        {
+          "expr": "openebs_connection_retry_total{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "total connection retry",
+          "refId": "B"
+        },
+        {
+          "expr": "openebs_connection_error_total{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "total connection error",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Errors",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 3,
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 11
+      },
+      "id": 22,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "irate(openebs_reads{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "Reads",
+          "refId": "A"
+        },
+        {
+          "expr": "irate(openebs_writes{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Writes",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "IOPS",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": false,
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 3,
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 11
+      },
+      "id": 23,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "((irate(openebs_read_time{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m]))/(irate(openebs_reads{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])))/1000000",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Read latency",
+          "refId": "A"
+        },
+        {
+          "expr": "((irate(openebs_write_time{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m]))/(irate(openebs_writes{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])))/1000000",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Write  latency",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": false,
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 11
+      },
+      "id": 57,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "openebs_size_of_volume{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Total size",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Total capacity",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decgbytes",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "mappedLabelOnly": false,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 3,
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 19
+      },
+      "id": 28,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "openebs_actual_used{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "used",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Storage usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decgbytes",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "labelMappings": [],
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 3,
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 19
+      },
+      "id": 31,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "irate(openebs_read_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])/(2048)",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Read Throughput",
+          "refId": "A"
+        },
+        {
+          "expr": "irate(openebs_write_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])/(2048)",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Write Throughput",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Throughput",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "MBs",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fill": 3,
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 19
+      },
+      "id": 26,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "(irate(openebs_read_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])/(1024))*512/(irate(openebs_reads{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m]))",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "Read block size",
+          "refId": "A"
+        },
+        {
+          "expr": "(irate(openebs_write_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])/(1024))*512/(irate(openebs_writes{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m]))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Write block size",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Block size",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": false,
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "deckbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 16,
+  "style": "light",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "DS_OPENEBS_PROMETHEUS",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Volume",
+        "multi": true,
+        "name": "openebs_Volume",
+        "options": [],
+        "query": "label_values(openebs_size_of_volume, openebs_pv)",
+        "refresh": 2,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "DS_OPENEBS_PROMETHEUS",
+        "hide": 2,
+        "includeAll": false,
+        "label": "Openebs pvc",
+        "multi": false,
+        "name": "openebs_pvc",
+        "options": [],
+        "query": "label_values(openebs_size_of_volume{openebs_pv=~\"$openebs_Volume\"},openebs_pvc)",
+        "refresh": 2,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "DS_OPENEBS_PROMETHEUS",
+        "hide": 2,
+        "includeAll": false,
+        "label": "pool",
+        "multi": false,
+        "name": "pool",
+        "options": [],
+        "query": "label_values(openebs_replica_status{vol=~\"$openebs_Volume\"},pool)",
+        "refresh": 2,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "DS_OPENEBS_PROMETHEUS",
+        "hide": 2,
+        "includeAll": false,
+        "label": "replica_count",
+        "multi": false,
+        "name": "replica_count",
+        "options": [],
+        "query": "query_result(openebs_total_replica_count{openebs_pv=~\"$openebs_Volume\"})",
+        "refresh": 2,
+        "regex": "/.*}(.*) .*/",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "DS_OPENEBS_PROMETHEUS",
+        "hide": 2,
+        "includeAll": false,
+        "label": "uptime",
+        "multi": false,
+        "name": "uptime",
+        "options": [],
+        "query": "query_result(openebs_volume_uptime{openebs_pv=~\"$openebs_Volume\"})",
+        "refresh": 2,
+        "regex": "/.*}(.*) .*/",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "DS_OPENEBS_PROMETHEUS",
+        "hide": 2,
+        "includeAll": false,
+        "label": "vol",
+        "multi": false,
+        "name": "vol",
+        "options": [],
+        "query": "label_values(openebs_size_of_volume{openebs_pvc=~\"$openebs_pvc\"},openebs_pv)",
+        "refresh": 2,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Volume tiled view dashboard",
+  "uid": "f46a2d03-c2af-4954-b2b3-307c4d77bcaf",
+  "version": 3
 }

--- a/grafana-charts/volumetiledviewdashboard.json
+++ b/grafana-charts/volumetiledviewdashboard.json
@@ -1,0 +1,1254 @@
+{
+	"dashboard": {
+		"__inputs": [
+			{
+				"name": "DS_OPENEBS_PROMETHEUS",
+				"label": "openebs Prometheus",
+				"description": "",
+				"type": "datasource",
+				"pluginId": "prometheus",
+				"pluginName": "Prometheus"
+			}
+		],
+		"__requires": [
+			{
+				"type": "grafana",
+				"id": "grafana",
+				"name": "Grafana",
+				"version": "5.1.3"
+			},
+			{
+				"type": "panel",
+				"id": "graph",
+				"name": "Graph",
+				"version": ""
+			},
+			{
+				"type": "datasource",
+				"id": "prometheus",
+				"name": "Prometheus",
+				"version": "1.0.0"
+			},
+			{
+				"type": "panel",
+				"id": "singlestat",
+				"name": "Singlestat",
+				"version": ""
+			},
+			{
+				"type": "panel",
+				"id": "text",
+				"name": "Text",
+				"version": ""
+			}
+		],
+		"annotations": {
+			"list": [
+			]
+		},
+		"editable": true,
+		"gnetId": null,
+		"graphTooltip": 0,
+		"id": null,
+		"iteration": 1542985639100,
+		"links": [
+			{
+				"icon": "doc",
+				"includeVars": true,
+				"keepTime": true,
+				"tags": [
+				],
+				"targetBlank": true,
+				"title": "report",
+				"tooltip": "",
+				"type": "link",
+				"url": "${MAYA_URL}/reporter/?dashboard=f46a2d03-c2af-4954-b2b3-307c4d77bcaf"
+			}
+		],
+		"panels": [
+			{
+				"content": "<html>\n<head>\n\n<script>\nwindow.onload = load('$openebs_pvc', '$vol','$cluster_name', '$pool', '$replica_count', '$uptime');\n\nfunction getCell(name, value) {\n  return \"<div class=\\\"outlet-header-meta-bar_item\\\"><div class=\\\"outlet-header-meta-bar_title\\\"><span>\"+name+\"</span></div><div class=\\\"outlet-header-meta-bar_value\\\"><span>\"+value+\"</span></div></div>\";\n}\n\nfunction load(volClaimStr, volNameStr,clusterNameStr, poolsStr, replicaCount, uptime) {\nvar volClaim = volClaimStr.replace( /[{}]/g, '' );\nvar volName = volNameStr.replace( /[{}]/g, '' );\nvar clusterName = clusterNameStr.replace( /[{}]/g, '' );\nvar pools = poolsStr.replace( /[{}]/g, '' );\nvar rc = replicaCount.replace( /[{}]/g, '' );\nif(!rc) {\n  rc = \"none\";\n}\nvar uptimes = uptime.replace( /[{}]/g, '' );\nif(uptimes) {\nvar seconds = parseInt(uptimes, 10);\n\nvar days = Math.floor(seconds / (3600*24));\nseconds  -= days*3600*24;\nvar hrs   = Math.floor(seconds / 3600);\nseconds  -= hrs*3600;\nvar mnts = Math.floor(seconds / 60);\nseconds  -= mnts*60;\nuptimes = days+\" days, \"+hrs+\" Hrs, \"+mnts+\" Mins\";\n}\nelse {\n  uptimes = \"No Data\";\n}\n\n\n\nz=\"\";\nz+=getCell(\"PVC\", volClaim);\n//z+=getCell(\"Name\", volName);\nz+=getCell(\"Cluster Name\", clusterName);\n//z+=getCell(\"Pool Name\", pools);\nz+=getCell(\"No. of Replicas\", rc);\nz+=getCell(\"Uptime\", uptimes);\n//z+=getCell(\"\",\"\")\n\ndocument.getElementById(\"volume-info\").innerHTML = z;\n}\n</script>\n</head>\n\n<body>\n\n<div id=\"volume-info\" class=\"outlet-header-bar\"></div>\n\n</body>\n\n</html>",
+				"gridPos": {
+					"h": 3,
+					"w": 24,
+					"x": 0,
+					"y": 0
+				},
+				"id": 55,
+				"links": [
+				],
+				"mode": "html",
+				"title": "Volume information",
+				"transparent": false,
+				"type": "text"
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fill": 3,
+				"gridPos": {
+					"h": 8,
+					"w": 8,
+					"x": 0,
+					"y": 3
+				},
+				"id": 35,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 2,
+				"links": [
+				],
+				"nullPointMode": "null",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "openebs_volume_status{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
+						"format": "time_series",
+						"intervalFactor": 1,
+						"legendFormat": "volume status",
+						"refId": "A"
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Volume status",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"decimals": 0,
+						"format": "none",
+						"label": null,
+						"labelMappings": [
+							{
+								"label": "Offline",
+								"value": 1
+							},
+							{
+								"label": "Degraded",
+								"value": 2
+							},
+							{
+								"label": "Healthy",
+								"value": 3
+							},
+							{
+								"label": "Unknown",
+								"value": 4
+							}
+						],
+						"logBase": 1,
+						"mappedLabelOnly": true,
+						"max": "4",
+						"min": "1",
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"mappedLabelOnly": false,
+						"max": null,
+						"min": null,
+						"show": true
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fill": 3,
+				"gridPos": {
+					"h": 8,
+					"w": 8,
+					"x": 8,
+					"y": 3
+				},
+				"id": 39,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 2,
+				"links": [
+				],
+				"nullPointMode": "null",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "openebs_total_replica_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
+						"format": "time_series",
+						"hide": false,
+						"intervalFactor": 1,
+						"legendFormat": "total",
+						"refId": "A"
+					},
+					{
+						"expr": "openebs_healthy_replica_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
+						"format": "time_series",
+						"intervalFactor": 1,
+						"legendFormat": "healthy",
+						"refId": "B"
+					},
+					{
+						"expr": "openebs_degraded_replica_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
+						"format": "time_series",
+						"intervalFactor": 1,
+						"legendFormat": "degraded",
+						"refId": "C"
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Replica count",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"decimals": 0,
+						"format": "none",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"mappedLabelOnly": false,
+						"max": null,
+						"min": "0",
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"mappedLabelOnly": false,
+						"max": null,
+						"min": null,
+						"show": true
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fill": 3,
+				"gridPos": {
+					"h": 8,
+					"w": 8,
+					"x": 16,
+					"y": 3
+				},
+				"id": 53,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 2,
+				"links": [
+				],
+				"nullPointMode": "null",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "openebs_parse_error_total{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
+						"format": "time_series",
+						"intervalFactor": 1,
+						"legendFormat": "total parse error",
+						"refId": "A"
+					},
+					{
+						"expr": "openebs_connection_retry_total{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
+						"format": "time_series",
+						"intervalFactor": 1,
+						"legendFormat": "total connection retry",
+						"refId": "B"
+					},
+					{
+						"expr": "openebs_connection_error_total{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
+						"format": "time_series",
+						"intervalFactor": 1,
+						"legendFormat": "total connection error",
+						"refId": "C"
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Errors",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"format": "short",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"mappedLabelOnly": false,
+						"max": null,
+						"min": "0",
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"mappedLabelOnly": false,
+						"max": null,
+						"min": null,
+						"show": true
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fill": 3,
+				"gridPos": {
+					"h": 8,
+					"w": 8,
+					"x": 0,
+					"y": 11
+				},
+				"id": 22,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 2,
+				"links": [
+				],
+				"nullPointMode": "null",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "irate(openebs_reads{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])",
+						"format": "time_series",
+						"hide": false,
+						"interval": "",
+						"intervalFactor": 2,
+						"legendFormat": "Reads",
+						"refId": "A"
+					},
+					{
+						"expr": "irate(openebs_writes{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])",
+						"format": "time_series",
+						"intervalFactor": 1,
+						"legendFormat": "Writes",
+						"refId": "B"
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "IOPS",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"transparent": false,
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"format": "short",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": "0",
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": null,
+						"show": false
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fill": 3,
+				"gridPos": {
+					"h": 8,
+					"w": 8,
+					"x": 8,
+					"y": 11
+				},
+				"id": 23,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 2,
+				"links": [
+				],
+				"nullPointMode": "null as zero",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "((irate(openebs_read_time{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m]))/(irate(openebs_reads{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])))/1000000",
+						"format": "time_series",
+						"intervalFactor": 2,
+						"legendFormat": "Read latency",
+						"refId": "A"
+					},
+					{
+						"expr": "((irate(openebs_write_time{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m]))/(irate(openebs_writes{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])))/1000000",
+						"format": "time_series",
+						"intervalFactor": 2,
+						"legendFormat": "Write  latency",
+						"refId": "B"
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Latency",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"transparent": false,
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"format": "ms",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": "0",
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": null,
+						"show": false
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fill": 1,
+				"gridPos": {
+					"h": 8,
+					"w": 8,
+					"x": 16,
+					"y": 11
+				},
+				"id": 57,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 1,
+				"links": [
+				],
+				"nullPointMode": "null",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "openebs_size_of_volume{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
+						"format": "time_series",
+						"intervalFactor": 1,
+						"legendFormat": "Total size",
+						"refId": "A"
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Total capacity",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"format": "decgbytes",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"mappedLabelOnly": false,
+						"max": null,
+						"min": null,
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"mappedLabelOnly": false,
+						"max": null,
+						"min": null,
+						"show": true
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fill": 3,
+				"gridPos": {
+					"h": 8,
+					"w": 8,
+					"x": 0,
+					"y": 19
+				},
+				"id": 28,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 2,
+				"links": [
+				],
+				"nullPointMode": "null",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "openebs_actual_used{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
+						"format": "time_series",
+						"intervalFactor": 2,
+						"legendFormat": "used",
+						"refId": "A"
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Storage usage",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"format": "decgbytes",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"max": null,
+						"min": "0",
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"labelMappings": [
+						],
+						"logBase": 1,
+						"max": null,
+						"min": null,
+						"show": false
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fill": 3,
+				"gridPos": {
+					"h": 8,
+					"w": 8,
+					"x": 8,
+					"y": 19
+				},
+				"id": 31,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 2,
+				"links": [
+				],
+				"nullPointMode": "null",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "irate(openebs_read_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])/(2048)",
+						"format": "time_series",
+						"intervalFactor": 2,
+						"legendFormat": "Read Throughput",
+						"refId": "A"
+					},
+					{
+						"expr": "irate(openebs_write_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])/(2048)",
+						"format": "time_series",
+						"intervalFactor": 2,
+						"legendFormat": "Write Throughput",
+						"refId": "B"
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Throughput",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"format": "MBs",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": "0",
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": null,
+						"show": false
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			},
+			{
+				"aliasColors": {
+				},
+				"bars": false,
+				"dashLength": 10,
+				"dashes": false,
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fill": 3,
+				"gridPos": {
+					"h": 8,
+					"w": 8,
+					"x": 16,
+					"y": 19
+				},
+				"id": 26,
+				"legend": {
+					"avg": false,
+					"current": false,
+					"max": false,
+					"min": false,
+					"show": true,
+					"total": false,
+					"values": false
+				},
+				"lines": true,
+				"linewidth": 2,
+				"links": [
+				],
+				"nullPointMode": "null as zero",
+				"percentage": false,
+				"pointradius": 5,
+				"points": false,
+				"renderer": "flot",
+				"seriesOverrides": [
+				],
+				"spaceLength": 10,
+				"stack": false,
+				"steppedLine": false,
+				"targets": [
+					{
+						"expr": "(irate(openebs_read_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])/(1024))*512/(irate(openebs_reads{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m]))",
+						"format": "time_series",
+						"hide": false,
+						"intervalFactor": 2,
+						"legendFormat": "Read block size",
+						"refId": "A"
+					},
+					{
+						"expr": "(irate(openebs_write_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m])/(1024))*512/(irate(openebs_writes{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[2m]))",
+						"format": "time_series",
+						"intervalFactor": 2,
+						"legendFormat": "Write block size",
+						"refId": "B"
+					}
+				],
+				"thresholds": [
+				],
+				"timeFrom": null,
+				"timeShift": null,
+				"title": "Block size",
+				"tooltip": {
+					"shared": true,
+					"sort": 0,
+					"value_type": "individual"
+				},
+				"transparent": false,
+				"type": "graph",
+				"xaxis": {
+					"buckets": null,
+					"mode": "time",
+					"name": null,
+					"show": true,
+					"values": [
+					]
+				},
+				"yaxes": [
+					{
+						"format": "deckbytes",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": "0",
+						"show": true
+					},
+					{
+						"format": "short",
+						"label": null,
+						"logBase": 1,
+						"max": null,
+						"min": null,
+						"show": false
+					}
+				],
+				"yaxis": {
+					"align": false,
+					"alignLevel": null
+				}
+			}
+		],
+		"refresh": "1m",
+		"schemaVersion": 16,
+		"style": "light",
+		"tags": [
+		],
+		"templating": {
+			"list": [
+				{
+					"allValue": null,
+					"current": {
+					},
+					"hide": 2,
+					"includeAll": false,
+					"label": "Cluster:",
+					"multi": false,
+					"name": "Cluster_uuid",
+					"options": [
+						{
+							"selected": false,
+							"text": "",
+							"value": ""
+						}
+					],
+					"query": "",
+					"type": "custom"
+				},
+				{
+					"allValue": null,
+					"current": {
+					},
+					"hide": 2,
+					"includeAll": false,
+					"label": "Volume:",
+					"multi": false,
+					"name": "openebs_Volume",
+					"options": [
+						{
+							"selected": false,
+							"text": "",
+							"value": ""
+						}
+					],
+					"query": "",
+					"type": "custom"
+				},
+				{
+					"allValue": null,
+					"current": {
+					},
+					"datasource": "DS_OPENEBS_PROMETHEUS",
+					"hide": 2,
+					"includeAll": false,
+					"label": "Cluster",
+					"multi": false,
+					"name": "cluster_name",
+					"options": [
+					],
+					"query": "label_values(openebs_actual_used{openebs_pv=~\"$openebs_Volume\"},job)",
+					"refresh": 2,
+					"regex": "/cluster_uuid_(.*)_.*/",
+					"sort": 0,
+					"tagValuesQuery": "",
+					"tags": [
+					],
+					"tagsQuery": "",
+					"type": "query",
+					"useTags": false
+				},
+				{
+					"allValue": null,
+					"current": {
+					},
+					"datasource": "DS_OPENEBS_PROMETHEUS",
+					"hide": 2,
+					"includeAll": false,
+					"label": "Openebs pvc",
+					"multi": false,
+					"name": "openebs_pvc",
+					"options": [
+					],
+					"query": "label_values(openebs_size_of_volume{job=~\".*$Cluster_uuid.*\",openebs_pv=~\"$openebs_Volume\"},openebs_pvc)",
+					"refresh": 2,
+					"regex": "",
+					"sort": 0,
+					"tagValuesQuery": "",
+					"tags": [
+					],
+					"tagsQuery": "",
+					"type": "query",
+					"useTags": false
+				},
+				{
+					"allValue": null,
+					"current": {
+					},
+					"datasource": "DS_OPENEBS_PROMETHEUS",
+					"hide": 2,
+					"includeAll": false,
+					"label": "pool",
+					"multi": false,
+					"name": "pool",
+					"options": [
+					],
+					"query": "label_values(openebs_replica_status{vol=~\"$openebs_Volume\"},pool)",
+					"refresh": 2,
+					"regex": "",
+					"sort": 0,
+					"tagValuesQuery": "",
+					"tags": [
+					],
+					"tagsQuery": "",
+					"type": "query",
+					"useTags": false
+				},
+				{
+					"allValue": null,
+					"current": {
+					},
+					"datasource": "DS_OPENEBS_PROMETHEUS",
+					"hide": 2,
+					"includeAll": false,
+					"label": "replica_count",
+					"multi": false,
+					"name": "replica_count",
+					"options": [
+					],
+					"query": "query_result(openebs_total_replica_count{openebs_pv=~\"$openebs_Volume\"})",
+					"refresh": 2,
+					"regex": "/.*}(.*) .*/",
+					"sort": 0,
+					"tagValuesQuery": "",
+					"tags": [
+					],
+					"tagsQuery": "",
+					"type": "query",
+					"useTags": false
+				},
+				{
+					"allValue": null,
+					"current": {
+					},
+					"datasource": "DS_OPENEBS_PROMETHEUS",
+					"hide": 2,
+					"includeAll": false,
+					"label": "uptime",
+					"multi": false,
+					"name": "uptime",
+					"options": [
+					],
+					"query": "query_result(openebs_volume_uptime{openebs_pv=~\"$openebs_Volume\"})",
+					"refresh": 2,
+					"regex": "/.*}(.*) .*/",
+					"sort": 0,
+					"tagValuesQuery": "",
+					"tags": [
+					],
+					"tagsQuery": "",
+					"type": "query",
+					"useTags": false
+				},
+				{
+					"allValue": null,
+					"current": {
+					},
+					"datasource": "DS_OPENEBS_PROMETHEUS",
+					"hide": 2,
+					"includeAll": false,
+					"label": "vol",
+					"multi": false,
+					"name": "vol",
+					"options": [
+					],
+					"query": "label_values(openebs_size_of_volume{openebs_pvc=~\"$openebs_pvc\"},openebs_pv)",
+					"refresh": 2,
+					"regex": "",
+					"sort": 0,
+					"tagValuesQuery": "",
+					"tags": [
+					],
+					"tagsQuery": "",
+					"type": "query",
+					"useTags": false
+				},
+				{
+					"allValue": null,
+					"current": {
+					},
+					"hide": 2,
+					"includeAll": false,
+					"label": "projectid",
+					"multi": false,
+					"name": "projectid",
+					"options": [
+						{
+							"selected": false,
+							"text": "",
+							"value": ""
+						}
+					],
+					"query": "",
+					"type": "custom"
+				},
+				{
+					"allValue": null,
+					"current": {
+					},
+					"hide": 2,
+					"includeAll": false,
+					"label": "groupid",
+					"multi": false,
+					"name": "groupid",
+					"options": [
+						{
+							"selected": false,
+							"text": "",
+							"value": ""
+						}
+					],
+					"query": "",
+					"type": "custom"
+				}
+			]
+		},
+		"time": {
+			"from": "now-1h",
+			"to": "now"
+		},
+		"timepicker": {
+			"refresh_intervals": [
+				"5s",
+				"10s",
+				"30s",
+				"1m",
+				"5m",
+				"15m",
+				"30m",
+				"1h",
+				"2h",
+				"1d"
+			],
+			"time_options": [
+				"5m",
+				"15m",
+				"1h",
+				"6h",
+				"12h",
+				"24h",
+				"2d",
+				"7d",
+				"30d"
+			]
+		},
+		"timezone": "",
+		"title": "Volume tiled view dashboard",
+		"uid": "f46a2d03-c2af-4954-b2b3-307c4d77bcaf",
+		"version": 3
+	},
+	"overwrite": true
+}

--- a/grafana-charts/volumeworkloadreportdashboard.json
+++ b/grafana-charts/volumeworkloadreportdashboard.json
@@ -1,0 +1,423 @@
+{
+	"dashboard": {
+		"__inputs": [
+			{
+				"name": "DS_OPENEBS_PROMETHEUS",
+				"label": "openebs Prometheus",
+				"description": "",
+				"type": "datasource",
+				"pluginId": "prometheus",
+				"pluginName": "Prometheus"
+			}
+		],
+		"__requires": [
+			{
+				"type": "grafana",
+				"id": "grafana",
+				"name": "Grafana",
+				"version": "5.1.3"
+			},
+			{
+				"type": "panel",
+				"id": "graph",
+				"name": "Graph",
+				"version": ""
+			},
+			{
+				"type": "datasource",
+				"id": "prometheus",
+				"name": "Prometheus",
+				"version": "1.0.0"
+			},
+			{
+				"type": "panel",
+				"id": "singlestat",
+				"name": "Singlestat",
+				"version": ""
+			},
+			{
+				"type": "panel",
+				"id": "text",
+				"name": "Text",
+				"version": ""
+			}
+		],
+		"annotations": {
+			"list": [
+			]
+		},
+		"editable": true,
+		"gnetId": null,
+		"graphTooltip": 0,
+		"id": null,
+		"iteration": 1526476933420,
+		"links": [
+		],
+		"panels": [
+			{
+				"columns": [
+					{
+						"text": "Total",
+						"value": "total"
+					}
+				],
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fontSize": "100%",
+				"gridPos": {
+					"h": 8,
+					"w": 12,
+					"x": 0,
+					"y": 0
+				},
+				"id": 1,
+				"links": [
+				],
+				"pageSize": null,
+				"scroll": true,
+				"showHeader": true,
+				"sort": {
+					"col": 1,
+					"desc": true
+				},
+				"styles": [
+					{
+						"alias": "",
+						"colorMode": null,
+						"colors": [
+							"rgba(245, 54, 54, 0.9)",
+							"rgba(237, 129, 40, 0.89)",
+							"rgba(50, 172, 45, 0.97)"
+						],
+						"decimals": null,
+						"pattern": "Total",
+						"thresholds": [
+						],
+						"type": "number",
+						"unit": "none"
+					},
+					{
+						"alias": "Volume Name",
+						"colorMode": null,
+						"colors": [
+							"rgba(245, 54, 54, 0.9)",
+							"rgba(237, 129, 40, 0.89)",
+							"rgba(50, 172, 45, 0.97)"
+						],
+						"dateFormat": "YYYY-MM-DD HH:mm:ss",
+						"decimals": null,
+						"pattern": "Metric",
+						"sanitize": false,
+						"thresholds": [
+						],
+						"type": "string",
+						"unit": "short"
+					}
+				],
+				"targets": [
+					{
+						"expr": "(irate(openebs_reads{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m]))+(irate(openebs_writes{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m]))",
+						"format": "time_series",
+						"intervalFactor": 2,
+						"legendFormat": "{{openebs_pvc}}",
+						"refId": "A"
+					}
+				],
+				"title": "IOPS",
+				"transform": "timeseries_aggregations",
+				"type": "table"
+			},
+			{
+				"columns": [
+					{
+						"text": "Total",
+						"value": "total"
+					}
+				],
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fontSize": "100%",
+				"gridPos": {
+					"h": 8,
+					"w": 12,
+					"x": 12,
+					"y": 0
+				},
+				"id": 2,
+				"links": [
+				],
+				"pageSize": null,
+				"scroll": true,
+				"showHeader": true,
+				"sort": {
+					"col": 1,
+					"desc": true
+				},
+				"styles": [
+					{
+						"alias": "",
+						"colorMode": null,
+						"colors": [
+							"rgba(245, 54, 54, 0.9)",
+							"rgba(237, 129, 40, 0.89)",
+							"rgba(50, 172, 45, 0.97)"
+						],
+						"decimals": 3,
+						"pattern": "Total",
+						"thresholds": [
+						],
+						"type": "number",
+						"unit": "MBs"
+					},
+					{
+						"alias": "Volume Name",
+						"colorMode": null,
+						"colors": [
+							"rgba(245, 54, 54, 0.9)",
+							"rgba(237, 129, 40, 0.89)",
+							"rgba(50, 172, 45, 0.97)"
+						],
+						"dateFormat": "YYYY-MM-DD HH:mm:ss",
+						"decimals": 2,
+						"pattern": "Metric",
+						"thresholds": [
+						],
+						"type": "string",
+						"unit": "short"
+					}
+				],
+				"targets": [
+					{
+						"expr": "(irate(openebs_read_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m])/(2048)) + (irate(openebs_write_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m])/(2048))",
+						"format": "time_series",
+						"intervalFactor": 2,
+						"legendFormat": "{{openebs_pvc}}",
+						"refId": "A"
+					}
+				],
+				"title": "Throughput",
+				"transform": "timeseries_aggregations",
+				"type": "table"
+			},
+			{
+				"columns": [
+					{
+						"text": "Current",
+						"value": "current"
+					}
+				],
+				"datasource": "DS_OPENEBS_PROMETHEUS",
+				"fontSize": "100%",
+				"gridPos": {
+					"h": 7,
+					"w": 24,
+					"x": 0,
+					"y": 8
+				},
+				"id": 3,
+				"links": [
+				],
+				"pageSize": null,
+				"scroll": true,
+				"showHeader": true,
+				"sort": {
+					"col": 1,
+					"desc": true
+				},
+				"styles": [
+					{
+						"alias": "Latest Storage Usage",
+						"colorMode": null,
+						"colors": [
+							"rgba(245, 54, 54, 0.9)",
+							"rgba(237, 129, 40, 0.89)",
+							"rgba(50, 172, 45, 0.97)"
+						],
+						"decimals": 3,
+						"pattern": "Current",
+						"thresholds": [
+						],
+						"type": "number",
+						"unit": "decgbytes"
+					},
+					{
+						"alias": "Volume Name",
+						"colorMode": null,
+						"colors": [
+							"rgba(245, 54, 54, 0.9)",
+							"rgba(237, 129, 40, 0.89)",
+							"rgba(50, 172, 45, 0.97)"
+						],
+						"dateFormat": "YYYY-MM-DD HH:mm:ss",
+						"decimals": 2,
+						"pattern": "Metric",
+						"thresholds": [
+						],
+						"type": "string",
+						"unit": "short"
+					}
+				],
+				"targets": [
+					{
+						"expr": "openebs_actual_used{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
+						"format": "time_series",
+						"intervalFactor": 2,
+						"legendFormat": "{{openebs_pvc}}",
+						"refId": "A"
+					}
+				],
+				"title": "Storage",
+				"transform": "timeseries_aggregations",
+				"type": "table"
+			}
+		],
+		"refresh": "1m",
+		"schemaVersion": 16,
+		"style": "dark",
+		"tags": [
+		],
+		"templating": {
+			"list": [
+				{
+					"allValue": null,
+					"current": {
+					},
+					"datasource": "DS_OPENEBS_PROMETHEUS",
+					"hide": 0,
+					"includeAll": false,
+					"label": "Cluster",
+					"multi": false,
+					"name": "Cluster_uuid",
+					"options": [
+					],
+					"query": "label_values(openebs_size_of_volume,job)",
+					"refresh": 2,
+					"regex": "/cluster_uuid_(.*)_.*/",
+					"sort": 0,
+					"tagValuesQuery": "",
+					"tags": [
+					],
+					"tagsQuery": "",
+					"type": "query",
+					"useTags": false
+				},
+				{
+					"allValue": null,
+					"current": {
+					},
+					"datasource": "DS_OPENEBS_PROMETHEUS",
+					"hide": 2,
+					"includeAll": true,
+					"label": "Volume",
+					"multi": true,
+					"name": "openebs_Volume",
+					"options": [
+					],
+					"query": "label_values(openebs_size_of_volume{job=~\".*$Cluster_uuid.*\"},openebs_pv)",
+					"refresh": 2,
+					"regex": "",
+					"sort": 0,
+					"tagValuesQuery": "",
+					"tags": [
+					],
+					"tagsQuery": "",
+					"type": "query",
+					"useTags": false
+				},
+				{
+					"allValue": null,
+					"current": {
+					},
+					"datasource": "DS_OPENEBS_PROMETHEUS",
+					"hide": 0,
+					"includeAll": true,
+					"label": "Openebs pvc",
+					"multi": true,
+					"name": "openebs_pvc",
+					"options": [
+					],
+					"query": "label_values(openebs_size_of_volume{job=~\".*$Cluster_uuid.*\",openebs_pv=~\"$openebs_Volume\"},openebs_pvc)",
+					"refresh": 2,
+					"regex": "",
+					"sort": 0,
+					"tagValuesQuery": "",
+					"tags": [
+					],
+					"tagsQuery": "",
+					"type": "query",
+					"useTags": false
+				},
+				{
+					"allValue": null,
+					"current": {
+					},
+					"hide": 2,
+					"includeAll": false,
+					"label": "projectid",
+					"multi": false,
+					"name": "projectid",
+					"options": [
+						{
+							"selected": false,
+							"text": "",
+							"value": ""
+						}
+					],
+					"query": "",
+					"type": "custom"
+				},
+				{
+					"allValue": null,
+					"current": {
+					},
+					"hide": 2,
+					"includeAll": false,
+					"label": "groupid",
+					"multi": false,
+					"name": "groupid",
+					"options": [
+						{
+							"selected": false,
+							"text": "",
+							"value": ""
+						}
+					],
+					"query": "",
+					"type": "custom"
+				}
+			]
+		},
+		"time": {
+			"from": "now-1h",
+			"to": "now"
+		},
+		"timepicker": {
+			"refresh_intervals": [
+				"5s",
+				"10s",
+				"30s",
+				"1m",
+				"5m",
+				"15m",
+				"30m",
+				"1h",
+				"2h",
+				"1d"
+			],
+			"time_options": [
+				"5m",
+				"15m",
+				"1h",
+				"6h",
+				"12h",
+				"24h",
+				"2d",
+				"7d",
+				"30d"
+			]
+		},
+		"timezone": "",
+		"title": "Volume workload report",
+		"uid": "c6472980-592f-476c-92a5-f63478a733cf",
+		"version": 2
+	},
+	"overwrite": true
+}

--- a/grafana-charts/volumeworkloadreportdashboard.json
+++ b/grafana-charts/volumeworkloadreportdashboard.json
@@ -1,423 +1,377 @@
 {
-	"dashboard": {
-		"__inputs": [
-			{
-				"name": "DS_OPENEBS_PROMETHEUS",
-				"label": "openebs Prometheus",
-				"description": "",
-				"type": "datasource",
-				"pluginId": "prometheus",
-				"pluginName": "Prometheus"
-			}
-		],
-		"__requires": [
-			{
-				"type": "grafana",
-				"id": "grafana",
-				"name": "Grafana",
-				"version": "5.1.3"
-			},
-			{
-				"type": "panel",
-				"id": "graph",
-				"name": "Graph",
-				"version": ""
-			},
-			{
-				"type": "datasource",
-				"id": "prometheus",
-				"name": "Prometheus",
-				"version": "1.0.0"
-			},
-			{
-				"type": "panel",
-				"id": "singlestat",
-				"name": "Singlestat",
-				"version": ""
-			},
-			{
-				"type": "panel",
-				"id": "text",
-				"name": "Text",
-				"version": ""
-			}
-		],
-		"annotations": {
-			"list": [
-			]
-		},
-		"editable": true,
-		"gnetId": null,
-		"graphTooltip": 0,
-		"id": null,
-		"iteration": 1526476933420,
-		"links": [
-		],
-		"panels": [
-			{
-				"columns": [
-					{
-						"text": "Total",
-						"value": "total"
-					}
-				],
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fontSize": "100%",
-				"gridPos": {
-					"h": 8,
-					"w": 12,
-					"x": 0,
-					"y": 0
-				},
-				"id": 1,
-				"links": [
-				],
-				"pageSize": null,
-				"scroll": true,
-				"showHeader": true,
-				"sort": {
-					"col": 1,
-					"desc": true
-				},
-				"styles": [
-					{
-						"alias": "",
-						"colorMode": null,
-						"colors": [
-							"rgba(245, 54, 54, 0.9)",
-							"rgba(237, 129, 40, 0.89)",
-							"rgba(50, 172, 45, 0.97)"
-						],
-						"decimals": null,
-						"pattern": "Total",
-						"thresholds": [
-						],
-						"type": "number",
-						"unit": "none"
-					},
-					{
-						"alias": "Volume Name",
-						"colorMode": null,
-						"colors": [
-							"rgba(245, 54, 54, 0.9)",
-							"rgba(237, 129, 40, 0.89)",
-							"rgba(50, 172, 45, 0.97)"
-						],
-						"dateFormat": "YYYY-MM-DD HH:mm:ss",
-						"decimals": null,
-						"pattern": "Metric",
-						"sanitize": false,
-						"thresholds": [
-						],
-						"type": "string",
-						"unit": "short"
-					}
-				],
-				"targets": [
-					{
-						"expr": "(irate(openebs_reads{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m]))+(irate(openebs_writes{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m]))",
-						"format": "time_series",
-						"intervalFactor": 2,
-						"legendFormat": "{{openebs_pvc}}",
-						"refId": "A"
-					}
-				],
-				"title": "IOPS",
-				"transform": "timeseries_aggregations",
-				"type": "table"
-			},
-			{
-				"columns": [
-					{
-						"text": "Total",
-						"value": "total"
-					}
-				],
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fontSize": "100%",
-				"gridPos": {
-					"h": 8,
-					"w": 12,
-					"x": 12,
-					"y": 0
-				},
-				"id": 2,
-				"links": [
-				],
-				"pageSize": null,
-				"scroll": true,
-				"showHeader": true,
-				"sort": {
-					"col": 1,
-					"desc": true
-				},
-				"styles": [
-					{
-						"alias": "",
-						"colorMode": null,
-						"colors": [
-							"rgba(245, 54, 54, 0.9)",
-							"rgba(237, 129, 40, 0.89)",
-							"rgba(50, 172, 45, 0.97)"
-						],
-						"decimals": 3,
-						"pattern": "Total",
-						"thresholds": [
-						],
-						"type": "number",
-						"unit": "MBs"
-					},
-					{
-						"alias": "Volume Name",
-						"colorMode": null,
-						"colors": [
-							"rgba(245, 54, 54, 0.9)",
-							"rgba(237, 129, 40, 0.89)",
-							"rgba(50, 172, 45, 0.97)"
-						],
-						"dateFormat": "YYYY-MM-DD HH:mm:ss",
-						"decimals": 2,
-						"pattern": "Metric",
-						"thresholds": [
-						],
-						"type": "string",
-						"unit": "short"
-					}
-				],
-				"targets": [
-					{
-						"expr": "(irate(openebs_read_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m])/(2048)) + (irate(openebs_write_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m])/(2048))",
-						"format": "time_series",
-						"intervalFactor": 2,
-						"legendFormat": "{{openebs_pvc}}",
-						"refId": "A"
-					}
-				],
-				"title": "Throughput",
-				"transform": "timeseries_aggregations",
-				"type": "table"
-			},
-			{
-				"columns": [
-					{
-						"text": "Current",
-						"value": "current"
-					}
-				],
-				"datasource": "DS_OPENEBS_PROMETHEUS",
-				"fontSize": "100%",
-				"gridPos": {
-					"h": 7,
-					"w": 24,
-					"x": 0,
-					"y": 8
-				},
-				"id": 3,
-				"links": [
-				],
-				"pageSize": null,
-				"scroll": true,
-				"showHeader": true,
-				"sort": {
-					"col": 1,
-					"desc": true
-				},
-				"styles": [
-					{
-						"alias": "Latest Storage Usage",
-						"colorMode": null,
-						"colors": [
-							"rgba(245, 54, 54, 0.9)",
-							"rgba(237, 129, 40, 0.89)",
-							"rgba(50, 172, 45, 0.97)"
-						],
-						"decimals": 3,
-						"pattern": "Current",
-						"thresholds": [
-						],
-						"type": "number",
-						"unit": "decgbytes"
-					},
-					{
-						"alias": "Volume Name",
-						"colorMode": null,
-						"colors": [
-							"rgba(245, 54, 54, 0.9)",
-							"rgba(237, 129, 40, 0.89)",
-							"rgba(50, 172, 45, 0.97)"
-						],
-						"dateFormat": "YYYY-MM-DD HH:mm:ss",
-						"decimals": 2,
-						"pattern": "Metric",
-						"thresholds": [
-						],
-						"type": "string",
-						"unit": "short"
-					}
-				],
-				"targets": [
-					{
-						"expr": "openebs_actual_used{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
-						"format": "time_series",
-						"intervalFactor": 2,
-						"legendFormat": "{{openebs_pvc}}",
-						"refId": "A"
-					}
-				],
-				"title": "Storage",
-				"transform": "timeseries_aggregations",
-				"type": "table"
-			}
-		],
-		"refresh": "1m",
-		"schemaVersion": 16,
-		"style": "dark",
-		"tags": [
-		],
-		"templating": {
-			"list": [
-				{
-					"allValue": null,
-					"current": {
-					},
-					"datasource": "DS_OPENEBS_PROMETHEUS",
-					"hide": 0,
-					"includeAll": false,
-					"label": "Cluster",
-					"multi": false,
-					"name": "Cluster_uuid",
-					"options": [
-					],
-					"query": "label_values(openebs_size_of_volume,job)",
-					"refresh": 2,
-					"regex": "/cluster_uuid_(.*)_.*/",
-					"sort": 0,
-					"tagValuesQuery": "",
-					"tags": [
-					],
-					"tagsQuery": "",
-					"type": "query",
-					"useTags": false
-				},
-				{
-					"allValue": null,
-					"current": {
-					},
-					"datasource": "DS_OPENEBS_PROMETHEUS",
-					"hide": 2,
-					"includeAll": true,
-					"label": "Volume",
-					"multi": true,
-					"name": "openebs_Volume",
-					"options": [
-					],
-					"query": "label_values(openebs_size_of_volume{job=~\".*$Cluster_uuid.*\"},openebs_pv)",
-					"refresh": 2,
-					"regex": "",
-					"sort": 0,
-					"tagValuesQuery": "",
-					"tags": [
-					],
-					"tagsQuery": "",
-					"type": "query",
-					"useTags": false
-				},
-				{
-					"allValue": null,
-					"current": {
-					},
-					"datasource": "DS_OPENEBS_PROMETHEUS",
-					"hide": 0,
-					"includeAll": true,
-					"label": "Openebs pvc",
-					"multi": true,
-					"name": "openebs_pvc",
-					"options": [
-					],
-					"query": "label_values(openebs_size_of_volume{job=~\".*$Cluster_uuid.*\",openebs_pv=~\"$openebs_Volume\"},openebs_pvc)",
-					"refresh": 2,
-					"regex": "",
-					"sort": 0,
-					"tagValuesQuery": "",
-					"tags": [
-					],
-					"tagsQuery": "",
-					"type": "query",
-					"useTags": false
-				},
-				{
-					"allValue": null,
-					"current": {
-					},
-					"hide": 2,
-					"includeAll": false,
-					"label": "projectid",
-					"multi": false,
-					"name": "projectid",
-					"options": [
-						{
-							"selected": false,
-							"text": "",
-							"value": ""
-						}
-					],
-					"query": "",
-					"type": "custom"
-				},
-				{
-					"allValue": null,
-					"current": {
-					},
-					"hide": 2,
-					"includeAll": false,
-					"label": "groupid",
-					"multi": false,
-					"name": "groupid",
-					"options": [
-						{
-							"selected": false,
-							"text": "",
-							"value": ""
-						}
-					],
-					"query": "",
-					"type": "custom"
-				}
-			]
-		},
-		"time": {
-			"from": "now-1h",
-			"to": "now"
-		},
-		"timepicker": {
-			"refresh_intervals": [
-				"5s",
-				"10s",
-				"30s",
-				"1m",
-				"5m",
-				"15m",
-				"30m",
-				"1h",
-				"2h",
-				"1d"
-			],
-			"time_options": [
-				"5m",
-				"15m",
-				"1h",
-				"6h",
-				"12h",
-				"24h",
-				"2d",
-				"7d",
-				"30d"
-			]
-		},
-		"timezone": "",
-		"title": "Volume workload report",
-		"uid": "c6472980-592f-476c-92a5-f63478a733cf",
-		"version": 2
-	},
-	"overwrite": true
+  "__inputs": [
+    {
+      "name": "DS_OPENEBS_PROMETHEUS",
+      "label": "openebs Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "5.1.3"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "singlestat",
+      "name": "Singlestat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "text",
+      "name": "Text",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "iteration": 1526476933420,
+  "links": [],
+  "panels": [
+    {
+      "columns": [
+        {
+          "text": "Total",
+          "value": "total"
+        }
+      ],
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "links": [],
+      "pageSize": null,
+      "scroll": true,
+      "showHeader": true,
+      "sort": {
+        "col": 1,
+        "desc": true
+      },
+      "styles": [
+        {
+          "alias": "",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "decimals": null,
+          "pattern": "Total",
+          "thresholds": [],
+          "type": "number",
+          "unit": "none"
+        },
+        {
+          "alias": "Volume Name",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": null,
+          "pattern": "Metric",
+          "sanitize": false,
+          "thresholds": [],
+          "type": "string",
+          "unit": "short"
+        }
+      ],
+      "targets": [
+        {
+          "expr": "(irate(openebs_reads{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m]))+(irate(openebs_writes{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m]))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{openebs_pvc}}",
+          "refId": "A"
+        }
+      ],
+      "title": "IOPS",
+      "transform": "timeseries_aggregations",
+      "type": "table"
+    },
+    {
+      "columns": [
+        {
+          "text": "Total",
+          "value": "total"
+        }
+      ],
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "links": [],
+      "pageSize": null,
+      "scroll": true,
+      "showHeader": true,
+      "sort": {
+        "col": 1,
+        "desc": true
+      },
+      "styles": [
+        {
+          "alias": "",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "decimals": 3,
+          "pattern": "Total",
+          "thresholds": [],
+          "type": "number",
+          "unit": "MBs"
+        },
+        {
+          "alias": "Volume Name",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "pattern": "Metric",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short"
+        }
+      ],
+      "targets": [
+        {
+          "expr": "(irate(openebs_read_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m])/(2048)) + (irate(openebs_write_block_count{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}[5m])/(2048))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{openebs_pvc}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Throughput",
+      "transform": "timeseries_aggregations",
+      "type": "table"
+    },
+    {
+      "columns": [
+        {
+          "text": "Current",
+          "value": "current"
+        }
+      ],
+      "datasource": "DS_OPENEBS_PROMETHEUS",
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "links": [],
+      "pageSize": null,
+      "scroll": true,
+      "showHeader": true,
+      "sort": {
+        "col": 1,
+        "desc": true
+      },
+      "styles": [
+        {
+          "alias": "Latest Storage Usage",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "decimals": 3,
+          "pattern": "Current",
+          "thresholds": [],
+          "type": "number",
+          "unit": "decgbytes"
+        },
+        {
+          "alias": "Volume Name",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "pattern": "Metric",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short"
+        }
+      ],
+      "targets": [
+        {
+          "expr": "openebs_actual_used{openebs_pvc=~\"$openebs_pvc\",openebs_pv=~\"$openebs_Volume\"}",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{openebs_pvc}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Storage",
+      "transform": "timeseries_aggregations",
+      "type": "table"
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 16,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "DS_OPENEBS_PROMETHEUS",
+        "hide": 2,
+        "includeAll": true,
+        "label": "Volume",
+        "multi": true,
+        "name": "openebs_Volume",
+        "options": [],
+        "query": "label_values(openebs_size_of_volume, openebs_pv)",
+        "refresh": 2,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "DS_OPENEBS_PROMETHEUS",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Openebs pvc",
+        "multi": true,
+        "name": "openebs_pvc",
+        "options": [],
+        "query": "label_values(openebs_size_of_volume{openebs_pv=~\"$openebs_Volume\"},openebs_pvc)",
+        "refresh": 2,
+        "regex": "",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "hide": 2,
+        "includeAll": false,
+        "label": "projectid",
+        "multi": false,
+        "name": "projectid",
+        "options": [
+          {
+            "selected": false,
+            "text": "",
+            "value": ""
+          }
+        ],
+        "query": "",
+        "type": "custom"
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "hide": 2,
+        "includeAll": false,
+        "label": "groupid",
+        "multi": false,
+        "name": "groupid",
+        "options": [
+          {
+            "selected": false,
+            "text": "",
+            "value": ""
+          }
+        ],
+        "query": "",
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Volume workload report",
+  "uid": "c6472980-592f-476c-92a5-f63478a733cf",
+  "version": 2
 }


### PR DESCRIPTION
#### Special notes for your reviewer:
The following grafana dashboards for volumes and pools are added:
1. clustervolumesdashboard
2. cstorvolumereplicasdashboard
3. localpvdashboard
4. storagepoolclaimdashboard
5. storageclassvolumedashboard
6. Storagepooldashboard
7. volumetiledviewdashboard
8. volumeworkloadreportdashboard

## Here are the following screenshots for the dashboards:
### Localpv dashboard:
![Screenshot from 2021-02-13 15-41-39](https://user-images.githubusercontent.com/44068648/107848531-20987700-6e1a-11eb-8dc5-e08e1a70d7a9.png)

### clustervolume dashboard:
![Screenshot from 2021-02-12 15-20-43](https://user-images.githubusercontent.com/44068648/107848570-6d7c4d80-6e1a-11eb-9ac4-64d9a5845b83.png)

### cstorvolumereplica dashboard:
![Screenshot from 2021-02-12 21-57-50](https://user-images.githubusercontent.com/44068648/107848594-a5839080-6e1a-11eb-8e00-a23a1d742848.png)

### storageclassvolume dashboard:
![Screenshot from 2021-02-12 22-41-47](https://user-images.githubusercontent.com/44068648/107848620-d82d8900-6e1a-11eb-878d-7d4030658e7d.png)

### storagepoolclaim dashboard:
![Screenshot from 2021-02-12 15-15-24](https://user-images.githubusercontent.com/44068648/107848634-001cec80-6e1b-11eb-8627-4758bcd53a53.png)

### storagepool dashboard:
![Screenshot from 2021-02-13 16-33-03](https://user-images.githubusercontent.com/44068648/107848643-162aad00-6e1b-11eb-86b0-d7866619996b.png)

### volumetitleview dashboard:
![Screenshot from 2021-02-12 21-51-06](https://user-images.githubusercontent.com/44068648/107848663-3490a880-6e1b-11eb-98ff-8e9e593877ea.png)

### volumeworkloadreport dashboard:
![Screenshot from 2021-02-12 14-08-09](https://user-images.githubusercontent.com/44068648/107848675-4f631d00-6e1b-11eb-99d3-4a430e721b9a.png)

Refer the following doc for details regarding the dashboards: https://docs.google.com/document/d/1hM9jaPX8OUoAx4exklJq0pLxgvvf-Hh4BJLaZ8V2bFs/edit
 
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/openebs]`)
