### PR TITLE
fix(cleanup-job): add OR clause to prevent job from failing

### DIFF
--- a/charts/openebs/Chart.yaml
+++ b/charts/openebs/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 2.10.0
+version: 2.10.1
 name: openebs
 appVersion: 2.10.0
 description: Containerized Storage for Containers

--- a/charts/openebs/Chart.yaml
+++ b/charts/openebs/Chart.yaml
@@ -27,11 +27,11 @@ dependencies:
     repository: "https://openebs.github.io/dynamic-localpv-provisioner"
     condition: localpv-provisioner.enabled
   - name: cstor
-    version: "2.10.0"
+    version: "2.10.1"
     repository: "https://openebs.github.io/cstor-operators"
     condition: cstor.enabled
   - name: jiva
-    version: "2.10.0"
+    version: "2.10.1"
     repository: "https://openebs.github.io/jiva-operator"
     condition: jiva.enabled
   - name: zfs-localpv

--- a/charts/openebs/templates/cleanup-webhook.yaml
+++ b/charts/openebs/templates/cleanup-webhook.yaml
@@ -40,6 +40,6 @@ spec:
           - /bin/sh
           - -c
           - >
-              kubectl delete validatingWebhookConfiguration openebs-validation-webhook-cfg;
+              kubectl delete validatingWebhookConfiguration openebs-validation-webhook-cfg || true;
       restartPolicy: OnFailure
 {{- end }}

--- a/charts/openebs/values.yaml
+++ b/charts/openebs/values.yaml
@@ -326,7 +326,7 @@ jiva:
 #      registry: quay.io/
 #      repository: openebs/jiva-operator
 #      pullPolicy: IfNotPresent
-#      tag: 2.10.0
+#      tag: 2.10.1
 #
 #  jivaCSIPlugin:
 #    remount: "true"
@@ -334,7 +334,7 @@ jiva:
 #      registry: quay.io/
 #      repository: openebs/jiva-csi
 #      pullPolicy: IfNotPresent
-#      tag: 2.10.0
+#      tag: 2.10.1
 
 cstor:
 


### PR DESCRIPTION
Signed-off-by: Niladri Halder <niladri.halder@mayadata.io>

Cleanup job fails if the validatingwebhookconfiguration is deleted beforehand. This stalls helm chart remove. Eventually leads to timeout. Fixed it with a OR clause.