### PR TITLE
fix(helm): replace deprecated hyperkube image in pre-delete hook

### DIFF
--- a/charts/openebs/Chart.yaml
+++ b/charts/openebs/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 2.8.0
+version: 2.8.1
 name: openebs
 appVersion: 2.8.0
 description: Containerized Storage for Containers

--- a/charts/openebs/templates/cleanup-webhook.yaml
+++ b/charts/openebs/templates/cleanup-webhook.yaml
@@ -1,3 +1,9 @@
+# HELM first deletes RBAC, then it tries to delete other resources like SPC and PVC. 
+# We've got validating webhook on SPC and PVC.
+# But even that the policy of this webhook is Ignore, it fails because the ServiceAccount 
+# does not have permission to access resources like BDC anymore which are used for validation.
+# Therefore we first need to delete webhook so we can delete the rest of the deployments.
+{{- $kubeMinor := .Capabilities.KubeVersion.Minor | replace "+" "" }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -22,8 +28,9 @@ spec:
       {{- end }}
       containers:
         - name: kubectl
-          image: "{{ .Values.hyperkubeImage.repository }}:{{ .Values.hyperkubeImage.tag }}"
-          imagePullPolicy: "{{ .Values.hyperkubeImage.pullPolicy }}"
+          {{- /* bitnami maintains an image for all k8s versions */}}
+          {{- /* see: https://hub.docker.com/r/bitnami/kubectl */}}
+          image: {{ printf "%s/%s:%s.%s" "bitnami" "kubectl" .Capabilities.KubeVersion.Major $kubeMinor }}
           command:
           - /bin/sh
           - -c

--- a/charts/openebs/values.yaml
+++ b/charts/openebs/values.yaml
@@ -270,11 +270,3 @@ analytics:
   enabled: true
   # Specify in hours the duration after which a ping event needs to be sent.
   pingInterval: "24h"
-
-
-# To cleanup the validatingwebhook just before deletion of the charts
-# via a pre-delete webhook job
-hyperkubeImage:
-  repository: "k8s.gcr.io/hyperkube"
-  tag: "v1.12.1"
-  pullPolicy: "IfNotPresent"


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

This PR addresses the issue: https://github.com/openebs/openebs/issues/3383
The solution is based on looking into other projects with similar webhook related problems ref: https://github.com/Kong/gcp-marketplace/blob/main/GKE/Kuma/chart/templates/pre-delete-webhooks.yaml

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/openebs]`)
