### PR TITLE
refact(charts): make cleanup pre hook image configurable

### DIFF
--- a/charts/openebs/Chart.yaml
+++ b/charts/openebs/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 2.9.1
+version: 2.9.2
 name: openebs
 appVersion: 2.9.0
 description: Containerized Storage for Containers

--- a/charts/openebs/README.md
+++ b/charts/openebs/README.md
@@ -135,7 +135,8 @@ The following table lists the configurable parameters of the OpenEBS chart and t
 | `varDirectoryPath.baseDir`              | To store debug info of OpenEBS containers     | `/var/openebs`                            |
 | `healthCheck.initialDelaySeconds`       | Delay before liveness probe is initiated      | `30`                                      |
 | `healthCheck.periodSeconds`             | How often to perform the liveness probe       | `60`                                      |
-
+| `cleanup.image.registry`                | Cleanup pre hook image registry               | `nil`                                     |
+| `cleanup.image.repository`              | Cleanup pre hook image repository             | `"bitnami/kubectl"`                                      |
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,

--- a/charts/openebs/README.md
+++ b/charts/openebs/README.md
@@ -136,7 +136,8 @@ The following table lists the configurable parameters of the OpenEBS chart and t
 | `healthCheck.initialDelaySeconds`       | Delay before liveness probe is initiated      | `30`                                      |
 | `healthCheck.periodSeconds`             | How often to perform the liveness probe       | `60`                                      |
 | `cleanup.image.registry`                | Cleanup pre hook image registry               | `nil`                                     |
-| `cleanup.image.repository`              | Cleanup pre hook image repository             | `"bitnami/kubectl"`                                      |
+| `cleanup.image.repository`              | Cleanup pre hook image repository             | `"bitnami/kubectl"`                       |
+| `cleanup.image.tag`                     | Cleanup pre hook image tag             | `if not provided determined by the k8s version`                       |
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,

--- a/charts/openebs/templates/cleanup-webhook.yaml
+++ b/charts/openebs/templates/cleanup-webhook.yaml
@@ -30,7 +30,11 @@ spec:
         - name: kubectl
           {{- /* bitnami maintains an image for all k8s versions */}}
           {{- /* see: https://hub.docker.com/r/bitnami/kubectl */}}
+          {{- if .Values.cleanup.image.tag }}
+          image: "{{ .Values.cleanup.image.registry }}{{ .Values.cleanup.image.repository }}:{{ .Values.cleanup.image.tag }}"
+          {{- else }}
           image: "{{ .Values.cleanup.image.registry }}{{ .Values.cleanup.image.repository }}:{{ .Capabilities.KubeVersion.Major }}.{{ $kubeMinor }}"
+          {{- end }}
           command:
           - /bin/sh
           - -c

--- a/charts/openebs/templates/cleanup-webhook.yaml
+++ b/charts/openebs/templates/cleanup-webhook.yaml
@@ -30,7 +30,7 @@ spec:
         - name: kubectl
           {{- /* bitnami maintains an image for all k8s versions */}}
           {{- /* see: https://hub.docker.com/r/bitnami/kubectl */}}
-          image: {{ printf "%s/%s:%s.%s" "bitnami" "kubectl" .Capabilities.KubeVersion.Major $kubeMinor }}
+          image: "{{ .Values.cleanup.image.registry }}{{ .Values.cleanup.image.repository }}:{{ .Capabilities.KubeVersion.Major }}.{{ $kubeMinor }}"
           command:
           - /bin/sh
           - -c

--- a/charts/openebs/values.yaml
+++ b/charts/openebs/values.yaml
@@ -269,6 +269,7 @@ analytics:
   # Specify in hours the duration after which a ping event needs to be sent.
   pingInterval: "24h"
 
+<<<<<<< HEAD
 jiva:
 
   # non csi configuration
@@ -571,3 +572,11 @@ zfs-localpv:
 #      repository: openebs/zfs-driver
 #      pullPolicy: IfNotPresent
 #      tag: 1.7.0
+=======
+cleanup:
+  image:
+    # Make sure that registry name end with a '/'.
+    # For example : quay.io/ is a correct value here and quay.io is incorrect
+    registry:
+    repository: bitnami/kubectl
+>>>>>>> refact(charts): make cleanup pre hook image configurable

--- a/charts/openebs/values.yaml
+++ b/charts/openebs/values.yaml
@@ -269,7 +269,6 @@ analytics:
   # Specify in hours the duration after which a ping event needs to be sent.
   pingInterval: "24h"
 
-<<<<<<< HEAD
 jiva:
 
   # non csi configuration
@@ -572,11 +571,10 @@ zfs-localpv:
 #      repository: openebs/zfs-driver
 #      pullPolicy: IfNotPresent
 #      tag: 1.7.0
-=======
 cleanup:
   image:
     # Make sure that registry name end with a '/'.
     # For example : quay.io/ is a correct value here and quay.io is incorrect
     registry:
     repository: bitnami/kubectl
->>>>>>> refact(charts): make cleanup pre hook image configurable
+    tag:


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

This PR makes the cleanup pre delete hook job image configurable for air-gap setups

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/openebs]`)
