### PR TITLE
refact(charts): update jiva operator to 2.12.2

### DIFF
--- a/jiva-operator.yaml
+++ b/jiva-operator.yaml
@@ -38,12 +38,6 @@ spec:
           spec:
             description: JivaVolumePolicySpec defines the desired state of JivaVolumePolicy
             properties:
-              autoScaling:
-                description: AutoScaling ...
-                type: boolean
-              enableBufio:
-                description: EnableBufio ...
-                type: boolean
               priorityClassName:
                 description: PriorityClassName if specified applies to the pod If
                   left empty, no priority class is applied.
@@ -1401,8 +1395,9 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                         type: object
                     type: object
-                  monitor:
-                    description: Monitor enables or disables the target exporter sidecar
+                  disableMonitor:
+                    description: DisableMonitor will not attach prometheus exporter
+                      sidecar to jiva volume target.
                     type: boolean
                   nodeSelector:
                     additionalProperties:
@@ -1483,9 +1478,6 @@ spec:
                       type: object
                     type: array
                 type: object
-            required:
-            - autoScaling
-            - enableBufio
             type: object
           status:
             description: JivaVolumePolicyStatus is for handling status of JivaVolumePolicy
@@ -1594,12 +1586,6 @@ spec:
                   and replica pods during volume provisioning
                 nullable: true
                 properties:
-                  autoScaling:
-                    description: AutoScaling ...
-                    type: boolean
-                  enableBufio:
-                    description: EnableBufio ...
-                    type: boolean
                   priorityClassName:
                     description: PriorityClassName if specified applies to the pod
                       If left empty, no priority class is applied.
@@ -3008,9 +2994,9 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                             type: object
                         type: object
-                      monitor:
-                        description: Monitor enables or disables the target exporter
-                          sidecar
+                      disableMonitor:
+                        description: DisableMonitor will not attach prometheus exporter
+                          sidecar to jiva volume target.
                         type: boolean
                       nodeSelector:
                         additionalProperties:
@@ -3093,9 +3079,6 @@ spec:
                           type: object
                         type: array
                     type: object
-                required:
-                - autoScaling
-                - enableBufio
                 type: object
               pv:
                 type: string
@@ -3531,7 +3514,7 @@ metadata:
   namespace: openebs
   labels:
     openebs.io/component-name: jiva-operator
-    openebs.io/version: 2.12.1
+    openebs.io/version: 2.12.2
     name: jiva-operator
 spec:
   replicas: 1
@@ -3543,13 +3526,13 @@ spec:
       labels:
         name: jiva-operator
         openebs.io/component-name: jiva-operator
-        openebs.io/version: 2.12.1
+        openebs.io/version: 2.12.2
     spec:
       serviceAccountName: jiva-operator
       containers:
         - name: jiva-operator
           # Replace this with the built image name
-          image: openebs/jiva-operator:2.12.1
+          image: openebs/jiva-operator:2.12.2
           command:
           - jiva-operator
           imagePullPolicy: IfNotPresent
@@ -3569,9 +3552,9 @@ spec:
             - name: OPERATOR_NAME
               value: "jiva-operator"
             - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
-              value: "openebs/jiva:2.12.1"
+              value: "openebs/jiva:2.12.2"
             - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
-              value: "openebs/jiva:2.12.1"
+              value: "openebs/jiva:2.12.2"
           livenessProbe:
             httpGet:
               path: /healthz
@@ -3672,7 +3655,7 @@ metadata:
   labels:
     name: openebs-jiva-csi-controller
     openebs.io/component-name: openebs-jiva-csi-controller
-    openebs.io/version: 2.12.1
+    openebs.io/version: 2.12.2
 spec:
   selector:
     matchLabels:
@@ -3689,7 +3672,7 @@ spec:
         role: openebs-jiva-csi
         name: openebs-jiva-csi-controller
         openebs.io/component-name: openebs-jiva-csi-controller
-        openebs.io/version: 2.12.1
+        openebs.io/version: 2.12.2
     spec:
       priorityClassName: system-cluster-critical
       serviceAccount: openebs-jiva-csi-controller-sa
@@ -3726,7 +3709,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: jiva-csi-plugin
-          image: openebs/jiva-csi:2.12.1
+          image: openebs/jiva-csi:2.12.2
           env:
             - name: OPENEBS_JIVA_CSI_CONTROLLER
               value: controller
@@ -3900,7 +3883,7 @@ metadata:
     app: openebs-jiva-csi-node
     name: openebs-jiva-csi-node
     openebs.io/component-name: openebs-jiva-csi-node
-    openebs.io/version: 2.12.1
+    openebs.io/version: 2.12.2
 spec:
   selector:
     matchLabels:
@@ -3915,7 +3898,7 @@ spec:
         role: openebs-jiva-csi
         name: openebs-jiva-csi-node
         openebs.io/component-name: openebs-jiva-csi-node
-        openebs.io/version: 2.12.1
+        openebs.io/version: 2.12.2
     spec:
       priorityClassName: system-node-critical
       serviceAccount: openebs-jiva-csi-node-sa
@@ -3951,7 +3934,7 @@ spec:
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
-          image: openebs/jiva-csi:2.12.1
+          image: openebs/jiva-csi:2.12.2
           args:
             - "--name=jiva.csi.openebs.io"
             - "--nodeid=$(OPENEBS_NODE_ID)"

--- a/versioned/2.12.0/jiva-operator.yaml
+++ b/versioned/2.12.0/jiva-operator.yaml
@@ -38,12 +38,6 @@ spec:
           spec:
             description: JivaVolumePolicySpec defines the desired state of JivaVolumePolicy
             properties:
