### PR TITLE
fix(charts): Update provisioner-localpv image to 2.10.1

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -44,7 +44,7 @@ jobs:
         run: ct lint --config ct.yaml
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.0.0
+        uses: helm/kind-action@v1.2.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Add dependency chart repos

--- a/charts/openebs/Chart.yaml
+++ b/charts/openebs/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 2.10.1
+version: 2.10.2
 name: openebs
 appVersion: 2.10.0
 description: Containerized Storage for Containers
@@ -23,7 +23,7 @@ dependencies:
     repository: "https://openebs.github.io/node-disk-manager"
     condition: openebs-ndm.enabled
   - name: localpv-provisioner
-    version: "2.10.0"
+    version: "2.10.1"
     repository: "https://openebs.github.io/dynamic-localpv-provisioner"
     condition: localpv-provisioner.enabled
   - name: cstor

--- a/charts/openebs/README.md
+++ b/charts/openebs/README.md
@@ -77,7 +77,7 @@ The following table lists the configurable parameters of the OpenEBS chart and t
 | `provisioner.patchJivaNodeAffinity`     | Enable/disable node affinity on jiva replica deployment| `enabled`                                 |
 | `localprovisioner.enabled`              | Enable localProvisioner                       | `true`                                    |
 | `localprovisioner.image`                | Image for localProvisioner                    | `openebs/provisioner-localpv`             |
-| `localprovisioner.imageTag`             | Image Tag for localProvisioner                | `2.10.0`                                  |
+| `localprovisioner.imageTag`             | Image Tag for localProvisioner                | `2.10.1`                                  |
 | `localprovisioner.replicas`             | Number of localProvisioner Replicas           | `1`                                       |
 | `localprovisioner.basePath`             | BasePath for hostPath volumes on Nodes        | `/var/openebs/local`                      |
 | `localprovisioner.resources`            | Set resource limits for localProvisioner      | `{}`                                      |

--- a/charts/openebs/values.yaml
+++ b/charts/openebs/values.yaml
@@ -87,7 +87,7 @@ provisioner:
 localprovisioner:
   enabled: true
   image: "openebs/provisioner-localpv"
-  imageTag: "2.10.0"
+  imageTag: "2.10.1"
   replicas: 1
   enableLeaderElection: true
   basePath: "/var/openebs/local"
@@ -535,7 +535,7 @@ localpv-provisioner:
 #    image:
 #      registry: quay.io/
 #      repository: openebs/provisioner-localpv
-#      tag: 2.10.0
+#      tag: 2.10.1
 #      pullPolicy: IfNotPresent
 #    healthCheck:
 #      initialDelaySeconds: 30


### PR DESCRIPTION
Signed-off-by: Niladri Halder <niladri.halder@mayadata.io>

This PR updates the helm chart to pull v2.10.1 of openebs-localpv/localpv-provisioner dependent chart. 
Then PR requires https://github.com/openebs/dynamic-localpv-provisioner/pull/66 to be merged.