### PR TITLE
fix(docs): update helm instructions

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -10,3 +10,4 @@
 
 #Reviewers
 "Prateek Pandey",@prateekpandey14,MayaData
+"Shovan Maity",@shovanmaity,MayaData

--- a/README.md
+++ b/README.md
@@ -1,41 +1,102 @@
 # OpenEBS Helm Chart and other artifacts
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Lint and Test Charts](https://github.com/openebs/charts/workflows/Lint%20and%20Test%20Charts/badge.svg?branch=master)](https://github.com/openebs/charts/actions)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fopenebs%2Fcharts.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fopenebs%2Fcharts?ref=badge_shield)
+[![Slack](https://img.shields.io/badge/chat!!!-slack-ff1493.svg?style=flat-square)](https://kubernetes.slack.com/messages/openebs)
 
-The content in this repository is published using GitHub pages at https://openebs.github.io/charts/. 
 
-This repository contains OpenEBS Helm charts and other example artifacts like openebs-operator.yaml or example YAMLs. 
+<img width="200" align="right" alt="OpenEBS Logo" src="https://raw.githubusercontent.com/cncf/artwork/master/projects/openebs/stacked/color/openebs-stacked-color.png" xmlns="http://www.w3.org/1999/html">
+
+
+This repository contains OpenEBS Helm charts and other example artifacts like openebs-operator.yaml or example YAMLs. The content in this repository is published using GitHub pages at https://openebs.github.io/charts/. 
 
 ## OpenEBS Helm Chart
 
-The helm chart is located under [./charts/](./charts/) directory. 
+The helm chart is located under [./charts/openebs/](./charts/openebs/) directory. 
 
-When new changes to helm chart are pushed to master branch, the changes are picked up by [Helm Chart releaser](https://github.com/helm/chart-releaser-action) GitHub Action. The chart releaser will: 
-- Upload the new version of the charts to the [GitHub releases](https://github.com/openebs/charts/releases).
-- Update the helm repo index file and push to the [GitHub Pages branch](https://github.com/openebs/charts/tree/gh-pages).
+OpenEBS helm chart is an umbrella chart that pulls together engine specific charts. The engine charts are included as dependencies in [Chart.yaml](charts/openebs/Chart.yaml).
 
-## Mayastor Helm Chart
+OpenEBS helm chart will includes common components that are used by multiple engines like:
+- Node Disk Manager related components
+- Dynamic Local Provisioner related components
+- Security Policies like RBAC, PSP, Kyverno 
 
-Helm chart for Mayastor is currently maintained [along the Mayastor code-base](https://github.com/openebs/Mayastor/tree/develop/chart). Please, note, that it is being actively developed and can change or break without warning.
+Engine charts included as dependencies are:
+- [cStor](https://github.com/openebs/cstor-operators/tree/master/deploy/helm/charts)
+- [Jiva](https://github.com/openebs/jiva-operator/tree/master/deploy/helm/charts)
+- [ZFS Local PV](https://github.com/openebs/zfs-localpv/tree/master/deploy/helm/charts)
+- [LVM Local PV](https://github.com/openebs/lvm-localpv/tree/master/deploy/helm/charts)
+- [Dynamic NFS](https://github.com/openebs/dynamic-nfs-provisioner/tree/develop/deploy/helm/charts)
+
+Some of the other charts that will be included in the upcoming releases are:
+- [Rawfile Local PV](https://github.com/openebs/rawfile-localpv/tree/master/deploy/charts/rawfile-csi)
+- [Mayastor](https://github.com/openebs/mayastor/tree/develop/chart)
+- [Dashboard](https://github.com/openebs/monitoring/tree/develop/deploy/charts/openebs-monitoring)
+
+> **Note:** cStor and Jiva out-of-tree provisioners will be replaced by respective CSI charts listed above. OpenEBS users are expected to install the cstor and jiva CSI components and migrate the pools and volumes. The steps to migate are available at: https://github.com/openebs/upgrade
+
+### Releasing a new version 
+
+- Raise a PR with the required changes to the master branch. 
+- Tag the [maintainers](./MAINTAINERS) for review
+- Once changes are reviewed and merged, the changes are picked up by [Helm Chart releaser](https://github.com/helm/chart-releaser-action) GitHub Action. The chart releaser will: 
+  - Upload the new version of the charts to the [GitHub releases](https://github.com/openebs/charts/releases).
+  - Update the helm repo index file and push to the [GitHub Pages branch](https://github.com/openebs/charts/tree/gh-pages).
+
 
 ## OpenEBS Artifacts
 
+The artifacts are located in the [GitHub Pages(gh-pages) branch](https://github.com/openebs/charts/tree/gh-pages).
+
+The files can be accessed either as github rawfile or as hosted files. Example, openebs operator can be used as follows:
+- As github raw file URL:
+  ```
+  kubectl apply -f https://raw.githubusercontent.com/openebs/charts/gh-pages/openebs-operator.yaml
+  ```
+- As hosted URL:
+  ```
+  kubectl apply -f https://openebs.github.io/charts/openebs-operator.yaml
+  ```
+
 This is a collection of YAMLs or scripts that help to perform some OpenEBS tasks like:
 - YAML file to setup OpenEBS via kubectl.
+  - [OpenEBS Commons Operator](https://github.com/openebs/charts/blob/gh-pages/openebs-operator.yaml)
+  - [OpenEBS cStor](https://github.com/openebs/charts/blob/gh-pages/cstor-operator.yaml)
+  - [OpenEBS Jiva](https://github.com/openebs/charts/blob/gh-pages/jiva-operator.yaml)
+  - [OpenEBS Hostpath](https://github.com/openebs/charts/blob/gh-pages/hostpath-operator.yaml) 
+  - [OpenEBS Hostpath and Device](https://github.com/openebs/charts/blob/gh-pages/openebs-operator-lite.yaml)
+  - [OpenEBS LVM Local PV](https://github.com/openebs/charts/blob/gh-pages/lvm-operator.yaml)
+  - [OpenEBS ZFS Local PV](https://github.com/openebs/charts/blob/gh-pages/zfs-operator.yaml)
+  - [OpenEBS NFS PV](https://github.com/openebs/charts/blob/gh-pages/nfs-operator.yaml)
+- YAML file to install OpenEBS prerequisties on hosts via nsenter pods via kubectl.
+  - [Setup iSCSI on Ubuntu](https://github.com/openebs/charts/blob/gh-pages/openebs-ubuntu-setup.yaml)
+  - [Setup iSCSI on Amazon Linux](https://github.com/openebs/charts/blob/gh-pages/openebs-amazonlinux-setup.yaml)
 - Scripts to push the OpenEBS container images to a custom registry for air-gapped environments. 
 - and more. 
 
-The artifacts are located in the [GitHub Pages(gh-pages) branch](https://github.com/openebs/charts/tree/gh-pages).
 
 ## Contributing
 
-See [./CONTRIBUTING.md](./CONTRIBUTING.md).
+See [CONTRIBUTING.md](./CONTRIBUTING.md).
+
+## Community, discussion, and support
+
+You can reach the maintainers of this project at:
+
+- [Kubernetes Slack](http://slack.k8s.io/) channels: 
+      * [#openebs](https://kubernetes.slack.com/messages/openebs/)
+      * [#openebs-dev](https://kubernetes.slack.com/messages/openebs-dev/)
+- [Mailing List](https://lists.cncf.io/g/cncf-openebs-users)
+
+For more ways of getting involved with community, check our [community page](https://github.com/openebs/openebs/tree/master/community).
+
+### Code of conduct
+
+Participation in the OpenEBS community is governed by the [CNCF Code of Conduct](./CODE-OF-CONDUCT.md).
+
+
 
 ## License
-
-[Apache 2.0 License](./LICENSE).
-
 
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fopenebs%2Fcharts.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Fopenebs%2Fcharts?ref=badge_large)

--- a/charts/openebs/.gitignore
+++ b/charts/openebs/.gitignore
@@ -1,0 +1,2 @@
+Chart.lock
+charts

--- a/charts/openebs/Chart.yaml
+++ b/charts/openebs/Chart.yaml
@@ -1,15 +1,18 @@
 apiVersion: v2
-version: 2.12.0
+version: 2.12.1
 name: openebs
 appVersion: 2.12.0
-description: Containerized Storage for Containers
+description: Container Attached Storage
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/openebs/icon/color/openebs-icon-color.png
 home: http://www.openebs.io/
 keywords:
   - cloud-native-storage
   - block-storage
+  - local storage
+  - NVMe
   - iSCSI
   - storage
+  - kubernetes
 sources:
   - https://github.com/openebs/openebs
 maintainers:
@@ -17,15 +20,9 @@ maintainers:
     email: kiran.mova@openebs.io
   - name: prateekpandey14
     email: prateek.pandey@openebs.io
+  - name: shovanmaity
+    email: shovan.maity@mayadata.io
 dependencies:
-  - name: openebs-ndm
-    version: "1.6.1"
-    repository: "https://openebs.github.io/node-disk-manager"
-    condition: openebs-ndm.enabled
-  - name: localpv-provisioner
-    version: "2.12.0"
-    repository: "https://openebs.github.io/dynamic-localpv-provisioner"
-    condition: localpv-provisioner.enabled
   - name: cstor
     version: "2.12.0"
     repository: "https://openebs.github.io/cstor-operators"

--- a/charts/openebs/README.md
+++ b/charts/openebs/README.md
@@ -1,132 +1,105 @@
 # OpenEBS Helm Chart
 
-[OpenEBS](https://github.com/openebs/openebs) is an *open source storage platform* that provides persistent and containerized block storage for DevOps and container environments. 
-OpenEBS provides multiple storage engines that can be plugged in easily. A common pattern is the use of OpenEBS to deliver Dynamic LocalPV for those applications and workloads that want to access disks and cloud volumes directly.
+[OpenEBS](https://openebs.io) helps Developers and Platform SREs easily deploy Kubernetes Stateful Workloads that require fast and highly reliable container attached storage. OpenEBS can be deployed on any Kubernetes cluster - either in cloud, on-premise (virtual or bare metal) or developer laptop (minikube).
 
-OpenEBS can be deployed on any Kubernetes cluster - either in cloud, on-premise or developer laptop (minikube). OpenEBS itself is deployed as just another container on your cluster, and enables storage services that can be designated on a per pod, application, cluster or container level.
+OpenEBS Data Engines and Control Plane are implemented as micro-services, deployed as containers and orchestrated by Kubernetes itself. An added advantage of being a completely Kubernetes native solution is that administrators and developers can interact and manage OpenEBS using all the wonderful tooling that is available for Kubernetes like kubectl, Helm, Prometheus, Grafana, etc.
 
-## Introduction
+OpenEBS turns any storage available on the Kubernetes worker nodes into local or distributed Kubernetes Persistent Volumes.
+* Local Volumes are accessible only from a single node in the cluster. Pods using Local Volume have to be scheduled on the node where volume is provisioned. Local Volumes are typically preferred for distributed workloads like Cassandra, MongoDB, Elastic, etc that are distributed in nature and have high availability built into them. Depending on the type of storage attached to your Kubernetes worker nodes, you can select from different flavors of Dynamic Local PV - Hostpath, Device, LVM, ZFS or Rawfile.
+* Replicated Volumes as the name suggests, are those that have their data synchronously replicated to multiple nodes. Volumes can sustain node failures. The replication also can be setup across availability zones helping applications move across availability zones. Depending on the type of storage attached to your Kubernetes worker nodes and application performance requirements, you can select from Jiva, cStor or Mayastor.
 
-This chart bootstraps OpenEBS deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+## Documentation and user guides
 
-## Quickstart and documentation
+You can run OpenEBS on any Kubernetes 1.18+ cluster in a matter of minutes. See the [Quickstart Guide to OpenEBS](https://openebs.io/) for detailed instructions.
 
-You can run OpenEBS on any Kubernetes 1.13+ cluster in a matter of seconds. See the [Quickstart Guide to OpenEBS](https://docs.openebs.io/docs/next/quickstart.html) for detailed instructions.
+## Getting started
 
-For more comprehensive documentation, start with the [Welcome to OpenEBS](https://docs.openebs.io/docs/next/overview.html) docs.
+### How to customize OpenEBS Helm chart?
 
-## Prerequisites
+OpenEBS helm chart is an umbrella chart that pulls together engine specific charts. The engine charts are included as dependencies. 
+arts/openebs/Chart.yaml). 
+OpenEBS helm chart will includes common components that are used by multiple engines like:
+- Node Disk Manager related components
+- Dynamic Local Provisioner related components
+- Security Policies like RBAC, PSP, Kyverno 
 
-- Kubernetes 1.13+ with RBAC enabled
-- iSCSI PV support in the underlying infrastructure
+```bash
+openebs
+├── (default) openebs-ndm
+├── (default) localpv-provisioner
+├── jiva
+├── cstor
+├── zfs-localpv
+└── lvm-localpv
+└── nfs-provisioner
+```
 
-## Adding OpenEBS Helm repository
+To install the engine charts, the helm install must be provided with a engine enabled flag like `cstor.enabled=true` or `zfs-localpv.enabled=true` or by passing a custom values.yaml with required engines enabled.
+
+### Prerequisites
+
+- Kubernetes 1.18+ with RBAC enabled
+- When using cstor and jiva engines, iSCSI utils must be installed on all the nodes where stateful pods are going to run. 
+- Depending on the engine and type of platform, you may have to customize the values or run additional pre-requisistes. Refer to [documentation](https://openebs.io).
+
+### Setup Helm Repository
 
 Before installing OpenEBS Helm charts, you need to add the [OpenEBS Helm repository](https://openebs.github.io/charts) to your Helm client.
 
 ```bash
 helm repo add openebs https://openebs.github.io/charts
+helm repo update
 ```
 
-## Update the dependent charts
+### Installing OpenEBS 
 
 ```bash
-helm dependency update
+helm install --name `my-release` --namespace openebs openebs/openebs --create-namespace
 ```
 
-## Installing OpenEBS
+Examples:
+- Assuming the release will be called openebs, the command would be:
+  ```bash
+  helm install --name openebs --namespace openebs openebs/openebs --create-namespace
+  ```
 
-```bash
-helm install --namespace openebs openebs/openebs
-```
+- To install OpenEBS with cStor CSI driver, run
+  ```bash
+  helm install openebs openebs/openebs --namespace openebs --create-namespace --set cstor.enabled=true
+  ```
 
-## Installing OpenEBS with the release name
+- To install/enable a new engine on the installed helm release `openebs`, you can run the helm upgrade command as follows:
+  ```bash
+  helm upgrade openebs openebs/openebs --namespace openebs --reuse-values --set jiva.enabled=true 
+  ```
 
-```bash
-helm install --name `my-release` --namespace openebs openebs/openebs
-```
+- To disable legacy out of tree jiva and cstor provisioners, run the following command.
+  ```bash
+  helm upgrade openebs openebs/openebs --namespace openebs --reuse-values --set legacy.enabled=false 
+  ```
 
-## To uninstall/delete instance with release name
+### To uninstall/delete instance with release name
 
 ```bash
 helm ls --all
 helm delete `my-release`
 ```
 
+> **Tip**: Prior to deleting the helm chart, make sure all the storage volumes and pools are deleted.
+
 ## Configuration
 
-The following table lists the configurable parameters of the OpenEBS chart and their default values.
+The following table lists the common configurable parameters of the OpenEBS chart and their default values. For a full list of configurable parameters check out the [values.yaml](https://github.com/openebs/charts/blob/master/charts/openebs/values.yaml).
 
 | Parameter                               | Description                                   | Default                                   |
 | ----------------------------------------| --------------------------------------------- | ----------------------------------------- |
-| `rbac.create`                           | Enable RBAC Resources                         | `true`                                    |
-| `rbac.pspEnabled`                       | Create pod security policy resources          | `false`                                   |
-| `rbac.kyvernoEnabled`                   | Create Kyverno policy resources               | `false`                                   |
-| `image.pullPolicy`                      | Container pull policy                         | `IfNotPresent`                            |
-| `image.repository`                      | Specify which docker registry to use          | `""`                                      |
 | `apiserver.enabled`                     | Enable API Server                             | `true`                                    |
 | `apiserver.image`                       | Image for API Server                          | `openebs/m-apiserver`                     |
 | `apiserver.imageTag`                    | Image Tag for API Server                      | `2.12.0`                                  |
-| `apiserver.replicas`                    | Number of API Server Replicas                 | `1`                                       |
-| `apiserver.sparse.enabled`              | Create Sparse Pool based on Sparsefile        | `false`                                   |
-| `apiserver.resources`                   | Set resource limits for API Server            | `{}`                                      |
-| `provisioner.enabled`                   | Enable Provisioner                            | `true`                                    |
-| `provisioner.image`                     | Image for Provisioner                         | `openebs/openebs-k8s-provisioner`         |
-| `provisioner.imageTag`                  | Image Tag for Provisioner                     | `2.12.0`                                  |
-| `provisioner.replicas`                  | Number of Provisioner Replicas                | `1`                                       |
-| `provisioner.resources`                 | Set resource limits for Provisioner           | `{}`                                      |
-| `provisioner.patchJivaNodeAffinity`     | Enable/disable node affinity on jiva replica deployment| `enabled`                                 |
-| `localprovisioner.enabled`              | Enable localProvisioner                       | `true`                                    |
-| `localprovisioner.image`                | Image for localProvisioner                    | `openebs/provisioner-localpv`             |
-| `localprovisioner.imageTag`             | Image Tag for localProvisioner                | `2.12.0`                                  |
-| `localprovisioner.replicas`             | Number of localProvisioner Replicas           | `1`                                       |
-| `localprovisioner.basePath`             | BasePath for hostPath volumes on Nodes        | `/var/openebs/local`                      |
-| `localprovisioner.resources`            | Set resource limits for localProvisioner      | `{}`                                      |
-| `localpv.waitForBDBindTimeoutRetryCount`| This sets the number of times the provisioner should try with a polling interval of 5 seconds, to get the Blockdevice Name from a BlockDeviceClaim, before the BlockDeviceClaim is deleted. | "12" |
-| `webhook.enabled`                       | Enable admission server                       | `true`                                    |
-| `webhook.image`                         | Image for admission server                    | `openebs/admission-server`                |
-| `webhook.imageTag`                      | Image Tag for admission server                | `2.12.0`                                  |
-| `webhook.replicas`                      | Number of admission server Replicas           | `1`                                       |
-| `webhook.hostNetwork`                   | Use hostNetwork in admission server           | `false`                                   |
-| `webhook.resources`                     | Set resource limits for admission server      | `{}`                                      |
-| `snapshotOperator.enabled`              | Enable Snapshot Provisioner                   | `true`                                    |
-| `snapshotOperator.provisioner.image`    | Image for Snapshot Provisioner                | `openebs/snapshot-provisioner`            |
-| `snapshotOperator.provisioner.imageTag` | Image Tag for Snapshot Provisioner            | `2.12.0`                                  |
-| `snapshotOperator.controller.image`     | Image for Snapshot Controller                 | `openebs/snapshot-controller`             |
-| `snapshotOperator.controller.imageTag`  | Image Tag for Snapshot Controller             | `2.12.0`                                  |
-| `snapshotOperator.replicas`             | Number of Snapshot Operator Replicas          | `1`                                       |
-| `snapshotOperator.provisioner.resources`| Set resource limits for Snapshot Provisioner  | `{}`                                      |
-| `snapshotOperator.controller.resources` | Set resource limits for Snapshot Controller   | `{}`                                      |
-| `ndm.enabled`                           | Enable Node Disk Manager                      | `true`                                    |
-| `ndm.image`                             | Image for Node Disk Manager                   | `openebs/node-disk-manager`         |
-| `ndm.imageTag`                          | Image Tag for Node Disk Manager               | `1.6.1`                                   |
-| `ndm.sparse.path`                       | Directory where Sparse files are created      | `/var/openebs/sparse`                     |
-| `ndm.sparse.size`                       | Size of the sparse file in bytes              | `10737418240`                             |
-| `ndm.sparse.count`                      | Number of sparse files to be created          | `0`                                       |
-| `ndm.filters.enableOsDiskExcludeFilter` | Enable filters of OS disk exclude             | `true`                                    |
-| `ndm.filters.osDiskExcludePaths`        | Paths/Mountpoints to be excluded by OS Disk Filter| `/,/etc/hosts,/boot`                           |
-| `ndm.filters.enableVendorFilter`        | Enable filters of vendors                     | `true`                                    |
-| `ndm.filters.excludeVendors`            | Exclude devices with specified vendor         | `CLOUDBYT,OpenEBS`                        |
-| `ndm.filters.enablePathFilter`          | Enable filters of paths                       | `true`                                    |
-| `ndm.filters.includePaths`              | Include devices with specified path patterns  | `""`                                      |
-| `ndm.filters.excludePaths`              | Exclude devices with specified path patterns  | `/dev/loop,/dev/fd0,/dev/sr0,/dev/ram,/dev/dm-,/dev/md,/dev/rbd,/dev/zd`|
-| `ndm.probes.enableSeachest`             | Enable Seachest probe for NDM                 | `false`                                   |
-| `ndm.resources`                         | Set resource limits for NDM                   | `{}`                                      |
-| `ndmOperator.enabled`                   | Enable NDM Operator                           | `true`                                    |
-| `ndmOperator.image`                     | Image for NDM Operator                        | `openebs/node-disk-operator`        |
-| `ndmOperator.imageTag`                  | Image Tag for NDM Operator                    | `1.6.1`                                   |
-| `ndmOperator.resources`                 | Set resource limits for NDM Operator          | `{}`                                      |
-| `ndmExporter.enabled`                   | Enable NDM Exporters                          | `false`                                   |
-| `ndmExporter.image.registry`            | Registry for NDM Exporters image              | `""`                                      |
-| `ndmExporter.repository`                | Image repository for NDM Exporters            | `openebs/node-disk-exporter`              |
-| `ndmExporter.pullPolicy`                | Image pull policy for NDM Exporters           | `IfNotPresent`                            |
-| `ndmExporter.tag`                       | Image tag for NDM Exporters                   | `1.6.1`                                   |
-| `ndmExporter.nodeExporter.metricsPort`  | The TCP port number used for exposing NDM node exporter metrics    | `9101`               |
-| `ndmExporter.clusterExporter.metricsPort`   | The TCP port number used for exposing NDM cluster exporter metrics  | `9100`          |
-| `jiva.image`                            | Image for Jiva                                | `openebs/jiva`                            |
-| `jiva.imageTag`                         | Image Tag for Jiva                            | `2.12.1`                                  |
-| `jiva.replicas`                         | Number of Jiva Replicas                       | `3`                                       |
-| `jiva.defaultStoragePath`               | hostpath used by default Jiva StorageClass    | `/var/openebs`                            |
+| `cleanup.image.registry`                | Cleanup pre hook image registry               | `nil`                                     |
+| `cleanup.image.repository`              | Cleanup pre hook image repository             | `"bitnami/kubectl"`                       |
+| `cleanup.image.tag`                     | Cleanup pre hook image tag                    | `if not provided determined by the k8s version`                       |
+| `crd.enableInstall`                     | Enable installation of CRDs by OpenEBS        | `true`                                    |
 | `cstor.pool.image`                      | Image for cStor Pool                          | `openebs/cstor-pool`                      |
 | `cstor.pool.imageTag`                   | Image Tag for cStor Pool                      | `2.12.0`                                  |
 | `cstor.poolMgmt.image`                  | Image for cStor Pool  Management              | `openebs/cstor-pool-mgmt`                 |
@@ -135,125 +108,61 @@ The following table lists the configurable parameters of the OpenEBS chart and t
 | `cstor.target.imageTag`                 | Image Tag for cStor Target                    | `2.12.0`                                  |
 | `cstor.volumeMgmt.image`                | Image for cStor Volume  Management            | `openebs/cstor-volume-mgmt`               |
 | `cstor.volumeMgmt.imageTag`             | Image Tag for cStor Volume Management         | `2.12.0`                                  |
-| `helper.image`                          | Image for helper                              | `openebs/linux-utils`                     |
-| `helper.imageTag`                       | Image Tag for helper                          | `2.12.0`                                  |
-| `featureGates.enabled`                  | Enable feature gates for OpenEBS              | `true`                                   |
-| `featureGates.APIService.enabled`       | Enable APIService in NDM                      | `false`                                  |
-| `featureGates.UseOSDisk.enabled`        | Enable using unused partitions on OS Disk     | `false`                                  |
-| `featureGates.MountChangeDetection.enabled` | Enable feature-gate to detect mountpoint/filesystem changes | `false`                                   |
-| `crd.enableInstall`                     | Enable installation of CRDs by OpenEBS        | `true`                                    |
-| `policies.monitoring.image`             | Image for Prometheus Exporter                 | `openebs/m-exporter`                      |
-| `policies.monitoring.imageTag`          | Image Tag for Prometheus Exporter             | `2.12.0`                                  |
-| `analytics.enabled`                     | Enable sending stats to Google Analytics      | `true`                                    |
-| `analytics.pingInterval`                | Duration(hours) between sending ping stat     | `24h`                                     |
 | `defaultStorageConfig.enabled`          | Enable default storage class installation     | `true`                                    |
-| `varDirectoryPath.baseDir`              | To store debug info of OpenEBS containers     | `/var/openebs`                            |
 | `healthCheck.initialDelaySeconds`       | Delay before liveness probe is initiated      | `30`                                      |
 | `healthCheck.periodSeconds`             | How often to perform the liveness probe       | `60`                                      |
-| `cleanup.image.registry`                | Cleanup pre hook image registry               | `nil`                                     |
-| `cleanup.image.repository`              | Cleanup pre hook image repository             | `"bitnami/kubectl"`                       |
-| `cleanup.image.tag`                     | Cleanup pre hook image tag             | `if not provided determined by the k8s version`                       |
+| `helper.image`                          | Image for helper                              | `openebs/linux-utils`                     |
+| `helper.imageTag`                       | Image Tag for helper                          | `2.12.0`                                  |
+| `image.pullPolicy`                      | Container pull policy                         | `IfNotPresent`                            |
+| `image.repository`                      | Specify which docker registry to use          | `""`                                      |
+| `jiva.defaultStoragePath`               | hostpath used by default Jiva StorageClass    | `/var/openebs`                            |
+| `jiva.image`                            | Image for Jiva                                | `openebs/jiva`                            |
+| `jiva.imageTag`                         | Image Tag for Jiva                            | `2.12.1`                                  |
+| `jiva.replicas`                         | Number of Jiva Replicas                       | `3`                                       |
+| `localprovisioner.basePath`             | BasePath for hostPath volumes on Nodes        | `/var/openebs/local`                      |
+| `localprovisioner.enabled`              | Enable localProvisioner                       | `true`                                    |
+| `localprovisioner.image`                | Image for localProvisioner                    | `openebs/provisioner-localpv`             |
+| `localprovisioner.imageTag`             | Image Tag for localProvisioner                | `2.12.0`                                  |
+| `ndm.enabled`                           | Enable Node Disk Manager                      | `true`                                    |
+| `ndm.filters.enableOsDiskExcludeFilter` | Enable filters of OS disk exclude             | `true`                                    |
+| `ndm.filters.enablePathFilter`          | Enable filters of paths                       | `true`                                    |
+| `ndm.filters.enableVendorFilter`        | Enable filters of vendors                     | `true`                                    |
+| `ndm.filters.excludePaths`              | Exclude devices with specified path patterns  | `/dev/loop,/dev/fd0,/dev/sr0,/dev/ram,/dev/dm-,/dev/md,/dev/rbd,/dev/zd`|
+| `ndm.filters.excludeVendors`            | Exclude devices with specified vendor         | `CLOUDBYT,OpenEBS`                        |
+| `ndm.filters.includePaths`              | Include devices with specified path patterns  | `""`                                      |
+| `ndm.filters.osDiskExcludePaths`        | Paths/Mounts to be excluded by OS Disk Filter | `/,/etc/hosts,/boot`                      |
+| `ndm.image`                             | Image for Node Disk Manager                   | `openebs/node-disk-manager`               |
+| `ndm.imageTag`                          | Image Tag for Node Disk Manager               | `1.6.1`                                   |
+| `ndmOperator.enabled`                   | Enable NDM Operator                           | `true`                                    |
+| `ndmOperator.image`                     | Image for NDM Operator                        | `openebs/node-disk-operator`              |
+| `ndmOperator.imageTag`                  | Image Tag for NDM Operator                    | `1.6.1`                                   |
+| `ndm.probes.enableSeachest`             | Enable Seachest probe for NDM                 | `false`                                   |
+| `policies.monitoring.image`             | Image for Prometheus Exporter                 | `openebs/m-exporter`                      |
+| `policies.monitoring.imageTag`          | Image Tag for Prometheus Exporter             | `2.12.0`                                  |
+| `provisioner.enabled`                   | Enable Provisioner                            | `true`                                    |
+| `provisioner.image`                     | Image for Provisioner                         | `openebs/openebs-k8s-provisioner`         |
+| `provisioner.imageTag`                  | Image Tag for Provisioner                     | `2.12.0`                                  |
+| `rbac.create`                           | Enable RBAC Resources                         | `true`                                    |
+| `rbac.kyvernoEnabled`                   | Create Kyverno policy resources               | `false`                                   |
+| `rbac.pspEnabled`                       | Create pod security policy resources          | `false`                                   |
+| `snapshotOperator.controller.image`     | Image for Snapshot Controller                 | `openebs/snapshot-controller`             |
+| `snapshotOperator.controller.imageTag`  | Image Tag for Snapshot Controller             | `2.12.0`                                  |
+| `snapshotOperator.enabled`              | Enable Snapshot Provisioner                   | `true`                                    |
+| `snapshotOperator.provisioner.image`    | Image for Snapshot Provisioner                | `openebs/snapshot-provisioner`            |
+| `snapshotOperator.provisioner.imageTag` | Image Tag for Snapshot Provisioner            | `2.12.0`                                  |
+| `varDirectoryPath.baseDir`              | To store debug info of OpenEBS containers     | `/var/openebs`                            |
+| `webhook.enabled`                       | Enable admission server                       | `true`                                    |
+| `webhook.hostNetwork`                   | Use hostNetwork in admission server           | `false`                                   |
+| `webhook.image`                         | Image for admission server                    | `openebs/admission-server`                |
+| `webhook.imageTag`                      | Image Tag for admission server                | `2.12.0`                                  |
+
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash
-helm install --name openebs -f values.yaml openebs/openebs
+helm install --name `my-release` -f values.yaml --namespace openebs openebs/openebs --create-namespace
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
 
-## Below charts are dependent charts of this chart
--  [openebs-ndm](https://openebs.github.io/node-disk-manager)
--  [localpv-provisioner](https://openebs.github.io/dynamic-localpv-provisioner)
--  [cstor](https://openebs.github.io/cstor-operators)
--  [jiva](https://openebs.github.io/jiva-operator)
--  [zfs-localpv](https://openebs.github.io/zfs-localpv)
--  [lvm-localpv](https://openebs.github.io/lvm-localpv)
--  [nfs](https://openebs.github.io/dynamic-nfs-provisioner)
-
-## Dependency tree of this chart
-```bash
-openebs
-├── openebs-ndm
-├── localpv-provisioner
-│   └── openebs-ndm (optional)
-├── jiva
-│   └── localpv-provisioner
-│       └── openebs-ndm (optional)
-├── cstor
-│   └── openebs-ndm
-├── zfs-localpv
-└── lvm-localpv
-└── nfs-provisioner
-
-```
-
-#### (Default) Install Jiva, cStor and Local PV with out-of-tree provisioners
-```bash
-helm install openebs openebs/openebs --namespace openebs --create-namespace
-```
-
-#### Install cStor with CSI driver
-```bash
-helm install openebs openebs/openebs --namespace openebs --create-namespace \
---set legacy.enabled=false \
---set cstor.enabled=true \
---set openebs-ndm.enabled=true
-```
-
-#### Install Jiva with CSI driver
-```bash
-helm install openebs openebs/openebs --namespace openebs --create-namespace \
---set legacy.enabled=false \
---set jiva.enabled=true \
---set openebs-ndm.enabled=true \
---set localpv-provisioner.enabled=true
-```
-
-#### Install ZFS Local PV
-```bash
-helm install openebs openebs/openebs --namespace openebs --create-namespace \
---set legacy.enabled=false \
---set zfs-localpv.enabled=true
-```
-
-#### Install LVM Local PV
-```bash
-helm install openebs openebs/openebs --namespace openebs --create-namespace \
---set legacy.enabled=false \
---set lvm-localpv.enabled=true
-```
-
-#### Install Local PV hostpath and device
-```bash
-helm install openebs openebs/openebs --namespace openebs --create-namespace \
---set legacy.enabled=false \
---set localpv-provisioner.enabled=true
---set openebs-ndm.enabled=true \
-```
-
-#### Install NFS Provisioner
-```bash
-helm install openebs openebs/openebs --namespace openebs --create-namespace \
---set legacy.enabled=false \
---set nfs-provisioner.enabled=true
-```
-
-
-> **Tip**: You can install multiple csi driver by merging the configuration.
-
-## Kyverno Policy Integration
-
-PodSecurityPolicy(PSP) is being deprecated in Kubernetes 1.21 and will be removed in v1.25. So, the suitable alternative is Kyverno.
-Kyverno is an open-source policy engine built specifically for Kubernetes to not only validate and ensure requests comply with your
-internal best practices and policies.
-
-
-As part of kyverno integration, some required policies have been added as a helm template in openebs charts, installation disable by default and can be enabled using a flag. But before enabling that [Kyverno](https://kyverno.io/docs/installation/) should be installed in your Kubernetes cluster using 
-[Helm](https://kyverno.io/docs/installation/#install-kyverno-using-helm) or [YAMLs](https://kyverno.io/docs/installation/#install-kyverno-using-yamls).
-
-Check the default kyverno policies in Kubernetes cluster using
-```bash
-kubectl get pol
-```

--- a/charts/openebs/templates/NOTES.txt
+++ b/charts/openebs/templates/NOTES.txt
@@ -1,27 +1,22 @@
-The OpenEBS has been installed. Check its status by running:
-$ kubectl get pods -n {{ .Release.Namespace }}
 
-For dynamically creating OpenEBS Volumes, you can either create a new StorageClass or
-use one of the default storage classes provided by OpenEBS.
+Successfully installed OpenEBS.
 
-Use `kubectl get sc` to see the list of installed OpenEBS StorageClasses. A sample
-PVC spec using `openebs-jiva-default` StorageClass is given below:"
+Check the status by running: kubectl get pods -n {{ .Release.Namespace }}
 
----
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-  name: demo-vol-claim
-spec:
-  storageClassName: openebs-jiva-default
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 5G
----
+The default values enables OpenEBS hostpath, device and jiva engines along with 
+their default storage classes. Use `kubectl get sc` to see the list of installed 
+OpenEBS StorageClasses. 
 
-Please note that, OpenEBS uses iSCSI for connecting applications with the
-OpenEBS Volumes and your nodes should have the iSCSI initiator installed.
+For other engines, you will need to perform a few more additional steps to
+enable the engine, configure the engines (like creating pools) and create 
+storage classes. 
 
-For more information, visit our Slack at https://openebs.io/community or view the documentation online at http://docs.openebs.io/.
+For example, cStor can be enabled using commands like:
+
+helm upgrade {{ .Release.Name }} openebs/openebs  --set cstor.enabled=true --reuse-values --namespace {{ .Release.Namespace }}
+
+For more information, 
+- view the online documentation at http://docs.openebs.io/ or
+- connect with an active community on Kubernetes slack #openebs channel.
+
+

--- a/charts/openebs/templates/deployment-local-provisioner.yaml
+++ b/charts/openebs/templates/deployment-local-provisioner.yaml
@@ -1,6 +1,4 @@
 {{- if .Values.localprovisioner.enabled }}
-{{- $localpvprovisionerValues := index .Values "localpv-provisioner" }}
-{{- if not $localpvprovisionerValues.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -121,6 +119,5 @@ spec:
 {{- if .Values.localprovisioner.affinity }}
       affinity:
 {{ toYaml .Values.localprovisioner.affinity | indent 8 }}
-{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/openebs/templates/ndm/cluster-exporter-service.yaml
+++ b/charts/openebs/templates/ndm/cluster-exporter-service.yaml
@@ -1,7 +1,5 @@
 {{- if .Values.ndm.enabled }}
 {{- if and .Values.ndmExporter.enabled .Values.ndmExporter.clusterExporter.metricsPort }}
-{{- $ndmValues := index .Values "openebs-ndm" }}
-{{- if not $ndmValues.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -18,6 +16,5 @@ spec:
     {{- with .Values.ndmExporter.clusterExporter.podLabels }}
       {{ toYaml . }}
       {{- end }}
-{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/openebs/templates/ndm/cluster-exporter.yaml
+++ b/charts/openebs/templates/ndm/cluster-exporter.yaml
@@ -1,6 +1,4 @@
 {{- if and (.Values.ndm.enabled) (.Values.ndmExporter.enabled) }}
-{{- $ndmValues := index .Values "openebs-ndm" }}
-{{- if not $ndmValues.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -22,6 +20,10 @@ spec:
           {{ toYaml . | nindent 8 }}
           {{- end }}
     spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       serviceAccountName: {{ template "openebs.serviceAccountName" . }}
       containers:
         - name: {{ template "openebs.ndm-cluster-exporter.fullname" . }}
@@ -38,6 +40,17 @@ spec:
               protocol: TCP
               name: metrics
           imagePullPolicy: {{ .Values.ndmExporter.image.pullPolicy }}
+{{- if .Values.ndmExporter.clusterExporter.resources }}
+        resources:
+{{ toYaml .Values.ndmExporter.clusterExporter.resources | trimSuffix "\n" | indent 10 }}
+{{- end }}
+        livenessProbe:
+          exec:
+            command:
+            - pgrep
+            - "exporter"
+          initialDelaySeconds: {{ .Values.ndmExporter.clusterExporter.healthCheck.initialDelaySeconds }}
+          periodSeconds: {{ .Values.ndmExporter.clusterExporter.healthCheck.periodSeconds }}
           env:
             - name: NAMESPACE
               valueFrom:
@@ -47,5 +60,12 @@ spec:
             - name: METRICS_LISTEN_PORT
               value: :{{ .Values.ndmExporter.clusterExporter.metricsPort }}
             {{- end }}
+{{- if .Values.ndmExporter.clusterExporter.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.ndmExporter.clusterExporter.nodeSelector | indent 8 }}
+{{- end }}
+{{- if .Values.ndmExporter.clusterExporter.tolerations }}
+      tolerations:
+{{ toYaml .Values.ndmExporter.clusterExporter.tolerations | indent 8 }}
 {{- end }}
 {{- end }}

--- a/charts/openebs/templates/ndm/cm-node-disk-manager.yaml
+++ b/charts/openebs/templates/ndm/cm-node-disk-manager.yaml
@@ -1,6 +1,4 @@
 {{- if .Values.ndm.enabled }}
-{{- $ndmValues := index .Values "openebs-ndm" }}
-{{- if not $ndmValues.enabled }}
 # This is the node-disk-manager related config.
 # It can be used to customize the disks probes and filters
 apiVersion: v1
@@ -44,5 +42,4 @@ data:
         state: {{ .Values.ndm.filters.enablePathFilter }}
         include: "{{ .Values.ndm.filters.includePaths }}"
         exclude: "{{ .Values.ndm.filters.excludePaths }}"
-{{- end }}
 {{- end }}

--- a/charts/openebs/templates/ndm/daemonset-ndm.yaml
+++ b/charts/openebs/templates/ndm/daemonset-ndm.yaml
@@ -1,6 +1,4 @@
 {{- if .Values.ndm.enabled }}
-{{- $ndmValues := index .Values "openebs-ndm" }}
-{{- if not $ndmValues.enabled }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -178,6 +176,5 @@ spec:
 {{- if .Values.ndm.tolerations }}
       tolerations:
 {{ toYaml .Values.ndm.tolerations | indent 8 }}
-{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/openebs/templates/ndm/deployment-ndm-operator.yaml
+++ b/charts/openebs/templates/ndm/deployment-ndm-operator.yaml
@@ -1,6 +1,4 @@
 {{- if .Values.ndmOperator.enabled }}
-{{- $ndmValues := index .Values "openebs-ndm" }}
-{{- if not $ndmValues.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -86,6 +84,5 @@ spec:
 {{- if .Values.ndmOperator.tolerations }}
       tolerations:
 {{ toYaml .Values.ndmOperator.tolerations | indent 8 }}
-{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/openebs/templates/ndm/node-exporter-service.yaml
+++ b/charts/openebs/templates/ndm/node-exporter-service.yaml
@@ -1,7 +1,5 @@
 {{- if .Values.ndm.enabled }}
 {{- if and .Values.ndmExporter.enabled .Values.ndmExporter.nodeExporter.metricsPort }}
-{{- $ndmValues := index .Values "openebs-ndm" }}
-{{- if not $ndmValues.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -18,6 +16,5 @@ spec:
     {{- with .Values.ndmExporter.nodeExporter.podLabels }}
       {{ toYaml . }}
       {{- end }}
-{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/openebs/templates/ndm/node-exporter.yaml
+++ b/charts/openebs/templates/ndm/node-exporter.yaml
@@ -1,6 +1,4 @@
 {{- if and .Values.ndm.enabled .Values.ndmExporter.enabled }}
-{{- $ndmValues := index .Values "openebs-ndm" }}
-{{- if not $ndmValues.enabled }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -21,6 +19,10 @@ spec:
           {{ toYaml . | nindent 8 }}
           {{- end }}
     spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       serviceAccountName: {{ template "openebs.serviceAccountName" . }}
       containers:
         - name: {{ template "openebs.ndm-node-exporter.fullname" . }}
@@ -37,6 +39,10 @@ spec:
               protocol: TCP
               name: metrics
           imagePullPolicy: {{ .Values.ndmExporter.image.pullPolicy }}
+{{- if .Values.ndmExporter.nodeExporter.resources }}
+        resources:
+{{ toYaml .Values.ndmExporter.resources | trimSuffix "\n" | indent 10 }}
+{{- end }}
           securityContext:
             privileged: true
           env:
@@ -48,5 +54,19 @@ spec:
             - name: METRICS_LISTEN_PORT
               value: :{{ .Values.ndmExporter.nodeExporter.metricsPort }}
             {{- end }}
+        livenessProbe:
+          exec:
+            command:
+            - pgrep
+            - "exporter"
+          initialDelaySeconds: {{ .Values.ndmExporter.nodeExporter.healthCheck.initialDelaySeconds }}
+          periodSeconds: {{ .Values.ndmExporter.nodeExporter.healthCheck.periodSeconds }}
+{{- if .Values.ndmExporter.nodeExporter.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.ndmExporter.nodeExporter.nodeSelector | indent 8 }}
+{{- end }}
+{{- if .Values.ndmExporter.nodeExporter.tolerations }}
+      tolerations:
+{{ toYaml .Values.ndmExporter.nodeExporter.tolerations | indent 8 }}
 {{- end }}
 {{- end }}

--- a/charts/openebs/values.yaml
+++ b/charts/openebs/values.yaml
@@ -14,22 +14,25 @@ serviceAccount:
   name:
 
 imagePullSecrets: []
-  #  - name: image-pull-secret
+# - name: image-pull-secret
 
 release:
   # "openebs.io/version" label for control plane components
   version: "2.12.0"
 
-# Legacy components will be installed if it is enabled.
-# Legacy components are - admission-server, api-server, snapshot-operator
-# and storage-provisioner
-legacy:
-  enabled: true
-
 image:
   pullPolicy: IfNotPresent
   repository: ""
 
+# Legacy components will be installed if it is enabled.
+# Legacy components are - admission-server, api-server, snapshot-operator
+# and provisioner used by non-csi cstor and jiva provisioners
+legacy:
+  enabled: true
+
+# Used by jiva and cstor (non csi) for volume management
+# also installs and updates the CRDs for jiva and cstor (non-csi)
+# Will be disabled in OpenEBS 3.0 in favor of CSI Drivers
 apiserver:
   enabled: true
   image: "openebs/m-apiserver"
@@ -46,25 +49,28 @@ apiserver:
   healthCheck:
     initialDelaySeconds: 30
     periodSeconds: 60
-  ## apiserver resource requests and limits
-  ## Reference: http://kubernetes.io/docs/user-guide/compute-resources/
+  # apiserver resource requests and limits
+  # Reference: http://kubernetes.io/docs/user-guide/compute-resources/
   resources: {}
-    # limits:
-    #   cpu: 1000m
-    #   memory: 2Gi
-    # requests:
-    #   cpu: 500m
-    #   memory: 1Gi
+  # limits:
+  #   cpu: 1000m
+  #   memory: 2Gi
+  # requests:
+  #   cpu: 500m
+  #   memory: 1Gi
 
-
+# Used by apiserver to create default storage classes and pools.
 defaultStorageConfig:
   enabled: "true"
+
 
 # Directory used by the OpenEBS to store debug information and so forth
 # that are generated in the course of running OpenEBS containers.
 varDirectoryPath:
   baseDir: "/var/openebs"
 
+# Out of tree Kubernetes provisioner for jiva and cstor
+# Will be disabled in OpenEBS 3.0 in favor of CSI Drivers
 provisioner:
   enabled: true
   image: "openebs/openebs-k8s-provisioner"
@@ -78,20 +84,16 @@ provisioner:
   healthCheck:
     initialDelaySeconds: 30
     periodSeconds: 60
-  ## provisioner resource requests and limits
-  ## Reference: http://kubernetes.io/docs/user-guide/compute-resources/
+  # provisioner resource requests and limits
+  # Reference: http://kubernetes.io/docs/user-guide/compute-resources/
   resources: {}
-    # limits:
-    #   cpu: 1000m
-    #   memory: 2Gi
-    # requests:
-    #   cpu: 500m
-    #   memory: 1Gi
+  # limits:
+  #   cpu: 1000m
+  #   memory: 2Gi
+  # requests:
+  #   cpu: 500m
+  #   memory: 1Gi
 
-# If you want to enable local pv as a dependency chart then set
-# `localprovisioner.enabled: false` and enable it as dependency chart.
-# If you are using custom configuration then update those configuration
-# under `localpv-provisioner` key.
 localprovisioner:
   enabled: true
   image: "openebs/provisioner-localpv"
@@ -110,42 +112,44 @@ localprovisioner:
   healthCheck:
     initialDelaySeconds: 30
     periodSeconds: 60
-  ## localprovisioner resource requests and limits
-  ## Reference: http://kubernetes.io/docs/user-guide/compute-resources/
+  # localprovisioner resource requests and limits
+  # Reference: http://kubernetes.io/docs/user-guide/compute-resources/
   resources: {}
+  # limits:
+  #   cpu: 1000m
+  #   memory: 2Gi
+  # requests:
+  #   cpu: 500m
+  #   memory: 1Gi
+
+# Out of tree Kubernetes snapshot provisioner for cstor
+# Will be disabled in OpenEBS 3.0 in favor of CSI Drivers
+snapshotOperator:
+  enabled: true
+  controller:
+    image: "openebs/snapshot-controller"
+    imageTag: "2.12.0"
+    # snapshot controller resource requests and limits
+    # Reference: http://kubernetes.io/docs/user-guide/compute-resources/
+    resources: {}
     # limits:
     #   cpu: 1000m
     #   memory: 2Gi
     # requests:
     #   cpu: 500m
     #   memory: 1Gi
-
-snapshotOperator:
-  enabled: true
-  controller:
-    image: "openebs/snapshot-controller"
-    imageTag: "2.12.0"
-    ## snapshot controller resource requests and limits
-    ## Reference: http://kubernetes.io/docs/user-guide/compute-resources/
-    resources: {}
-      # limits:
-      #   cpu: 1000m
-      #   memory: 2Gi
-      # requests:
-      #   cpu: 500m
-      #   memory: 1Gi
   provisioner:
     image: "openebs/snapshot-provisioner"
     imageTag: "2.12.0"
-    ## snapshot provisioner resource requests and limits
-    ## Reference: http://kubernetes.io/docs/user-guide/compute-resources/
+    # snapshot provisioner resource requests and limits
+    # Reference: http://kubernetes.io/docs/user-guide/compute-resources/
     resources: {}
-      # limits:
-      #   cpu: 1000m
-      #   memory: 2Gi
-      # requests:
-      #   cpu: 500m
-      #   memory: 1Gi
+    # limits:
+    #   cpu: 1000m
+    #   memory: 2Gi
+    # requests:
+    #   cpu: 500m
+    #   memory: 1Gi
   replicas: 1
   enableLeaderElection: true
   upgradeStrategy: "Recreate"
@@ -156,9 +160,6 @@ snapshotOperator:
     initialDelaySeconds: 30
     periodSeconds: 60
 
-# If you want to enable openebs as a dependency chart then set `ndm.enabled: false`,
-# `ndmOperator.enabled: false` and enable it as dependency chart. If you are using
-# custom configuration then update those configuration under `openebs-ndm` key.
 ndm:
   enabled: true
   image: "openebs/node-disk-manager"
@@ -182,19 +183,16 @@ ndm:
   healthCheck:
     initialDelaySeconds: 30
     periodSeconds: 60
-  ## ndm resource requests and limits
-  ## Reference: http://kubernetes.io/docs/user-guide/compute-resources/
+  # ndm resource requests and limits
+  # Reference: http://kubernetes.io/docs/user-guide/compute-resources/
   resources: {}
-    # limits:
-    #   cpu: 1000m
-    #   memory: 2Gi
-    # requests:
-    #   cpu: 500m
-    #   memory: 1Gi
+  # limits:
+  #   cpu: 1000m
+  #   memory: 2Gi
+  # requests:
+  #   cpu: 500m
+  #   memory: 1Gi
 
-# If you want to enable openebs as a dependency chart then set `ndm.enabled: false`,
-# `ndmOperator.enabled: false` and enable it as dependency chart. If you are using
-# custom configuration then update those configuration under `openebs-ndm` key.
 ndmOperator:
   enabled: true
   image: "openebs/node-disk-operator"
@@ -209,15 +207,15 @@ ndmOperator:
   readinessCheck:
     initialDelaySeconds: 5
     periodSeconds: 10
-  ## ndmOperator resource requests and limits
-  ## Reference: http://kubernetes.io/docs/user-guide/compute-resources/
+  # ndmOperator resource requests and limits
+  # Reference: http://kubernetes.io/docs/user-guide/compute-resources/
   resources: {}
-    # limits:
-    #   cpu: 1000m
-    #   memory: 2Gi
-    # requests:
-    #   cpu: 500m
-    #   memory: 1Gi
+  # limits:
+  #   cpu: 1000m
+  #   memory: 2Gi
+  # requests:
+  #   cpu: 500m
+  #   memory: 1Gi
 
 ndmExporter:
   enabled: false
@@ -244,6 +242,8 @@ ndmExporter:
     # and listen-port flag will not be set and container port will be empty.
     metricsPort: 9100
 
+# Used by jiva and cstor (non csi) for validation the volume delete requests
+# Will be disabled in OpenEBS 3.0 in favor of CSI Drivers
 webhook:
   enabled: true
   image: "openebs/admission-server"
@@ -257,26 +257,22 @@ webhook:
   tolerations: []
   affinity: {}
   hostNetwork: false
-  ## admission-server resource requests and limits
-  ## Reference: http://kubernetes.io/docs/user-guide/compute-resources/
+  # admission-server resource requests and limits
+  # Reference: http://kubernetes.io/docs/user-guide/compute-resources/
   resources: {}
-    # limits:
-    #   cpu: 500m
-    #   memory: 1Gi
-    # requests:
-    #   cpu: 250m
-    #   memory: 500Mi
+  # limits:
+  #   cpu: 500m
+  #   memory: 1Gi
+  # requests:
+  #   cpu: 250m
+  #   memory: 500Mi
 
-# If you are migrating from 2.x to 3.x and if you are using custom values
-# then put this configuration under `localpv-provisioner` and `openebs-ndm` key.
+# Used by ndm and localprovisioner to carry out tasks like
+# creating or deleting directory, filesystem, etc.
 helper:
   image: "openebs/linux-utils"
   imageTag: "2.12.0"
 
-# These are ndm related configuration. If you want to enable openebs as a dependency
-# chart then set `ndm.enabled: false`, `ndmOperator.enabled: false` and enable it as
-# dependency chart. If you are using custom configuration then update those configuration
-# under `openebs-ndm` key.
 featureGates:
   enabled: true
   GPTBasedUUID:
@@ -296,8 +292,8 @@ featureGates:
 crd:
   enableInstall: true
 
-# If you are migrating from 2.x to 3.x and if you are using custom values
-# then put these configuration under `cstor` key.
+# Used by jiva and cstor (non csi) for validation the volume delete requests
+# Will be disabled in OpenEBS 3.0 in favor of CSI Drivers
 policies:
   monitoring:
     enabled: true
@@ -310,7 +306,6 @@ analytics:
   pingInterval: "24h"
 
 jiva:
-
   # non csi configuration
   image: "openebs/jiva"
   imageTag: "2.12.1"
@@ -322,26 +317,7 @@ jiva:
   # only jiva csi related settings can be added here
   # ref - https://openebs.github.io/jiva-operator
 
-  # jiva chart dependency tree is here -
-  # jiva
-  # | - localpv-provisioner
-  # | | - openebs-ndm
-
-  # Enable localpv-provisioner and openebs-ndm as root dependency not as
-  # sub dependency.
-  # openebs
-  # | - jiva(enable)
-  # | | - localpv-provisioner(disable)
-  # | | | - openebs-ndm(disable)
-  # | - localpv-provisioner(enable)
-  # | - openebs-ndm(enable)
-
   enabled: false
-  openebsLocalpv:
-    enabled: false
-  localpv-provisioner:
-    openebsNDM:
-      enabled: false
 
   # Sample configuration if you want to configure jiva csi driver with custom values.
   # This is a small part of the full configuration. Full configuration available
@@ -354,16 +330,16 @@ jiva:
 #  jivaOperator:
 #    controller:
 #      image:
-#        registry: quay.io/
+#        registry:
 #        repository: openebs/jiva
 #        tag: 2.12.1
 #    replica:
 #      image:
-#        registry: quay.io/
+#        registry:
 #        repository: openebs/jiva
 #        tag: 2.12.1
 #    image:
-#      registry: quay.io/
+#      registry:
 #      repository: openebs/jiva-operator
 #      pullPolicy: IfNotPresent
 #      tag: 2.12.1
@@ -371,7 +347,7 @@ jiva:
 #  jivaCSIPlugin:
 #    remount: "true"
 #    image:
-#      registry: quay.io/
+#      registry:
 #      repository: openebs/jiva-csi
 #      pullPolicy: IfNotPresent
 #      tag: 2.12.1
@@ -397,18 +373,7 @@ cstor:
   # only cstor csi related settings can be added here
   # ref - https://openebs.github.io/cstor-operators
 
-  # cstor chart dependency tree is here -
-  # cstor
-  # | - openebs-ndm
-
-  # Enable openebs-ndm as root dependency not as sub dependency.
-  # openebs
-  # | - cstor(enable)
-  # | | - openebs-ndm(disable)
-  # | - openebs-ndm(enable)
   enabled: false
-  openebsNDM:
-    enabled: false
 
   # Sample configuration if you want to configure cstor csi driver with custom values.
   # This is a small part of the full configuration. Full configuration available
@@ -479,117 +444,6 @@ cstor:
 #      pullPolicy: IfNotPresent
 #      tag: 2.12.0
 
-# ndm configuration goes here
-# https://openebs.github.io/node-disk-manager
-openebs-ndm:
-  enabled: false
-
-  # Sample configuration if you want to configure openebs ndm with custom values.
-  # This is a small part of the full configuration. Full configuration available
-  # here - https://openebs.github.io/node-disk-manager
-
-#  imagePullSecrets: []
-#
-#  ndm:
-#    image:
-#      registry: quay.io/
-#      repository: openebs/node-disk-manager
-#      pullPolicy: IfNotPresent
-#      tag: 1.6.1
-#    sparse:
-#      path: "/var/openebs/sparse"
-#      size: "10737418240"
-#      count: "0"
-#    filters:
-#      enableOsDiskExcludeFilter: true
-#      osDiskExcludePaths: "/,/etc/hosts,/boot"
-#      enableVendorFilter: true
-#      excludeVendors: "CLOUDBYT,OpenEBS"
-#      enablePathFilter: true
-#      includePaths: ""
-#      excludePaths: "loop,fd0,sr0,/dev/ram,/dev/dm-,/dev/md,/dev/rbd,/dev/zd"
-#    probes:
-#      enableSeachest: false
-#      enableUdevProbe: true
-#      enableSmartProbe: true
-#
-#  ndmOperator:
-#    image:
-#      registry: quay.io/
-#      repository: openebs/node-disk-operator
-#      pullPolicy: IfNotPresent
-#      tag: 1.6.1
-#
-#  helperPod:
-#    image:
-#      registry: quay.io/
-#      repository: openebs/linux-utils
-#      pullPolicy: IfNotPresent
-#      tag: 2.12.0
-#
-#  featureGates:
-#    enabled: true
-#    GPTBasedUUID:
-#      enabled: true
-#      featureGateFlag: "GPTBasedUUID"
-#    APIService:
-#      enabled: true
-#      featureGateFlag: "APIService"
-#      address: "0.0.0.0:9115"
-#    UseOSDisk:
-#      enabled: false
-#      featureGateFlag: "UseOSDisk"
-#
-#  varDirectoryPath:
-#    baseDir: "/var/openebs"
-
-  # local pv provisioner configuration goes here
-  # do not enable or configure any sub dependency here
-  # ref - https://openebs.github.io/dynamic-localpv-provisioner
-
-  # local pv chart dependency tree is here -
-  # localpv-provisioner
-  # | - openebs-ndm
-
-  # Enable openebs-ndm as root dependency not as sub dependency.
-  # openebs
-  # | - localpv-provisioner(enable)
-  # | | - openebs-ndm(disable)
-  # | - openebs-ndm(enable)
-localpv-provisioner:
-  enabled: false
-  openebsNDM:
-    enabled: false
-
-  # Sample configuration if you want to configure openebs locapv with custom values.
-  # This is a small part of the full configuration. Full configuration available
-  # here - https://openebs.github.io/dynamic-localpv-provisioner
-
-#  imagePullSecrets: []
-#
-#  rbac:
-#    create: true
-#    pspEnabled: false
-#
-#  localpv:
-#    image:
-#      registry: quay.io/
-#      repository: openebs/provisioner-localpv
-#      tag: 2.12.0
-#      pullPolicy: IfNotPresent
-#    healthCheck:
-#      initialDelaySeconds: 30
-#      periodSeconds: 60
-#    replicas: 1
-#    enableLeaderElection: true
-#    basePath: "/var/openebs/local"
-#
-#  helperPod:
-#    image:
-#      registry: quay.io/
-#      repository: openebs/linux-utils
-#      pullPolicy: IfNotPresent
-#      tag: 2.12.0
 
 # zfs local pv configuration goes here
 # ref - https://openebs.github.io/zfs-localpv

--- a/charts/openebs/values.yaml
+++ b/charts/openebs/values.yaml
@@ -233,6 +233,20 @@ ndmExporter:
     # If not set, service will not be created to expose metrics endpoint to serviceMonitor
     # and listen-port flag will not be set and container port will be empty.
     metricsPort: 9101
+    nodeSelector: {}
+    tolerations: []
+    healthCheck:
+      initialDelaySeconds: 30
+      periodSeconds: 60
+    # ndm resource requests and limits
+    # Reference: http://kubernetes.io/docs/user-guide/compute-resources/
+    resources: {}
+    # limits:
+    #   cpu: 1000m
+    #   memory: 2Gi
+    # requests:
+    #   cpu: 500m
+    #   memory: 1Gi
   clusterExporter:
     name: ndm-cluster-exporter
     podLabels:
@@ -241,6 +255,20 @@ ndmExporter:
     # If not set, service will not be created to expose metrics endpoint to serviceMonitor
     # and listen-port flag will not be set and container port will be empty.
     metricsPort: 9100
+    nodeSelector: {}
+    tolerations: []
+    healthCheck:
+      initialDelaySeconds: 30
+      periodSeconds: 60
+    # ndm resource requests and limits
+    # Reference: http://kubernetes.io/docs/user-guide/compute-resources/
+    resources: {}
+    # limits:
+    #   cpu: 1000m
+    #   memory: 2Gi
+    # requests:
+    #   cpu: 500m
+    #   memory: 1Gi
 
 # Used by jiva and cstor (non csi) for validation the volume delete requests
 # Will be disabled in OpenEBS 3.0 in favor of CSI Drivers


### PR DESCRIPTION
Signed-off-by: kmova <kiran.mova@mayadata.io>

As a pre-step towards 3.0 and enabling CSI drivers for jiva and 
cstor, made the necessary documentation and values.yaml updates. 

The premise is that openebs chart will continue its current templates 
of ndm and local provisioner, while jiva and cstor will be deprecated 
in favor of the corresponding csi charts.

Once 3.0 is released, the recommended way to install cstor, jiva and other
engines would be to enable via this umbrella chart. If there is a strong
use-case for using only one type of engine in a cluster - the user can opt to
install the sub-charts directly.

Trimmed down the configuration options in the README to the commonly used
options.

Also, added Shovan as a maintainer.


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/openebs]`)
