### PR TITLE
chore(openebs-operator): create LocalPV storageClasses using YAMLs

### DIFF
--- a/legacy-openebs-operator.yaml
+++ b/legacy-openebs-operator.yaml
@@ -97,7 +97,7 @@ metadata:
   labels:
     name: maya-apiserver
     openebs.io/component-name: maya-apiserver
-    openebs.io/version: 2.12.0
+    openebs.io/version: 2.12.1
 spec:
   selector:
     matchLabels:
@@ -112,13 +112,13 @@ spec:
       labels:
         name: maya-apiserver
         openebs.io/component-name: maya-apiserver
-        openebs.io/version: 2.12.0
+        openebs.io/version: 2.12.1
     spec:
       serviceAccountName: openebs-maya-operator
       containers:
       - name: maya-apiserver
         imagePullPolicy: IfNotPresent
-        image: openebs/m-apiserver:2.12.0
+        image: openebs/m-apiserver:2.12.1
         ports:
         - containerPort: 5656
         env:
@@ -197,25 +197,25 @@ spec:
         #- name: OPENEBS_IO_LOCALPV_HOSTPATH_DIR
         #  value: "/var/openebs/local"
         - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
-          value: "openebs/jiva:2.12.1"
+          value: "openebs/jiva:2.12.2"
         - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
-          value: "openebs/jiva:2.12.1"
+          value: "openebs/jiva:2.12.2"
         - name: OPENEBS_IO_JIVA_REPLICA_COUNT
           value: "3"
         - name: OPENEBS_IO_CSTOR_TARGET_IMAGE
-          value: "openebs/cstor-istgt:2.12.0"
+          value: "openebs/cstor-istgt:2.12.1"
         - name: OPENEBS_IO_CSTOR_POOL_IMAGE
-          value: "openebs/cstor-pool:2.12.0"
+          value: "openebs/cstor-pool:2.12.1"
         - name: OPENEBS_IO_CSTOR_POOL_MGMT_IMAGE
-          value: "openebs/cstor-pool-mgmt:2.12.0"
+          value: "openebs/cstor-pool-mgmt:2.12.1"
         - name: OPENEBS_IO_CSTOR_VOLUME_MGMT_IMAGE
-          value: "openebs/cstor-volume-mgmt:2.12.0"
+          value: "openebs/cstor-volume-mgmt:2.12.1"
         - name: OPENEBS_IO_VOLUME_MONITOR_IMAGE
-          value: "openebs/m-exporter:2.12.0"
+          value: "openebs/m-exporter:2.12.1"
         - name: OPENEBS_IO_CSTOR_POOL_EXPORTER_IMAGE
-          value: "openebs/m-exporter:2.12.0"
+          value: "openebs/m-exporter:2.12.1"
         - name: OPENEBS_IO_HELPER_IMAGE
-          value: "openebs/linux-utils:2.12.0"
+          value: "openebs/linux-utils:2.12.1"
         # OPENEBS_IO_ENABLE_ANALYTICS if set to true sends anonymous usage
         # events to Google Analytics
         - name: OPENEBS_IO_ENABLE_ANALYTICS
@@ -272,7 +272,7 @@ metadata:
   labels:
     name: openebs-provisioner
     openebs.io/component-name: openebs-provisioner
-    openebs.io/version: 2.12.0
+    openebs.io/version: 2.12.1
 spec:
   selector:
     matchLabels:
@@ -287,13 +287,13 @@ spec:
       labels:
         name: openebs-provisioner
         openebs.io/component-name: openebs-provisioner
-        openebs.io/version: 2.12.0
+        openebs.io/version: 2.12.1
     spec:
       serviceAccountName: openebs-maya-operator
       containers:
       - name: openebs-provisioner
         imagePullPolicy: IfNotPresent
-        image: openebs/openebs-k8s-provisioner:2.12.0
+        image: openebs/openebs-k8s-provisioner:2.12.1
         env:
         # OPENEBS_IO_K8S_MASTER enables openebs provisioner to connect to K8s
         # based on this address. This is ignored if empty.
