### PR TITLE
chore(cstor-operator): add custom priorityclass in csi driver deployments

### DIFF
--- a/2.6.0/cstor-operator.yaml
+++ b/2.6.0/cstor-operator.yaml
@@ -897,6 +897,22 @@ spec:
   podInfoOnMount: true
   attachRequired: false
 ---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: openebs-csi-controller-critical
+value: 900000000
+globalDefault: false
+description: "This priority class should be used for the CStor CSI driver controller deployment only."
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: openebs-csi-node-critical
+value: 900001000
+globalDefault: false
+description: "This priority class should be used for the CStor CSI driver node deployment only."
+---
 
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -1055,7 +1071,7 @@ spec:
         openebs.io/component-name: openebs-cstor-csi-controller
         openebs.io/version: 2.6.0
     spec:
-      priorityClassName: system-cluster-critical
+      priorityClassName: openebs-csi-controller-critical
       serviceAccount: openebs-cstor-csi-controller-sa
       containers:
         - name: csi-resizer
@@ -1310,7 +1326,7 @@ spec:
         openebs.io/component-name: openebs-cstor-csi-node
         openebs.io/version: 2.6.0
     spec:
-      priorityClassName: system-node-critical
+      priorityClassName: openebs-csi-node-critical
       serviceAccount: openebs-cstor-csi-node-sa
       hostNetwork: true
       containers:

--- a/cstor-operator.yaml
+++ b/cstor-operator.yaml
@@ -1055,7 +1055,7 @@ spec:
         openebs.io/component-name: openebs-cstor-csi-controller
         openebs.io/version: 2.6.0
     spec:
-      priorityClassName: system-cluster-critical
+      priorityClassName: openebs-csi-controller-critical
       serviceAccount: openebs-cstor-csi-controller-sa
       containers:
         - name: csi-resizer
@@ -1310,7 +1310,7 @@ spec:
         openebs.io/component-name: openebs-cstor-csi-node
         openebs.io/version: 2.6.0
     spec:
-      priorityClassName: system-node-critical
+      priorityClassName: openebs-csi-node-critical
       serviceAccount: openebs-cstor-csi-node-sa
       hostNetwork: true
       containers:
@@ -4636,6 +4636,22 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: openebs-csi-controller-critical
+value: 900000000
+globalDefault: false
+description: "This priority class should be used for the CStor CSI driver controller deployment only."
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: openebs-csi-node-critical
+value: 900001000
+globalDefault: false
+description: "This priority class should be used for the CStor CSI driver node deployment only."
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION

some of the k8s distribution like GKE doesn't allow core priorityclass to be used outside `kube-system` namespace hence replacing k8s priorityclass with custom once.

These changes already done for cstor helm charts.

Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/openebs]`)
