### PR TITLE
chore(charts): Update openebs/openebs helm chart for dynamic-localpv and jiva-operator v2.11.1

### DIFF
--- a/charts/openebs/Chart.yaml
+++ b/charts/openebs/Chart.yaml
@@ -31,7 +31,7 @@ dependencies:
     repository: "https://openebs.github.io/cstor-operators"
     condition: cstor.enabled
   - name: jiva
-    version: "2.11.0"
+    version: "2.11.1"
     repository: "https://openebs.github.io/jiva-operator"
     condition: jiva.enabled
   - name: zfs-localpv

--- a/charts/openebs/Chart.yaml
+++ b/charts/openebs/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 2.11.1
+version: 2.11.2
 name: openebs
 appVersion: 2.11.0
 description: Containerized Storage for Containers
@@ -23,7 +23,7 @@ dependencies:
     repository: "https://openebs.github.io/node-disk-manager"
     condition: openebs-ndm.enabled
   - name: localpv-provisioner
-    version: "2.11.0"
+    version: "2.11.1"
     repository: "https://openebs.github.io/dynamic-localpv-provisioner"
     condition: localpv-provisioner.enabled
   - name: cstor

--- a/charts/openebs/README.md
+++ b/charts/openebs/README.md
@@ -77,7 +77,7 @@ The following table lists the configurable parameters of the OpenEBS chart and t
 | `provisioner.patchJivaNodeAffinity`     | Enable/disable node affinity on jiva replica deployment| `enabled`                                 |
 | `localprovisioner.enabled`              | Enable localProvisioner                       | `true`                                    |
 | `localprovisioner.image`                | Image for localProvisioner                    | `openebs/provisioner-localpv`             |
-| `localprovisioner.imageTag`             | Image Tag for localProvisioner                | `2.11.0`                                  |
+| `localprovisioner.imageTag`             | Image Tag for localProvisioner                | `2.11.1`                                  |
 | `localprovisioner.replicas`             | Number of localProvisioner Replicas           | `1`                                       |
 | `localprovisioner.basePath`             | BasePath for hostPath volumes on Nodes        | `/var/openebs/local`                      |
 | `localprovisioner.resources`            | Set resource limits for localProvisioner      | `{}`                                      |

--- a/charts/openebs/values.yaml
+++ b/charts/openebs/values.yaml
@@ -87,7 +87,7 @@ provisioner:
 localprovisioner:
   enabled: true
   image: "openebs/provisioner-localpv"
-  imageTag: "2.11.0"
+  imageTag: "2.11.1"
   replicas: 1
   enableLeaderElection: true
   basePath: "/var/openebs/local"
@@ -537,7 +537,7 @@ localpv-provisioner:
 #    image:
 #      registry: quay.io/
 #      repository: openebs/provisioner-localpv
-#      tag: 2.11.0
+#      tag: 2.11.1
 #      pullPolicy: IfNotPresent
 #    healthCheck:
 #      initialDelaySeconds: 30


### PR DESCRIPTION
Signed-off-by: Niladri Halder <niladri.halder@mayadata.io>

Update openebs/openebs helm chart with dynamic-localpv-provisioner items...
1. provisioner-localpv image version (v2.11.1)
2. dependent helm chart version (v2.11.1)

Update openebs/openebs helm chart with jiva-operator item...
1. dependent helm chart version (v2.11.1)

Ref: https://github.com/openebs/dynamic-localpv-provisioner/issues/71

Depends on 
https://github.com/openebs/dynamic-localpv-provisioner/pull/72
https://github.com/openebs/jiva-operator/pull/119