@@ -351,7 +351,7 @@ metadata:
   labels:
     name: openebs-snapshot-operator
     openebs.io/component-name: openebs-snapshot-operator
-    openebs.io/version: 2.12.0
+    openebs.io/version: 2.12.1
 spec:
   selector:
     matchLabels:
@@ -365,12 +365,12 @@ spec:
       labels:
         name: openebs-snapshot-operator
         openebs.io/component-name: openebs-snapshot-operator
-        openebs.io/version: 2.12.0
+        openebs.io/version: 2.12.1
     spec:
       serviceAccountName: openebs-maya-operator
       containers:
         - name: snapshot-controller
-          image: openebs/snapshot-controller:2.12.0
+          image: openebs/snapshot-controller:2.12.1
           imagePullPolicy: IfNotPresent
           env:
           - name: OPENEBS_NAMESPACE
@@ -398,7 +398,7 @@ spec:
         #- name: OPENEBS_MAYA_SERVICE_NAME
         #  value: "maya-apiserver-apiservice"
         - name: snapshot-provisioner
-          image: openebs/snapshot-provisioner:2.12.0
+          image: openebs/snapshot-provisioner:2.12.1
           imagePullPolicy: IfNotPresent
           env:
           - name: OPENEBS_NAMESPACE
@@ -862,7 +862,7 @@ metadata:
   labels:
     name: openebs-ndm
     openebs.io/component-name: ndm
-    openebs.io/version: 2.12.0
+    openebs.io/version: 2.12.1
 spec:
   selector:
     matchLabels:
@@ -875,7 +875,7 @@ spec:
       labels:
         name: openebs-ndm
         openebs.io/component-name: ndm
-        openebs.io/version: 2.12.0
+        openebs.io/version: 2.12.1
     spec:
       # By default the node-disk-manager will be run on all kubernetes nodes
       # If you would like to limit this to only some nodes, say the nodes
@@ -992,7 +992,7 @@ metadata:
   labels:
     name: openebs-ndm-operator
     openebs.io/component-name: ndm-operator
-    openebs.io/version: 2.12.0
+    openebs.io/version: 2.12.1
 spec:
   selector:
     matchLabels:
@@ -1006,7 +1006,7 @@ spec:
       labels:
         name: openebs-ndm-operator
         openebs.io/component-name: ndm-operator
-        openebs.io/version: 2.12.0
+        openebs.io/version: 2.12.1
     spec:
       serviceAccountName: openebs-maya-operator
       containers:
@@ -1030,7 +1030,7 @@ spec:
             - name: OPERATOR_NAME
               value: "node-disk-operator"
             - name: CLEANUP_JOB_IMAGE
-              value: "openebs/linux-utils:2.12.0"
+              value: "openebs/linux-utils:2.12.1"
             # OPENEBS_IO_IMAGE_PULL_SECRETS environment variable is used to pass the image pull secrets
             # to the cleanup pod launched by NDM operator
             #- name: OPENEBS_IO_IMAGE_PULL_SECRETS
@@ -1056,7 +1056,7 @@ metadata:
   labels:
     app: admission-webhook
     openebs.io/component-name: admission-webhook
-    openebs.io/version: 2.12.0
+    openebs.io/version: 2.12.1
 spec:
   replicas: 1
   strategy:
@@ -1070,12 +1070,12 @@ spec:
       labels:
         app: admission-webhook
         openebs.io/component-name: admission-webhook
-        openebs.io/version: 2.12.0
+        openebs.io/version: 2.12.1
     spec:
       serviceAccountName: openebs-maya-operator
       containers:
         - name: admission-webhook
-          image: openebs/admission-server:2.12.0
+          image: openebs/admission-server:2.12.1
           imagePullPolicy: IfNotPresent
           args:
             - -alsologtostderr

--- a/openebs-operator.yaml
+++ b/openebs-operator.yaml
@@ -195,25 +195,25 @@ spec:
         # This value takes effect only if OPENEBS_IO_CREATE_DEFAULT_STORAGE_CONFIG
         # is set to true
         - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
