### PR TITLE
fix(chart): Disable openebs webhook cleanup when legacy.enabled=false

### DIFF
--- a/charts/openebs/Chart.yaml
+++ b/charts/openebs/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 2.11.4
+version: 2.11.5
 name: openebs
 appVersion: 2.11.0
 description: Containerized Storage for Containers

--- a/charts/openebs/README.md
+++ b/charts/openebs/README.md
@@ -185,9 +185,6 @@ helm install openebs openebs/openebs --namespace openebs --create-namespace
 #### Install cStor with CSI driver
 ```bash
 helm install openebs openebs/openebs --namespace openebs --create-namespace \
---set localprovisioner.enabled=false \
---set ndm.enabled=false \
---set ndmOperator.enabled=false \
 --set legacy.enabled=false \
 --set cstor.enabled=true \
 --set openebs-ndm.enabled=true
@@ -196,9 +193,6 @@ helm install openebs openebs/openebs --namespace openebs --create-namespace \
 #### Install Jiva with CSI driver
 ```bash
 helm install openebs openebs/openebs --namespace openebs --create-namespace \
---set localprovisioner.enabled=false \
---set ndm.enabled=false \
---set ndmOperator.enabled=false \
 --set legacy.enabled=false \
 --set jiva.enabled=true \
 --set openebs-ndm.enabled=true \
@@ -208,9 +202,6 @@ helm install openebs openebs/openebs --namespace openebs --create-namespace \
 #### Install ZFS Local PV
 ```bash
 helm install openebs openebs/openebs --namespace openebs --create-namespace \
---set localprovisioner.enabled=false \
---set ndm.enabled=false \
---set ndmOperator.enabled=false \
 --set legacy.enabled=false \
 --set zfs-localpv.enabled=true
 ```
@@ -218,9 +209,6 @@ helm install openebs openebs/openebs --namespace openebs --create-namespace \
 #### Install LVM Local PV
 ```bash
 helm install openebs openebs/openebs --namespace openebs --create-namespace \
---set localprovisioner.enabled=false \
---set ndm.enabled=false \
---set ndmOperator.enabled=false \
 --set legacy.enabled=false \
 --set lvm-localpv.enabled=true
 ```
@@ -228,12 +216,9 @@ helm install openebs openebs/openebs --namespace openebs --create-namespace \
 #### Install Local PV hostpath and device
 ```bash
 helm install openebs openebs/openebs --namespace openebs --create-namespace \
---set localprovisioner.enabled=false \
---set ndm.enabled=false \
---set ndmOperator.enabled=false \
---set openebs-ndm.enabled=true \
 --set legacy.enabled=false \
 --set localpv-provisioner.enabled=true
+--set openebs-ndm.enabled=true \
 ```
 
 > **Tip**: You can install multiple csi driver by merging the configuration.

--- a/charts/openebs/templates/cleanup-webhook.yaml
+++ b/charts/openebs/templates/cleanup-webhook.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.webhook.enabled }}
+{{- if and (.Values.webhook.enabled) (.Values.legacy.enabled) }}
 # HELM first deletes RBAC, then it tries to delete other resources like SPC and PVC. 
 # We've got validating webhook on SPC and PVC.
 # But even that the policy of this webhook is Ignore, it fails because the ServiceAccount 


### PR DESCRIPTION
Signed-off-by: Niladri Halder <niladri.halder@mayadata.io>

openebs-webhook-cleanup job attempts to cleanup openebs-validating-webhook-cfg even when legacy.enabled=false is set.
Correcting the condition.

README.md changes to update the installation commands for cStor-CSI, Jiva-CSI, ZFS-LocalPV, LVM-LocalPV, LocalPV-Hostpath-and-Device.