### PR TITLE
refact(cstor-operator): update the service account name same as cstor charts

### DIFF
--- a/cstor-operator.yaml
+++ b/cstor-operator.yaml
@@ -8,7 +8,7 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: openebs-maya-operator
+  name: openebs-cstor-operator
   namespace: openebs
 ---
 # Define Role that allows operations on K8s pods/deployments
@@ -66,7 +66,7 @@ metadata:
   name: openebs-cstor-operator
 subjects:
 - kind: ServiceAccount
-  name: openebs-maya-operator
+  name: openebs-cstor-operator
   namespace: openebs
 roleRef:
   kind: ClusterRole
@@ -95,7 +95,7 @@ metadata:
   name: openebs-cstor-migration
 subjects:
 - kind: ServiceAccount
-  name: openebs-maya-operator
+  name: openebs-cstor-operator
   namespace: openebs
 roleRef:
   kind: ClusterRole
@@ -4681,7 +4681,7 @@ spec:
         openebs.io/component-name: cspc-operator
         openebs.io/version: 2.7.0
     spec:
-      serviceAccountName: openebs-maya-operator
+      serviceAccountName: openebs-cstor-operator
       containers:
       - name: cspc-operator
         imagePullPolicy: IfNotPresent
@@ -4746,7 +4746,7 @@ spec:
         openebs.io/component-name: cvc-operator
         openebs.io/version: 2.7.0
     spec:
-      serviceAccountName: openebs-maya-operator
+      serviceAccountName: openebs-cstor-operator
       containers:
       - name: cvc-operator
         imagePullPolicy: IfNotPresent
@@ -4820,7 +4820,7 @@ spec:
         openebs.io/component-name: cstor-admission-webhook
         openebs.io/version: 2.7.0
     spec:
-      serviceAccountName: openebs-maya-operator
+      serviceAccountName: openebs-cstor-operator
       containers:
         - name: admission-webhook
           image: openebs/cstor-webhook:2.7.0
@@ -4916,7 +4916,7 @@ spec:
       # kubectl label node <node-name> "openebs.io/nodegroup"="storage-node"
       #nodeSelector:
       #  "openebs.io/nodegroup": "storage-node"
-      serviceAccountName: openebs-maya-operator
+      serviceAccountName: openebs-cstor-operator
       hostNetwork: true
       # host PID is used to check status of iSCSI Service when the NDM
       # API service is enabled
@@ -5034,7 +5034,7 @@ spec:
         openebs.io/component-name: ndm-operator
         openebs.io/version: 2.7.0
     spec:
-      serviceAccountName: openebs-maya-operator
+      serviceAccountName: openebs-cstor-operator
       containers:
         - name: node-disk-operator
           image: openebs/node-disk-operator:1.3.0


### PR DESCRIPTION
Use the similar naming convention as cstor charts to define the service account name , renamed the service accoint to  `openebs-cstor-operator`  instead of using the leagcy one `openebs-maya-operator`