-          value: "openebs/jiva:2.12.1"
+          value: "openebs/jiva:2.12.2"
         - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
-          value: "openebs/jiva:2.12.1"
+          value: "openebs/jiva:2.12.2"
         - name: OPENEBS_IO_JIVA_REPLICA_COUNT
           value: "3"
         - name: OPENEBS_IO_CSTOR_TARGET_IMAGE
-          value: "openebs/cstor-istgt:2.12.0"
+          value: "openebs/cstor-istgt:2.12.1"
         - name: OPENEBS_IO_CSTOR_POOL_IMAGE
-          value: "openebs/cstor-pool:2.12.0"
+          value: "openebs/cstor-pool:2.12.1"
         - name: OPENEBS_IO_CSTOR_POOL_MGMT_IMAGE
-          value: "openebs/cstor-pool-mgmt:2.12.0"
+          value: "openebs/cstor-pool-mgmt:2.12.1"
         - name: OPENEBS_IO_CSTOR_VOLUME_MGMT_IMAGE
-          value: "openebs/cstor-volume-mgmt:2.12.0"
+          value: "openebs/cstor-volume-mgmt:2.12.1"
         - name: OPENEBS_IO_VOLUME_MONITOR_IMAGE
-          value: "openebs/m-exporter:2.12.0"
+          value: "openebs/m-exporter:2.12.1"
         - name: OPENEBS_IO_CSTOR_POOL_EXPORTER_IMAGE
-          value: "openebs/m-exporter:2.12.0"
+          value: "openebs/m-exporter:2.12.1"
         - name: OPENEBS_IO_HELPER_IMAGE
-          value: "openebs/linux-utils:2.12.0"
+          value: "openebs/linux-utils:2.12.1"
         # OPENEBS_IO_ENABLE_ANALYTICS if set to true sends anonymous usage
         # events to Google Analytics
         - name: OPENEBS_IO_ENABLE_ANALYTICS
@@ -291,7 +291,7 @@ spec:
       containers:
       - name: openebs-provisioner
         imagePullPolicy: IfNotPresent
-        image: openebs/openebs-k8s-provisioner:2.12.0
+        image: openebs/openebs-k8s-provisioner:2.12.1
         env:
         # OPENEBS_IO_K8S_MASTER enables openebs provisioner to connect to K8s
         # based on this address. This is ignored if empty.
@@ -368,7 +368,7 @@ spec:
       serviceAccountName: openebs-maya-operator
       containers:
         - name: snapshot-controller
-          image: openebs/snapshot-controller:2.12.0
+          image: openebs/snapshot-controller:2.12.1
           imagePullPolicy: IfNotPresent
           env:
           - name: OPENEBS_NAMESPACE
@@ -396,7 +396,7 @@ spec:
         #- name: OPENEBS_MAYA_SERVICE_NAME
         #  value: "maya-apiserver-apiservice"
         - name: snapshot-provisioner
-          image: openebs/snapshot-provisioner:2.12.0
+          image: openebs/snapshot-provisioner:2.12.1
           imagePullPolicy: IfNotPresent
           env:
           - name: OPENEBS_NAMESPACE
@@ -1028,7 +1028,7 @@ spec:
             - name: OPERATOR_NAME
               value: "node-disk-operator"
             - name: CLEANUP_JOB_IMAGE
-              value: "openebs/linux-utils:2.12.0"
+              value: "openebs/linux-utils:2.12.1"
             # OPENEBS_IO_IMAGE_PULL_SECRETS environment variable is used to pass the image pull secrets
             # to the cleanup pod launched by NDM operator
             #- name: OPENEBS_IO_IMAGE_PULL_SECRETS
@@ -1073,7 +1073,7 @@ spec:
       serviceAccountName: openebs-maya-operator
       containers:
         - name: admission-webhook
-          image: openebs/admission-server:2.12.0
+          image: openebs/admission-server:2.12.1
           imagePullPolicy: IfNotPresent
           args:
             - -alsologtostderr
@@ -1131,7 +1131,7 @@ spec:
       containers:
       - name: openebs-provisioner-hostpath
         imagePullPolicy: IfNotPresent
