### PR TITLE
chore(chart): fix typo in go-template for hostpath-class.yaml and device-class.yaml

### DIFF
--- a/charts/openebs/Chart.yaml
+++ b/charts/openebs/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 2.12.3
+version: 2.12.4
 name: openebs
 appVersion: 2.12.1
 description: Containerized Storage for Containers

--- a/charts/openebs/templates/localprovisioner/device-class.yaml
+++ b/charts/openebs/templates/localprovisioner/device-class.yaml
@@ -1,7 +1,7 @@
-{{- if .Values.localprovisioner.enabled -}}
-{{- $localpvprovisionerValues := index .Values "localpv-provisioner" -}}
-{{- if not $localpvprovisionerValues.enabled -}}
-{{- if .Values.localprovisioner.enableDeviceClass -}}
+{{- if .Values.localprovisioner.enabled }}
+{{- $localpvprovisionerValues := index .Values "localpv-provisioner" }}
+{{- if not $localpvprovisionerValues.enabled }}
+{{- if .Values.localprovisioner.enableDeviceClass }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -14,6 +14,6 @@ metadata:
 provisioner: openebs.io/local
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete
-{{ end }}
-{{ end }}
-{{ end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/openebs/templates/localprovisioner/hostpath-class.yaml
+++ b/charts/openebs/templates/localprovisioner/hostpath-class.yaml
@@ -1,7 +1,7 @@
-{{- if .Values.localprovisioner.enabled -}}
-{{- $localpvprovisionerValues := index .Values "localpv-provisioner" -}}
-{{- if not $localpvprovisionerValues.enabled -}}
-{{- if .Values.localprovisioner.enableHostpathClass -}}
+{{- if .Values.localprovisioner.enabled }}
+{{- $localpvprovisionerValues := index .Values "localpv-provisioner" }}
+{{- if not $localpvprovisionerValues.enabled }}
+{{- if .Values.localprovisioner.enableHostpathClass }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -11,13 +11,13 @@ metadata:
     cas.openebs.io/config: |
       - name: StorageType
         value: "hostpath"
-{{ if .Values.localprovisioner.basePath }}
+{{- if .Values.localprovisioner.basePath }}
       - name: BasePath
         value: {{ .Values.localprovisioner.basePath }}
-{{ end -}}
+{{- end }}
 provisioner: openebs.io/local
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete
-{{ end }}
-{{ end }}
-{{ end }}
+{{- end }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
Signed-off-by: Niladri Halder <niladri.halder@mayadata.io>

Changes in #257 adds an extra newline to openebs-hostpath storageClass.
This one trims the whitespace characters, and removes the newline.