### PR TITLE
Fix(openebs-operator-lite): Fix typo in openebs-operator-lite.yaml

### DIFF
--- a/2.11.0/openebs-operator-lite.yaml
+++ b/2.11.0/openebs-operator-lite.yaml
@@ -679,7 +679,7 @@ spec:
               port: 8585
             initialDelaySeconds: 5
             periodSeconds: 10
-------
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/openebs-operator-lite.yaml
+++ b/openebs-operator-lite.yaml
@@ -679,7 +679,7 @@ spec:
               port: 8585
             initialDelaySeconds: 5
             periodSeconds: 10
-------
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
Signed-off-by: Niladri Halder <niladri.halder@mayadata.io>

This fixes a typo in the openebs-operator-lite.yaml file (v2.11.0). 
YAML end of directive marker between openebs-ndm-operator and openebs-localpv-provisioner deployments had too many '-' characters.