-        image: openebs/provisioner-localpv:2.12.0
+        image: openebs/provisioner-localpv:2.12.1
         args:
           - "--bd-time-out=$(BDC_BD_BIND_RETRIES)"
         env:
@@ -1170,7 +1170,7 @@ spec:
         - name: OPENEBS_IO_INSTALLER_TYPE
           value: "openebs-operator"
         - name: OPENEBS_IO_HELPER_IMAGE
-          value: "openebs/linux-utils:2.12.0"
+          value: "openebs/linux-utils:2.12.1"
         - name: OPENEBS_IO_BASE_PATH
           value: "/var/openebs/local"
         # LEADER_ELECTION_ENABLED is used to enable/disable leader election. By default
@@ -1236,4 +1236,3 @@ provisioner: openebs.io/local
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete
 ---
-

--- a/openebs-operator.yaml
+++ b/openebs-operator.yaml
@@ -97,7 +97,7 @@ metadata:
   labels:
     name: maya-apiserver
     openebs.io/component-name: maya-apiserver
-    openebs.io/version: 2.12.0
+    openebs.io/version: 2.12.1
 spec:
   selector:
     matchLabels:
@@ -112,13 +112,13 @@ spec:
       labels:
         name: maya-apiserver
         openebs.io/component-name: maya-apiserver
-        openebs.io/version: 2.12.0
+        openebs.io/version: 2.12.1
     spec:
       serviceAccountName: openebs-maya-operator
       containers:
       - name: maya-apiserver
         imagePullPolicy: IfNotPresent
-        image: openebs/m-apiserver:2.12.0
+        image: openebs/m-apiserver:2.12.1
         ports:
         - containerPort: 5656
         env:
@@ -194,8 +194,6 @@ spec:
         # The default path used is /var/openebs/local
         # This value takes effect only if OPENEBS_IO_CREATE_DEFAULT_STORAGE_CONFIG
         # is set to true
-        #- name: OPENEBS_IO_LOCALPV_HOSTPATH_DIR
-        #  value: "/var/openebs/local"
         - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
           value: "openebs/jiva:2.12.1"
         - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
@@ -272,7 +270,7 @@ metadata:
   labels:
     name: openebs-provisioner
     openebs.io/component-name: openebs-provisioner
-    openebs.io/version: 2.12.0
+    openebs.io/version: 2.12.1
 spec:
   selector:
     matchLabels:
@@ -287,7 +285,7 @@ spec:
       labels:
         name: openebs-provisioner
         openebs.io/component-name: openebs-provisioner
-        openebs.io/version: 2.12.0
+        openebs.io/version: 2.12.1
     spec:
       serviceAccountName: openebs-maya-operator
       containers:
@@ -351,7 +349,7 @@ metadata:
   labels:
     name: openebs-snapshot-operator
     openebs.io/component-name: openebs-snapshot-operator
-    openebs.io/version: 2.12.0
+    openebs.io/version: 2.12.1
 spec:
   selector:
     matchLabels:
@@ -365,7 +363,7 @@ spec:
       labels:
         name: openebs-snapshot-operator
         openebs.io/component-name: openebs-snapshot-operator
-        openebs.io/version: 2.12.0
+        openebs.io/version: 2.12.1
     spec:
       serviceAccountName: openebs-maya-operator
       containers:
@@ -862,7 +860,7 @@ metadata:
   labels:
     name: openebs-ndm
     openebs.io/component-name: ndm
-    openebs.io/version: 2.12.0
+    openebs.io/version: 2.12.1
 spec:
   selector:
     matchLabels:
@@ -875,7 +873,7 @@ spec:
       labels:
         name: openebs-ndm
         openebs.io/component-name: ndm
-        openebs.io/version: 2.12.0
+        openebs.io/version: 2.12.1
     spec:
       # By default the node-disk-manager will be run on all kubernetes nodes
       # If you would like to limit this to only some nodes, say the nodes
@@ -992,7 +990,7 @@ metadata:
   labels:
     name: openebs-ndm-operator
     openebs.io/component-name: ndm-operator