-              autoScaling:
-                description: AutoScaling ...
-                type: boolean
-              enableBufio:
-                description: EnableBufio ...
-                type: boolean
               priorityClassName:
                 description: PriorityClassName if specified applies to the pod If
                   left empty, no priority class is applied.
@@ -1401,8 +1395,9 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                         type: object
                     type: object
-                  monitor:
-                    description: Monitor enables or disables the target exporter sidecar
+                  disableMonitor:
+                    description: DisableMonitor will not attach prometheus exporter
+                      sidecar to jiva volume target.
                     type: boolean
                   nodeSelector:
                     additionalProperties:
@@ -1483,9 +1478,6 @@ spec:
                       type: object
                     type: array
                 type: object
-            required:
-            - autoScaling
-            - enableBufio
             type: object
           status:
             description: JivaVolumePolicyStatus is for handling status of JivaVolumePolicy
@@ -1594,12 +1586,6 @@ spec:
                   and replica pods during volume provisioning
                 nullable: true
                 properties:
-                  autoScaling:
-                    description: AutoScaling ...
-                    type: boolean
-                  enableBufio:
-                    description: EnableBufio ...
-                    type: boolean
                   priorityClassName:
                     description: PriorityClassName if specified applies to the pod
                       If left empty, no priority class is applied.
@@ -3008,9 +2994,9 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                             type: object
                         type: object
-                      monitor:
-                        description: Monitor enables or disables the target exporter
-                          sidecar
+                      disableMonitor:
+                        description: DisableMonitor will not attach prometheus exporter
+                          sidecar to jiva volume target.
                         type: boolean
                       nodeSelector:
                         additionalProperties:
@@ -3093,9 +3079,6 @@ spec:
                           type: object
                         type: array
                     type: object
-                required:
-                - autoScaling
-                - enableBufio
                 type: object
               pv:
                 type: string
@@ -3531,7 +3514,7 @@ metadata:
   namespace: openebs
   labels:
     openebs.io/component-name: jiva-operator
-    openebs.io/version: 2.12.1
+    openebs.io/version: 2.12.2
     name: jiva-operator
 spec:
   replicas: 1
@@ -3543,13 +3526,13 @@ spec:
       labels:
         name: jiva-operator
         openebs.io/component-name: jiva-operator
-        openebs.io/version: 2.12.1
+        openebs.io/version: 2.12.2
     spec:
       serviceAccountName: jiva-operator
       containers:
         - name: jiva-operator
           # Replace this with the built image name
-          image: openebs/jiva-operator:2.12.1
+          image: openebs/jiva-operator:2.12.2
           command:
           - jiva-operator
           imagePullPolicy: IfNotPresent
@@ -3569,9 +3552,9 @@ spec:
             - name: OPERATOR_NAME
               value: "jiva-operator"
             - name: OPENEBS_IO_JIVA_CONTROLLER_IMAGE
-              value: "openebs/jiva:2.12.1"
+              value: "openebs/jiva:2.12.2"
             - name: OPENEBS_IO_JIVA_REPLICA_IMAGE
-              value: "openebs/jiva:2.12.1"
+              value: "openebs/jiva:2.12.2"
           livenessProbe:
             httpGet:
               path: /healthz
@@ -3672,7 +3655,7 @@ metadata:
   labels:
     name: openebs-jiva-csi-controller
     openebs.io/component-name: openebs-jiva-csi-controller
-    openebs.io/version: 2.12.1
+    openebs.io/version: 2.12.2
 spec:
   selector:
     matchLabels:
@@ -3689,7 +3672,7 @@ spec:
         role: openebs-jiva-csi
         name: openebs-jiva-csi-controller
         openebs.io/component-name: openebs-jiva-csi-controller
-        openebs.io/version: 2.12.1
+        openebs.io/version: 2.12.2
     spec:
       priorityClassName: system-cluster-critical
       serviceAccount: openebs-jiva-csi-controller-sa
@@ -3726,7 +3709,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: jiva-csi-plugin
-          image: openebs/jiva-csi:2.12.1
+          image: openebs/jiva-csi:2.12.2
           env:
             - name: OPENEBS_JIVA_CSI_CONTROLLER
               value: controller
@@ -3900,7 +3883,7 @@ metadata:
     app: openebs-jiva-csi-node
     name: openebs-jiva-csi-node
     openebs.io/component-name: openebs-jiva-csi-node
-    openebs.io/version: 2.12.1
+    openebs.io/version: 2.12.2
 spec:
   selector:
     matchLabels:
@@ -3915,7 +3898,7 @@ spec:
         role: openebs-jiva-csi
         name: openebs-jiva-csi-node
         openebs.io/component-name: openebs-jiva-csi-node
-        openebs.io/version: 2.12.1
+        openebs.io/version: 2.12.2
     spec:
       priorityClassName: system-node-critical
       serviceAccount: openebs-jiva-csi-node-sa
@@ -3951,7 +3934,7 @@ spec:
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
-          image: openebs/jiva-csi:2.12.1
+          image: openebs/jiva-csi:2.12.2
           args:
             - "--name=jiva.csi.openebs.io"
             - "--nodeid=$(OPENEBS_NODE_ID)"


### PR DESCRIPTION
This PR updates the CRDs and images for jiva-operator to 2.12.2

Signed-off-by: shubham <shubham.bajpai@mayadata.io>

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/openebs]`)
