### PR TITLE
feat(charts): add flag to control legacy components installation

### DIFF
--- a/charts/openebs/Chart.yaml
+++ b/charts/openebs/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 2.11.2
+version: 2.11.3
 name: openebs
 appVersion: 2.11.0
 description: Containerized Storage for Containers

--- a/charts/openebs/README.md
+++ b/charts/openebs/README.md
@@ -188,10 +188,7 @@ helm install openebs openebs/openebs --namespace openebs --create-namespace \
 --set localprovisioner.enabled=false \
 --set ndm.enabled=false \
 --set ndmOperator.enabled=false \
---set webhook.enabled=false \
---set snapshotOperator.enabled=false \
---set provisioner.enabled=false \
---set apiserver.enabled=false \
+--set legacy.enabled=false \
 --set cstor.enabled=true \
 --set openebs-ndm.enabled=true
 ```
@@ -202,10 +199,7 @@ helm install openebs openebs/openebs --namespace openebs --create-namespace \
 --set localprovisioner.enabled=false \
 --set ndm.enabled=false \
 --set ndmOperator.enabled=false \
---set webhook.enabled=false \
---set snapshotOperator.enabled=false \
---set provisioner.enabled=false \
---set apiserver.enabled=false \
+--set legacy.enabled=false \
 --set jiva.enabled=true \
 --set openebs-ndm.enabled=true \
 --set localpv-provisioner.enabled=true
@@ -217,10 +211,7 @@ helm install openebs openebs/openebs --namespace openebs --create-namespace \
 --set localprovisioner.enabled=false \
 --set ndm.enabled=false \
 --set ndmOperator.enabled=false \
---set webhook.enabled=false \
---set snapshotOperator.enabled=false \
---set provisioner.enabled=false \
---set apiserver.enabled=false \
+--set legacy.enabled=false \
 --set zfs-localpv.enabled=true
 ```
 
@@ -230,10 +221,7 @@ helm install openebs openebs/openebs --namespace openebs --create-namespace \
 --set localprovisioner.enabled=false \
 --set ndm.enabled=false \
 --set ndmOperator.enabled=false \
---set webhook.enabled=false \
---set snapshotOperator.enabled=false \
---set provisioner.enabled=false \
---set apiserver.enabled=false \
+--set legacy.enabled=false \
 --set lvm-localpv.enabled=true
 ```
 
@@ -244,6 +232,7 @@ helm install openebs openebs/openebs --namespace openebs --create-namespace \
 --set ndm.enabled=false \
 --set ndmOperator.enabled=false \
 --set openebs-ndm.enabled=true \
+--set legacy.enabled=false \
 --set localpv-provisioner.enabled=true
 ```
 

--- a/charts/openebs/templates/deployment-admission-server.yaml
+++ b/charts/openebs/templates/deployment-admission-server.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.webhook.enabled }}
+{{- if and (.Values.webhook.enabled) (.Values.legacy.enabled) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/openebs/templates/deployment-maya-apiserver.yaml
+++ b/charts/openebs/templates/deployment-maya-apiserver.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.apiserver.enabled }}
+{{- if and (.Values.apiserver.enabled) (.Values.legacy.enabled) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/openebs/templates/deployment-maya-provisioner.yaml
+++ b/charts/openebs/templates/deployment-maya-provisioner.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.provisioner.enabled }}
+{{- if and (.Values.provisioner.enabled) (.Values.legacy.enabled) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/openebs/templates/deployment-maya-snapshot-operator.yaml
+++ b/charts/openebs/templates/deployment-maya-snapshot-operator.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.snapshotOperator.enabled }}
+{{- if and (.Values.snapshotOperator.enabled) (.Values.legacy.enabled) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/openebs/templates/service-maya-apiserver.yaml
+++ b/charts/openebs/templates/service-maya-apiserver.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.apiserver.enabled }}
+{{- if and (.Values.apiserver.enabled) (.Values.legacy.enabled) }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/openebs/values.yaml
+++ b/charts/openebs/values.yaml
@@ -18,6 +18,12 @@ release:
   # "openebs.io/version" label for control plane components
   version: "2.11.0"
 
+# Legacy components will be install if it is enabled.
+# Legacy components are - admission-server, api-server, snapshot-operator
+# and storage-provisioner
+legacy:
+  enabled: true
+
 image:
   pullPolicy: IfNotPresent
   repository: ""

--- a/charts/openebs/values.yaml
+++ b/charts/openebs/values.yaml
@@ -18,7 +18,7 @@ release:
   # "openebs.io/version" label for control plane components
   version: "2.11.0"
 
-# Legacy components will be install if it is enabled.
+# Legacy components will be installed if it is enabled.
 # Legacy components are - admission-server, api-server, snapshot-operator
 # and storage-provisioner
 legacy:


### PR DESCRIPTION
Add a flag to control legacy components installation. Default value is true, so by default legacy components will be installed.
Use - `--set legacy.enabled=false` to disable legacy components.
Fix - https://github.com/openebs/charts/issues/235