-    openebs.io/version: 2.12.0
+    openebs.io/version: 2.12.1
 spec:
   selector:
     matchLabels:
@@ -1006,7 +1004,7 @@ spec:
       labels:
         name: openebs-ndm-operator
         openebs.io/component-name: ndm-operator
-        openebs.io/version: 2.12.0
+        openebs.io/version: 2.12.1
     spec:
       serviceAccountName: openebs-maya-operator
       containers:
@@ -1056,7 +1054,7 @@ metadata:
   labels:
     app: admission-webhook
     openebs.io/component-name: admission-webhook
-    openebs.io/version: 2.12.0
+    openebs.io/version: 2.12.1
 spec:
   replicas: 1
   strategy:
@@ -1070,7 +1068,7 @@ spec:
       labels:
         app: admission-webhook
         openebs.io/component-name: admission-webhook
-        openebs.io/version: 2.12.0
+        openebs.io/version: 2.12.1
     spec:
       serviceAccountName: openebs-maya-operator
       containers:
@@ -1113,7 +1111,7 @@ metadata:
   labels:
     name: openebs-localpv-provisioner
     openebs.io/component-name: openebs-localpv-provisioner
-    openebs.io/version: 2.12.0
+    openebs.io/version: 2.12.1
 spec:
   selector:
     matchLabels:
@@ -1127,7 +1125,7 @@ spec:
       labels:
         name: openebs-localpv-provisioner
         openebs.io/component-name: openebs-localpv-provisioner
-        openebs.io/version: 2.12.0
+        openebs.io/version: 2.12.1
     spec:
       serviceAccountName: openebs-maya-operator
       containers:
@@ -1197,5 +1195,45 @@ spec:
             - test `pgrep -c "^provisioner-loc.*"` = 1
           initialDelaySeconds: 30
           periodSeconds: 60
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-hostpath
+  annotations:
+    openebs.io/cas-type: local
+    cas.openebs.io/config: |
+      #hostpath type will create a PV by 
+      # creating a sub-directory under the
+      # BASEPATH provided below.
+      - name: StorageType
+        value: "hostpath"
+      #Specify the location (directory) where
+      # where PV(volume) data will be saved. 
+      # A sub-directory with pv-name will be 
+      # created. When the volume is deleted, 
+      # the PV sub-directory will be deleted.
+      #Default value is /var/openebs/local
+      - name: BasePath
+        value: "/var/openebs/local/"
+provisioner: openebs.io/local
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-device
+  annotations:
+    openebs.io/cas-type: local
+    cas.openebs.io/config: |
+      #device type will create a PV by
+      # issuing a BDC and will extract the path
+      # values from the associated BD.
+      - name: StorageType
+        value: "device"
+provisioner: openebs.io/local
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
 ---
 

--- a/versioned/2.12.0/openebs-operator.yaml
+++ b/versioned/2.12.0/openebs-operator.yaml
@@ -195,25 +195,25 @@ spec:
         # This value takes effect only if OPENEBS_IO_CREATE_DEFAULT_STORAGE_CONFIG
         # is set to true
         - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
-          value: "openebs/jiva:2.12.1"
+          value: "openebs/jiva:2.12.2"
         - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
-          value: "openebs/jiva:2.12.1"
+          value: "openebs/jiva:2.12.2"
         - name: OPENEBS_IO_JIVA_REPLICA_COUNT
           value: "3"
         - name: OPENEBS_IO_CSTOR_TARGET_IMAGE
-          value: "openebs/cstor-istgt:2.12.0"
+          value: "openebs/cstor-istgt:2.12.1"
         - name: OPENEBS_IO_CSTOR_POOL_IMAGE
-          value: "openebs/cstor-pool:2.12.0"
+          value: "openebs/cstor-pool:2.12.1"
         - name: OPENEBS_IO_CSTOR_POOL_MGMT_IMAGE
-          value: "openebs/cstor-pool-mgmt:2.12.0"
+          value: "openebs/cstor-pool-mgmt:2.12.1"
         - name: OPENEBS_IO_CSTOR_VOLUME_MGMT_IMAGE
-          value: "openebs/cstor-volume-mgmt:2.12.0"
+          value: "openebs/cstor-volume-mgmt:2.12.1"
         - name: OPENEBS_IO_VOLUME_MONITOR_IMAGE
-          value: "openebs/m-exporter:2.12.0"
+          value: "openebs/m-exporter:2.12.1"
         - name: OPENEBS_IO_CSTOR_POOL_EXPORTER_IMAGE
-          value: "openebs/m-exporter:2.12.0"
+          value: "openebs/m-exporter:2.12.1"
         - name: OPENEBS_IO_HELPER_IMAGE
-          value: "openebs/linux-utils:2.12.0"
+          value: "openebs/linux-utils:2.12.1"
         # OPENEBS_IO_ENABLE_ANALYTICS if set to true sends anonymous usage
         # events to Google Analytics
         - name: OPENEBS_IO_ENABLE_ANALYTICS
@@ -291,7 +291,7 @@ spec:
       containers:
       - name: openebs-provisioner
         imagePullPolicy: IfNotPresent
-        image: openebs/openebs-k8s-provisioner:2.12.0
+        image: openebs/openebs-k8s-provisioner:2.12.1
         env:
         # OPENEBS_IO_K8S_MASTER enables openebs provisioner to connect to K8s
         # based on this address. This is ignored if empty.
@@ -368,7 +368,7 @@ spec:
       serviceAccountName: openebs-maya-operator
       containers:
         - name: snapshot-controller
-          image: openebs/snapshot-controller:2.12.0
+          image: openebs/snapshot-controller:2.12.1
           imagePullPolicy: IfNotPresent
           env:
           - name: OPENEBS_NAMESPACE
@@ -396,7 +396,7 @@ spec:
         #- name: OPENEBS_MAYA_SERVICE_NAME
         #  value: "maya-apiserver-apiservice"
         - name: snapshot-provisioner
-          image: openebs/snapshot-provisioner:2.12.0
+          image: openebs/snapshot-provisioner:2.12.1
           imagePullPolicy: IfNotPresent
           env:
           - name: OPENEBS_NAMESPACE
@@ -1028,7 +1028,7 @@ spec:
             - name: OPERATOR_NAME
               value: "node-disk-operator"
             - name: CLEANUP_JOB_IMAGE
-              value: "openebs/linux-utils:2.12.0"
+              value: "openebs/linux-utils:2.12.1"
             # OPENEBS_IO_IMAGE_PULL_SECRETS environment variable is used to pass the image pull secrets
             # to the cleanup pod launched by NDM operator
             #- name: OPENEBS_IO_IMAGE_PULL_SECRETS
@@ -1073,7 +1073,7 @@ spec:
       serviceAccountName: openebs-maya-operator
       containers:
         - name: admission-webhook
-          image: openebs/admission-server:2.12.0
+          image: openebs/admission-server:2.12.1
           imagePullPolicy: IfNotPresent
           args:
             - -alsologtostderr
@@ -1131,7 +1131,7 @@ spec:
       containers:
       - name: openebs-provisioner-hostpath
         imagePullPolicy: IfNotPresent
-        image: openebs/provisioner-localpv:2.12.0
+        image: openebs/provisioner-localpv:2.12.1
         args:
           - "--bd-time-out=$(BDC_BD_BIND_RETRIES)"
         env:
@@ -1170,7 +1170,7 @@ spec:
         - name: OPENEBS_IO_INSTALLER_TYPE
           value: "openebs-operator"
         - name: OPENEBS_IO_HELPER_IMAGE
-          value: "openebs/linux-utils:2.12.0"
+          value: "openebs/linux-utils:2.12.1"
         - name: OPENEBS_IO_BASE_PATH
           value: "/var/openebs/local"
         # LEADER_ELECTION_ENABLED is used to enable/disable leader election. By default
@@ -1236,4 +1236,3 @@ provisioner: openebs.io/local
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete
 ---
-

--- a/versioned/2.12.0/openebs-operator.yaml
+++ b/versioned/2.12.0/openebs-operator.yaml
@@ -1,22 +1,17 @@
-#
-#                             DEPRECATION NOTICE
-#    This operator file is deprecated in 2.12.0 in favour of individual operators
-#       for each storage engine and the file will be removed in version 3.0.0
-#
-# Further specific components can be deploy using there individual operator yamls
-#
-# To deploy cStor:
-# https://github.com/openebs/charts/blob/gh-pages/cstor-operator.yaml
-#
-# To deploy Jiva:
-# https://github.com/openebs/charts/blob/gh-pages/jiva-operator.yaml
-#
-# To deploy Dynamic hostpath localpv provisioner:
-# https://github.com/openebs/charts/blob/gh-pages/hostpath-operator.yaml
-#
-#
 # This manifest deploys the OpenEBS control plane components, with associated CRs & RBAC rules
 # NOTE: On GKE, deploy the openebs-operator.yaml in admin context
+#
+# NOTE: The Jiva and cStor components included in the Operator File will be deprecated 
+#  with 3.0 in favor of the following cStor and Jiva CSI operators. To upgrade your Jiva
+#  and cStor volumes to CSI, please checkout the documentation at:
+#  https://github.com/openebs/upgrade
+#
+# To deploy cStor CSI:
+# kubectl apply -f https://openebs.github.io/charts/cstor-operator.yaml
+#
+# To deploy Jiva CSI:
+# kubectl apply -f https://openebs.github.io/charts/jiva-operator.yaml
+#
 
 # Create the OpenEBS namespace
 apiVersion: v1
@@ -102,7 +97,7 @@ metadata:
   labels:
     name: maya-apiserver
     openebs.io/component-name: maya-apiserver
-    openebs.io/version: 2.12.0
+    openebs.io/version: 2.12.1
 spec:
   selector:
     matchLabels:
@@ -117,13 +112,13 @@ spec:
       labels:
         name: maya-apiserver
         openebs.io/component-name: maya-apiserver
-        openebs.io/version: 2.12.0
+        openebs.io/version: 2.12.1
     spec:
       serviceAccountName: openebs-maya-operator
       containers:
       - name: maya-apiserver
         imagePullPolicy: IfNotPresent
-        image: openebs/m-apiserver:2.12.0
+        image: openebs/m-apiserver:2.12.1
         ports:
         - containerPort: 5656
         env:
@@ -199,8 +194,6 @@ spec:
         # The default path used is /var/openebs/local
         # This value takes effect only if OPENEBS_IO_CREATE_DEFAULT_STORAGE_CONFIG
         # is set to true
-        #- name: OPENEBS_IO_LOCALPV_HOSTPATH_DIR
-        #  value: "/var/openebs/local"
         - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
           value: "openebs/jiva:2.12.1"
         - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
@@ -277,7 +270,7 @@ metadata:
   labels:
     name: openebs-provisioner
     openebs.io/component-name: openebs-provisioner
-    openebs.io/version: 2.12.0
+    openebs.io/version: 2.12.1
 spec:
   selector:
     matchLabels:
@@ -292,7 +285,7 @@ spec:
       labels:
         name: openebs-provisioner
         openebs.io/component-name: openebs-provisioner
-        openebs.io/version: 2.12.0
+        openebs.io/version: 2.12.1
     spec:
       serviceAccountName: openebs-maya-operator
       containers:
@@ -356,7 +349,7 @@ metadata:
   labels:
     name: openebs-snapshot-operator
     openebs.io/component-name: openebs-snapshot-operator
-    openebs.io/version: 2.12.0
+    openebs.io/version: 2.12.1
 spec:
   selector:
     matchLabels:
@@ -370,7 +363,7 @@ spec:
       labels:
         name: openebs-snapshot-operator
         openebs.io/component-name: openebs-snapshot-operator
-        openebs.io/version: 2.12.0
+        openebs.io/version: 2.12.1
     spec:
       serviceAccountName: openebs-maya-operator
       containers:
@@ -867,7 +860,7 @@ metadata:
   labels:
     name: openebs-ndm
     openebs.io/component-name: ndm
-    openebs.io/version: 2.12.0
+    openebs.io/version: 2.12.1
 spec:
   selector:
     matchLabels:
@@ -880,7 +873,7 @@ spec:
       labels:
         name: openebs-ndm
         openebs.io/component-name: ndm
-        openebs.io/version: 2.12.0
+        openebs.io/version: 2.12.1
     spec:
       # By default the node-disk-manager will be run on all kubernetes nodes
       # If you would like to limit this to only some nodes, say the nodes
@@ -997,7 +990,7 @@ metadata:
   labels:
     name: openebs-ndm-operator
     openebs.io/component-name: ndm-operator
-    openebs.io/version: 2.12.0
+    openebs.io/version: 2.12.1
 spec:
   selector:
     matchLabels:
@@ -1011,7 +1004,7 @@ spec:
       labels:
         name: openebs-ndm-operator
         openebs.io/component-name: ndm-operator
-        openebs.io/version: 2.12.0
+        openebs.io/version: 2.12.1
     spec:
       serviceAccountName: openebs-maya-operator
       containers:
@@ -1061,7 +1054,7 @@ metadata:
   labels:
     app: admission-webhook
     openebs.io/component-name: admission-webhook
-    openebs.io/version: 2.12.0
+    openebs.io/version: 2.12.1
 spec:
   replicas: 1
   strategy:
@@ -1075,7 +1068,7 @@ spec:
       labels:
         app: admission-webhook
         openebs.io/component-name: admission-webhook
-        openebs.io/version: 2.12.0
+        openebs.io/version: 2.12.1
     spec:
       serviceAccountName: openebs-maya-operator
       containers:
@@ -1118,7 +1111,7 @@ metadata:
   labels:
     name: openebs-localpv-provisioner
     openebs.io/component-name: openebs-localpv-provisioner
-    openebs.io/version: 2.12.0
+    openebs.io/version: 2.12.1
 spec:
   selector:
     matchLabels:
@@ -1132,7 +1125,7 @@ spec:
       labels:
         name: openebs-localpv-provisioner
         openebs.io/component-name: openebs-localpv-provisioner
-        openebs.io/version: 2.12.0
+        openebs.io/version: 2.12.1
     spec:
       serviceAccountName: openebs-maya-operator
       containers:
@@ -1202,5 +1195,45 @@ spec:
             - test `pgrep -c "^provisioner-loc.*"` = 1
           initialDelaySeconds: 30
           periodSeconds: 60
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-hostpath
+  annotations:
+    openebs.io/cas-type: local
+    cas.openebs.io/config: |
+      #hostpath type will create a PV by 
+      # creating a sub-directory under the
+      # BASEPATH provided below.
+      - name: StorageType
+        value: "hostpath"
+      #Specify the location (directory) where
+      # where PV(volume) data will be saved. 
+      # A sub-directory with pv-name will be 
+      # created. When the volume is deleted, 
+      # the PV sub-directory will be deleted.
+      #Default value is /var/openebs/local
+      - name: BasePath
+        value: "/var/openebs/local/"
+provisioner: openebs.io/local
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-device
+  annotations:
+    openebs.io/cas-type: local
+    cas.openebs.io/config: |
+      #device type will create a PV by
+      # issuing a BDC and will extract the path
+      # values from the associated BD.
+      - name: StorageType
+        value: "device"
+provisioner: openebs.io/local
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
 ---
 


### PR DESCRIPTION
Signed-off-by: Niladri Halder <niladri.halder@mayadata.io>

2.12.1 maya-apiserver image no longer creates LocalPV storageclasses.
This PR uses 2.12.1 maya-apiserver. Creates LocalPV storageClasses openebs-hostpath and openebs-device using YAMLs.

Bumped 2.12.0 to 2.12.1 in openebs.io/version labels throughout.

---------------------
Bumped all image tag (except openebs/jiva) to 2.12.1
Bumped openebs/jiva image tag to 2.12.2.

This depends on openebs/maya#1816
Ref: https://github.com/openebs/dynamic-localpv-provisioner/issues/90