### PR TITLE
fix(docs): update helm instructions and versions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,9 @@
-#### Special notes for your reviewer:
+#### Why is this change required?
+
+#### What is changed?
 
 #### Checklist
 [Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
-- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
+- [ ] [DCO](https://github.com/openebs/charts/blob/HEAD/CONTRIBUTING.md#sign-your-commits) signed
 - [ ] Chart Version bumped
 - [ ] Variables are documented in the README.md
-- [ ] Title of the PR starts with chart name (e.g. `[stable/openebs]`)

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Chart.lock
+charts

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,1 +1,1 @@
-This project follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+This project follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/HEAD/code-of-conduct.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ You can contribute to openebs/charts by filling an issue at [openebs/openebs](ht
 
 * If you want to file an issue for bug or feature request, please see [Filing an issue](#filing-an-issue)
 * If you are a first-time contributor, please see [Steps to Contribute](#steps-to-contribute) and code standard(code-standard.md).
-* If you would like to work on something more involved, please connect with the OpenEBS Contributors. See [OpenEBS Community](https://github.com/openebs/openebs/tree/master/community)
+* If you would like to work on something more involved, please connect with the OpenEBS Contributors. See [OpenEBS Community](https://github.com/openebs/openebs/tree/HEAD/community)
 
 ## Filing an issue
 
@@ -22,15 +22,15 @@ OpenEBS is an Apache 2.0 Licensed project and all your commits should be signed 
 * Find an issue to work on or create a new issue. The issues are maintained at [openebs/openebs](https://github.com/openebs/openebs/issues).
 * Claim your issue by commenting your intent to work on it to avoid duplication of efforts.
 * Fork the repository on GitHub.
-* Create a branch from where you want to base your work (usually master).
-  - If you are updating helm charts, create a branch from master. 
+* Create a branch from where you want to base your work (usually main).
+  - If you are updating helm charts, create a branch from main. 
   - If you are updating an artifact, create a branch from gh-pages.
 * Commit your changes by making sure the commit messages convey the need and notes about the commit.
 * Push your changes to the branch in your fork of the repository.
 * Submit a pull request to the original repository. See [Pull Request checklist](#pull-request-checklist)
 
 ## Pull Request Checklist
-* Rebase to the current master branch before submitting your pull request.
+* Rebase to the current HEAD branch before submitting your pull request.
 * Commits should be as small as possible. Each commit should follow the checklist below:
   - For code changes, add tests relevant to the fixed bug or new feature.
   - Commit header (first line) should convey what changed
@@ -58,18 +58,18 @@ OpenEBS is an Apache 2.0 Licensed project and all your commits should be signed 
     * `style`       - formatting, missing semicolons, linting fix, etc; no significant production code changes
     * `test`        - adding missing tests, refactoring tests; no production code change
     * `refactor`    - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes
-    * `cherry-pick` - if PR is merged in the master branch and raised to release branch(like v1.9.x)
+    * `cherry-pick` - if PR is merged in the HEAD branch and raised to release branch(like v1.9.x)
 
 ## Code Reviews
 All submissions, including submissions by project members, require review. We use GitHub pull requests for this purpose. Consult [GitHub Help](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests) for more information on using pull requests.
 
-* If your PR is not getting reviewed or you need a specific person to review it, please reach out to the OpenEBS Contributors. See [OpenEBS Community](https://github.com/openebs/openebs/tree/master/community)
+* If your PR is not getting reviewed or you need a specific person to review it, please reach out to the OpenEBS Contributors. See [OpenEBS Community](https://github.com/openebs/openebs/tree/HEAD/community)
 
 * If PR is fixing any issues from [github-issues](github.com/openebs/openebs/issues) then you need to mention the issue number with a link in PR description. like: _fixes https://github.com/openebs/openebs/issues/56_
 
 ## Sign your commits
 
-We use the Developer Certificate of Origin (DCO) as an additional safeguard for the OpenEBS projects. This is a well established and widely used mechanism to assure that contributors have confirmed their right to license their contribution under the project's license. Please read [dcofile](https://github.com/openebs/openebs/blob/master/contribute/developer-certificate-of-origin). If you can certify it, then just add a line to every git commit message:
+We use the Developer Certificate of Origin (DCO) as an additional safeguard for the OpenEBS projects. This is a well established and widely used mechanism to assure that contributors have confirmed their right to license their contribution under the project's license. Please read [dcofile](https://github.com/openebs/openebs/blob/HEAD/contribute/developer-certificate-of-origin). If you can certify it, then just add a line to every git commit message:
 
 ````
   Signed-off-by: Random J Developer <random@developer.example.org>

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,2 +1,2 @@
-This is a OpenEBS sub project and abides by the [OpenEBS Project Governance](https://github.com/openebs/openebs/blob/master/GOVERNANCE.md).
+This is a OpenEBS sub project and abides by the [OpenEBS Project Governance](https://github.com/openebs/openebs/blob/HEAD/GOVERNANCE.md).
 

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -10,3 +10,4 @@
 
 #Reviewers
 "Prateek Pandey",@prateekpandey14,MayaData
+"Shovan Maity",@shovanmaity,MayaData

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # OpenEBS Helm Chart and other artifacts
 
-[![Lint and Test Charts](https://github.com/openebs/charts/workflows/Lint%20and%20Test%20Charts/badge.svg?branch=master)](https://github.com/openebs/charts/actions)
+[![Lint and Test Charts](https://github.com/openebs/charts/workflows/Lint%20and%20Test%20Charts/badge.svg?branch=main)](https://github.com/openebs/charts/actions)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fopenebs%2Fcharts.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fopenebs%2Fcharts?ref=badge_shield)
 [![Slack](https://img.shields.io/badge/chat!!!-slack-ff1493.svg?style=flat-square)](https://kubernetes.slack.com/messages/openebs)
 
 
-<img width="200" align="right" alt="OpenEBS Logo" src="https://raw.githubusercontent.com/cncf/artwork/master/projects/openebs/stacked/color/openebs-stacked-color.png" xmlns="http://www.w3.org/1999/html">
+<img width="200" align="right" alt="OpenEBS Logo" src="https://raw.githubusercontent.com/cncf/artwork/HEAD/projects/openebs/stacked/color/openebs-stacked-color.png" xmlns="http://www.w3.org/1999/html">
 
 
 This repository contains OpenEBS Helm charts and other example artifacts like openebs-operator.yaml or example YAMLs. The content in this repository is published using GitHub pages at https://openebs.github.io/charts/. 
@@ -23,14 +23,14 @@ OpenEBS helm chart will includes common components that are used by multiple eng
 - Security Policies like RBAC, PSP, Kyverno 
 
 Engine charts included as dependencies are:
-- [cStor](https://github.com/openebs/cstor-operators/tree/master/deploy/helm/charts)
-- [Jiva](https://github.com/openebs/jiva-operator/tree/master/deploy/helm/charts)
-- [ZFS Local PV](https://github.com/openebs/zfs-localpv/tree/master/deploy/helm/charts)
-- [LVM Local PV](https://github.com/openebs/lvm-localpv/tree/master/deploy/helm/charts)
+- [cStor](https://github.com/openebs/cstor-operators/tree/HEAD/deploy/helm/charts)
+- [Jiva](https://github.com/openebs/jiva-operator/tree/HEAD/deploy/helm/charts)
+- [ZFS Local PV](https://github.com/openebs/zfs-localpv/tree/HEAD/deploy/helm/charts)
+- [LVM Local PV](https://github.com/openebs/lvm-localpv/tree/HEAD/deploy/helm/charts)
 - [Dynamic NFS](https://github.com/openebs/dynamic-nfs-provisioner/tree/develop/deploy/helm/charts)
 
 Some of the other charts that will be included in the upcoming releases are:
-- [Rawfile Local PV](https://github.com/openebs/rawfile-localpv/tree/master/deploy/charts/rawfile-csi)
+- [Rawfile Local PV](https://github.com/openebs/rawfile-localpv/tree/HEAD/deploy/charts/rawfile-csi)
 - [Mayastor](https://github.com/openebs/mayastor/tree/develop/chart)
 - [Dashboard](https://github.com/openebs/monitoring/tree/develop/deploy/charts/openebs-monitoring)
 
@@ -38,7 +38,7 @@ Some of the other charts that will be included in the upcoming releases are:
 
 ### Releasing a new version 
 
-- Raise a PR with the required changes to the master branch. 
+- Raise a PR with the required changes to the HEAD branch. 
 - Tag the [maintainers](./MAINTAINERS) for review
 - Once changes are reviewed and merged, the changes are picked up by [Helm Chart releaser](https://github.com/helm/chart-releaser-action) GitHub Action. The chart releaser will: 
   - Upload the new version of the charts to the [GitHub releases](https://github.com/openebs/charts/releases).
@@ -89,7 +89,7 @@ You can reach the maintainers of this project at:
       * [#openebs-dev](https://kubernetes.slack.com/messages/openebs-dev/)
 - [Mailing List](https://lists.cncf.io/g/cncf-openebs-users)
 
-For more ways of getting involved with community, check our [community page](https://github.com/openebs/openebs/tree/master/community).
+For more ways of getting involved with community, check our [community page](https://github.com/openebs/openebs/tree/HEAD/community).
 
 ### Code of conduct
 

--- a/README.md
+++ b/README.md
@@ -1,41 +1,102 @@
 # OpenEBS Helm Chart and other artifacts
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Lint and Test Charts](https://github.com/openebs/charts/workflows/Lint%20and%20Test%20Charts/badge.svg?branch=master)](https://github.com/openebs/charts/actions)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fopenebs%2Fcharts.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fopenebs%2Fcharts?ref=badge_shield)
+[![Slack](https://img.shields.io/badge/chat!!!-slack-ff1493.svg?style=flat-square)](https://kubernetes.slack.com/messages/openebs)
 
-The content in this repository is published using GitHub pages at https://openebs.github.io/charts/. 
 
-This repository contains OpenEBS Helm charts and other example artifacts like openebs-operator.yaml or example YAMLs. 
+<img width="200" align="right" alt="OpenEBS Logo" src="https://raw.githubusercontent.com/cncf/artwork/master/projects/openebs/stacked/color/openebs-stacked-color.png" xmlns="http://www.w3.org/1999/html">
+
+
+This repository contains OpenEBS Helm charts and other example artifacts like openebs-operator.yaml or example YAMLs. The content in this repository is published using GitHub pages at https://openebs.github.io/charts/. 
 
 ## OpenEBS Helm Chart
 
-The helm chart is located under [./charts/](./charts/) directory. 
+The helm chart is located under [./charts/openebs/](./charts/openebs/) directory. 
 
-When new changes to helm chart are pushed to master branch, the changes are picked up by [Helm Chart releaser](https://github.com/helm/chart-releaser-action) GitHub Action. The chart releaser will: 
-- Upload the new version of the charts to the [GitHub releases](https://github.com/openebs/charts/releases).
-- Update the helm repo index file and push to the [GitHub Pages branch](https://github.com/openebs/charts/tree/gh-pages).
+OpenEBS helm chart is an umbrella chart that pulls together engine specific charts. The engine charts are included as dependencies in [Chart.yaml](charts/openebs/Chart.yaml).
 
-## Mayastor Helm Chart
+OpenEBS helm chart will includes common components that are used by multiple engines like:
+- Node Disk Manager related components
+- Dynamic Local Provisioner related components
+- Security Policies like RBAC, PSP, Kyverno 
 
-Helm chart for Mayastor is currently maintained [along the Mayastor code-base](https://github.com/openebs/Mayastor/tree/develop/chart). Please, note, that it is being actively developed and can change or break without warning.
+Engine charts included as dependencies are:
+- [cStor](https://github.com/openebs/cstor-operators/tree/master/deploy/helm/charts)
+- [Jiva](https://github.com/openebs/jiva-operator/tree/master/deploy/helm/charts)
+- [ZFS Local PV](https://github.com/openebs/zfs-localpv/tree/master/deploy/helm/charts)
+- [LVM Local PV](https://github.com/openebs/lvm-localpv/tree/master/deploy/helm/charts)
+- [Dynamic NFS](https://github.com/openebs/dynamic-nfs-provisioner/tree/develop/deploy/helm/charts)
+
+Some of the other charts that will be included in the upcoming releases are:
+- [Rawfile Local PV](https://github.com/openebs/rawfile-localpv/tree/master/deploy/charts/rawfile-csi)
+- [Mayastor](https://github.com/openebs/mayastor/tree/develop/chart)
+- [Dashboard](https://github.com/openebs/monitoring/tree/develop/deploy/charts/openebs-monitoring)
+
+> **Note:** cStor and Jiva out-of-tree provisioners will be replaced by respective CSI charts listed above. OpenEBS users are expected to install the cstor and jiva CSI components and migrate the pools and volumes. The steps to migate are available at: https://github.com/openebs/upgrade
+
+### Releasing a new version 
+
+- Raise a PR with the required changes to the master branch. 
+- Tag the [maintainers](./MAINTAINERS) for review
+- Once changes are reviewed and merged, the changes are picked up by [Helm Chart releaser](https://github.com/helm/chart-releaser-action) GitHub Action. The chart releaser will: 
+  - Upload the new version of the charts to the [GitHub releases](https://github.com/openebs/charts/releases).
+  - Update the helm repo index file and push to the [GitHub Pages branch](https://github.com/openebs/charts/tree/gh-pages).
+
 
 ## OpenEBS Artifacts
 
+The artifacts are located in the [GitHub Pages(gh-pages) branch](https://github.com/openebs/charts/tree/gh-pages).
+
+The files can be accessed either as github rawfile or as hosted files. Example, openebs operator can be used as follows:
+- As github raw file URL:
+  ```
+  kubectl apply -f https://raw.githubusercontent.com/openebs/charts/gh-pages/openebs-operator.yaml
+  ```
+- As hosted URL:
+  ```
+  kubectl apply -f https://openebs.github.io/charts/openebs-operator.yaml
+  ```
+
 This is a collection of YAMLs or scripts that help to perform some OpenEBS tasks like:
 - YAML file to setup OpenEBS via kubectl.
+  - [OpenEBS Commons Operator](https://github.com/openebs/charts/blob/gh-pages/openebs-operator.yaml)
+  - [OpenEBS cStor](https://github.com/openebs/charts/blob/gh-pages/cstor-operator.yaml)
+  - [OpenEBS Jiva](https://github.com/openebs/charts/blob/gh-pages/jiva-operator.yaml)
+  - [OpenEBS Hostpath](https://github.com/openebs/charts/blob/gh-pages/hostpath-operator.yaml) 
+  - [OpenEBS Hostpath and Device](https://github.com/openebs/charts/blob/gh-pages/openebs-operator-lite.yaml)
+  - [OpenEBS LVM Local PV](https://github.com/openebs/charts/blob/gh-pages/lvm-operator.yaml)
+  - [OpenEBS ZFS Local PV](https://github.com/openebs/charts/blob/gh-pages/zfs-operator.yaml)
+  - [OpenEBS NFS PV](https://github.com/openebs/charts/blob/gh-pages/nfs-operator.yaml)
+- YAML file to install OpenEBS prerequisties on hosts via nsenter pods via kubectl.
+  - [Setup iSCSI on Ubuntu](https://github.com/openebs/charts/blob/gh-pages/openebs-ubuntu-setup.yaml)
+  - [Setup iSCSI on Amazon Linux](https://github.com/openebs/charts/blob/gh-pages/openebs-amazonlinux-setup.yaml)
 - Scripts to push the OpenEBS container images to a custom registry for air-gapped environments. 
 - and more. 
 
-The artifacts are located in the [GitHub Pages(gh-pages) branch](https://github.com/openebs/charts/tree/gh-pages).
 
 ## Contributing
 
-See [./CONTRIBUTING.md](./CONTRIBUTING.md).
+See [CONTRIBUTING.md](./CONTRIBUTING.md).
+
+## Community, discussion, and support
+
+You can reach the maintainers of this project at:
+
+- [Kubernetes Slack](http://slack.k8s.io/) channels: 
+      * [#openebs](https://kubernetes.slack.com/messages/openebs/)
+      * [#openebs-dev](https://kubernetes.slack.com/messages/openebs-dev/)
+- [Mailing List](https://lists.cncf.io/g/cncf-openebs-users)
+
+For more ways of getting involved with community, check our [community page](https://github.com/openebs/openebs/tree/master/community).
+
+### Code of conduct
+
+Participation in the OpenEBS community is governed by the [CNCF Code of Conduct](./CODE-OF-CONDUCT.md).
+
+
 
 ## License
-
-[Apache 2.0 License](./LICENSE).
-
 
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fopenebs%2Fcharts.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Fopenebs%2Fcharts?ref=badge_large)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ OpenEBS helm chart is an umbrella chart that pulls together engine specific char
 
 OpenEBS helm chart will includes common components that are used by multiple engines like:
 - Node Disk Manager related components
-- Dynamic Local Provisioner related components
+- Dynamic LocalPV (hostpath and device) Provisioner related components
 - Security Policies like RBAC, PSP, Kyverno 
 
 Engine charts included as dependencies are:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,2 +1,2 @@
-This is a OpenEBS sub project and abides by the [OpenEBS Security Policy](https://github.com/openebs/openebs/blob/master/SECURITY.md).
+This is a OpenEBS sub project and abides by the [OpenEBS Security Policy](https://github.com/openebs/openebs/blob/HEAD/SECURITY.md).
 

--- a/charts/openebs/Chart.yaml
+++ b/charts/openebs/Chart.yaml
@@ -1,22 +1,27 @@
 apiVersion: v2
-version: 2.12.7
+version: 2.12.8
 name: openebs
 appVersion: 2.12.1
-description: Containerized Storage for Containers
+description: Containerized Attached Storage for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/openebs/icon/color/openebs-icon-color.png
 home: http://www.openebs.io/
 keywords:
   - cloud-native-storage
   - block-storage
+  - local-storage
   - iSCSI
+  - NVMe
   - storage
+  - kubernetes
 sources:
   - https://github.com/openebs/openebs
 maintainers:
   - name: kmova
-    email: kiran.mova@openebs.io
+    email: kiran.mova@mayadata.io
   - name: prateekpandey14
-    email: prateek.pandey@openebs.io
+    email: prateek.pandey@mayadata.io
+  - name: shovanmaity
+    email: shovan.maity@mayadata.io
 dependencies:
   - name: openebs-ndm
     version: "1.6.1"
@@ -35,11 +40,11 @@ dependencies:
     repository: "https://openebs.github.io/jiva-operator"
     condition: jiva.enabled
   - name: zfs-localpv
-    version: "1.9.5"
+    version: "1.9.8"
     repository: "https://openebs.github.io/zfs-localpv"
     condition: zfs-localpv.enabled
   - name: lvm-localpv
-    version: "0.8.2"
+    version: "0.8.4"
     repository: "https://openebs.github.io/lvm-localpv"
     condition: lvm-localpv.enabled
   - name: nfs-provisioner

--- a/charts/openebs/Chart.yaml
+++ b/charts/openebs/Chart.yaml
@@ -3,7 +3,7 @@ version: 2.12.8
 name: openebs
 appVersion: 2.12.1
 description: Containerized Attached Storage for Kubernetes
-icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/openebs/icon/color/openebs-icon-color.png
+icon: https://raw.githubusercontent.com/cncf/artwork/HEAD/projects/openebs/icon/color/openebs-icon-color.png
 home: http://www.openebs.io/
 keywords:
   - cloud-native-storage

--- a/charts/openebs/README.md
+++ b/charts/openebs/README.md
@@ -1,132 +1,105 @@
 # OpenEBS Helm Chart
 
-[OpenEBS](https://github.com/openebs/openebs) is an *open source storage platform* that provides persistent and containerized block storage for DevOps and container environments. 
-OpenEBS provides multiple storage engines that can be plugged in easily. A common pattern is the use of OpenEBS to deliver Dynamic LocalPV for those applications and workloads that want to access disks and cloud volumes directly.
+[OpenEBS](https://openebs.io) helps Developers and Platform SREs easily deploy Kubernetes Stateful Workloads that require fast and highly reliable container attached storage. OpenEBS can be deployed on any Kubernetes cluster - either in cloud, on-premise (virtual or bare metal) or developer laptop (minikube).
 
-OpenEBS can be deployed on any Kubernetes cluster - either in cloud, on-premise or developer laptop (minikube). OpenEBS itself is deployed as just another container on your cluster, and enables storage services that can be designated on a per pod, application, cluster or container level.
+OpenEBS Data Engines and Control Plane are implemented as micro-services, deployed as containers and orchestrated by Kubernetes itself. An added advantage of being a completely Kubernetes native solution is that administrators and developers can interact and manage OpenEBS using all the wonderful tooling that is available for Kubernetes like kubectl, Helm, Prometheus, Grafana, etc.
 
-## Introduction
+OpenEBS turns any storage available on the Kubernetes worker nodes into local or distributed Kubernetes Persistent Volumes.
+* Local Volumes are accessible only from a single node in the cluster. Pods using Local Volume have to be scheduled on the node where volume is provisioned. Local Volumes are typically preferred for distributed workloads like Cassandra, MongoDB, Elastic, etc that are distributed in nature and have high availability built into them. Depending on the type of storage attached to your Kubernetes worker nodes, you can select from different flavors of Dynamic Local PV - Hostpath, Device, LVM, ZFS or Rawfile.
+* Replicated Volumes as the name suggests, are those that have their data synchronously replicated to multiple nodes. Volumes can sustain node failures. The replication also can be setup across availability zones helping applications move across availability zones. Depending on the type of storage attached to your Kubernetes worker nodes and application performance requirements, you can select from Jiva, cStor or Mayastor.
 
-This chart bootstraps OpenEBS deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+## Documentation and user guides
 
-## Quickstart and documentation
+You can run OpenEBS on any Kubernetes 1.18+ cluster in a matter of minutes. See the [Quickstart Guide to OpenEBS](https://openebs.io/) for detailed instructions.
 
-You can run OpenEBS on any Kubernetes 1.13+ cluster in a matter of seconds. See the [Quickstart Guide to OpenEBS](https://docs.openebs.io/docs/next/quickstart.html) for detailed instructions.
+## Getting started
 
-For more comprehensive documentation, start with the [Welcome to OpenEBS](https://docs.openebs.io/docs/next/overview.html) docs.
+### How to customize OpenEBS Helm chart?
 
-## Prerequisites
+OpenEBS helm chart is an umbrella chart that pulls together engine specific charts. The engine charts are included as dependencies. 
+arts/openebs/Chart.yaml). 
+OpenEBS helm chart will includes common components that are used by multiple engines like:
+- Node Disk Manager related components
+- Dynamic Local Provisioner related components
+- Security Policies like RBAC, PSP, Kyverno 
 
-- Kubernetes 1.13+ with RBAC enabled
-- iSCSI PV support in the underlying infrastructure
+```bash
+openebs
+├── (default) openebs-ndm
+├── (default) localpv-provisioner
+├── jiva
+├── cstor
+├── zfs-localpv
+└── lvm-localpv
+└── nfs-provisioner
+```
 
-## Adding OpenEBS Helm repository
+To install the engine charts, the helm install must be provided with a engine enabled flag like `cstor.enabled=true` or `zfs-localpv.enabled=true` or by passing a custom values.yaml with required engines enabled.
+
+### Prerequisites
+
+- Kubernetes 1.18+ with RBAC enabled
+- When using cstor and jiva engines, iSCSI utils must be installed on all the nodes where stateful pods are going to run. 
+- Depending on the engine and type of platform, you may have to customize the values or run additional pre-requisistes. Refer to [documentation](https://openebs.io).
+
+### Setup Helm Repository
 
 Before installing OpenEBS Helm charts, you need to add the [OpenEBS Helm repository](https://openebs.github.io/charts) to your Helm client.
 
 ```bash
 helm repo add openebs https://openebs.github.io/charts
+helm repo update
 ```
 
-## Update the dependent charts
+### Installing OpenEBS 
 
 ```bash
-helm dependency update
+helm install --name `my-release` --namespace openebs openebs/openebs --create-namespace
 ```
 
-## Installing OpenEBS
+Examples:
+- Assuming the release will be called openebs, the command would be:
+  ```bash
+  helm install --name openebs --namespace openebs openebs/openebs --create-namespace
+  ```
 
-```bash
-helm install --namespace openebs openebs/openebs
-```
+- To install OpenEBS with cStor CSI driver, run
+  ```bash
+  helm install openebs openebs/openebs --namespace openebs --create-namespace --set cstor.enabled=true
+  ```
 
-## Installing OpenEBS with the release name
+- To install/enable a new engine on the installed helm release `openebs`, you can run the helm upgrade command as follows:
+  ```bash
+  helm upgrade openebs openebs/openebs --namespace openebs --reuse-values --set jiva.enabled=true 
+  ```
 
-```bash
-helm install --name `my-release` --namespace openebs openebs/openebs
-```
+- To disable legacy out of tree jiva and cstor provisioners, run the following command.
+  ```bash
+  helm upgrade openebs openebs/openebs --namespace openebs --reuse-values --set legacy.enabled=false 
+  ```
 
-## To uninstall/delete instance with release name
+### To uninstall/delete instance with release name
 
 ```bash
 helm ls --all
 helm delete `my-release`
 ```
 
+> **Tip**: Prior to deleting the helm chart, make sure all the storage volumes and pools are deleted.
+
 ## Configuration
 
-The following table lists the configurable parameters of the OpenEBS chart and their default values.
+The following table lists the common configurable parameters of the OpenEBS chart and their default values. For a full list of configurable parameters check out the [values.yaml](https://github.com/openebs/charts/blob/master/charts/openebs/values.yaml).
 
 | Parameter                               | Description                                   | Default                                   |
 | ----------------------------------------| --------------------------------------------- | ----------------------------------------- |
-| `rbac.create`                           | Enable RBAC Resources                         | `true`                                    |
-| `rbac.pspEnabled`                       | Create pod security policy resources          | `false`                                   |
-| `rbac.kyvernoEnabled`                   | Create Kyverno policy resources               | `false`                                   |
-| `image.pullPolicy`                      | Container pull policy                         | `IfNotPresent`                            |
-| `image.repository`                      | Specify which docker registry to use          | `""`                                      |
 | `apiserver.enabled`                     | Enable API Server                             | `true`                                    |
 | `apiserver.image`                       | Image for API Server                          | `openebs/m-apiserver`                     |
 | `apiserver.imageTag`                    | Image Tag for API Server                      | `2.12.0`                                  |
-| `apiserver.replicas`                    | Number of API Server Replicas                 | `1`                                       |
-| `apiserver.sparse.enabled`              | Create Sparse Pool based on Sparsefile        | `false`                                   |
-| `apiserver.resources`                   | Set resource limits for API Server            | `{}`                                      |
-| `provisioner.enabled`                   | Enable Provisioner                            | `true`                                    |
-| `provisioner.image`                     | Image for Provisioner                         | `openebs/openebs-k8s-provisioner`         |
-| `provisioner.imageTag`                  | Image Tag for Provisioner                     | `2.12.0`                                  |
-| `provisioner.replicas`                  | Number of Provisioner Replicas                | `1`                                       |
-| `provisioner.resources`                 | Set resource limits for Provisioner           | `{}`                                      |
-| `provisioner.patchJivaNodeAffinity`     | Enable/disable node affinity on jiva replica deployment| `enabled`                                 |
-| `localprovisioner.enabled`              | Enable localProvisioner                       | `true`                                    |
-| `localprovisioner.image`                | Image for localProvisioner                    | `openebs/provisioner-localpv`             |
-| `localprovisioner.imageTag`             | Image Tag for localProvisioner                | `2.12.0`                                  |
-| `localprovisioner.replicas`             | Number of localProvisioner Replicas           | `1`                                       |
-| `localprovisioner.basePath`             | BasePath for hostPath volumes on Nodes        | `/var/openebs/local`                      |
-| `localprovisioner.resources`            | Set resource limits for localProvisioner      | `{}`                                      |
-| `localpv.waitForBDBindTimeoutRetryCount`| This sets the number of times the provisioner should try with a polling interval of 5 seconds, to get the Blockdevice Name from a BlockDeviceClaim, before the BlockDeviceClaim is deleted. | "12" |
-| `webhook.enabled`                       | Enable admission server                       | `true`                                    |
-| `webhook.image`                         | Image for admission server                    | `openebs/admission-server`                |
-| `webhook.imageTag`                      | Image Tag for admission server                | `2.12.0`                                  |
-| `webhook.replicas`                      | Number of admission server Replicas           | `1`                                       |
-| `webhook.hostNetwork`                   | Use hostNetwork in admission server           | `false`                                   |
-| `webhook.resources`                     | Set resource limits for admission server      | `{}`                                      |
-| `snapshotOperator.enabled`              | Enable Snapshot Provisioner                   | `true`                                    |
-| `snapshotOperator.provisioner.image`    | Image for Snapshot Provisioner                | `openebs/snapshot-provisioner`            |
-| `snapshotOperator.provisioner.imageTag` | Image Tag for Snapshot Provisioner            | `2.12.0`                                  |
-| `snapshotOperator.controller.image`     | Image for Snapshot Controller                 | `openebs/snapshot-controller`             |
-| `snapshotOperator.controller.imageTag`  | Image Tag for Snapshot Controller             | `2.12.0`                                  |
-| `snapshotOperator.replicas`             | Number of Snapshot Operator Replicas          | `1`                                       |
-| `snapshotOperator.provisioner.resources`| Set resource limits for Snapshot Provisioner  | `{}`                                      |
-| `snapshotOperator.controller.resources` | Set resource limits for Snapshot Controller   | `{}`                                      |
-| `ndm.enabled`                           | Enable Node Disk Manager                      | `true`                                    |
-| `ndm.image`                             | Image for Node Disk Manager                   | `openebs/node-disk-manager`         |
-| `ndm.imageTag`                          | Image Tag for Node Disk Manager               | `1.6.1`                                   |
-| `ndm.sparse.path`                       | Directory where Sparse files are created      | `/var/openebs/sparse`                     |
-| `ndm.sparse.size`                       | Size of the sparse file in bytes              | `10737418240`                             |
-| `ndm.sparse.count`                      | Number of sparse files to be created          | `0`                                       |
-| `ndm.filters.enableOsDiskExcludeFilter` | Enable filters of OS disk exclude             | `true`                                    |
-| `ndm.filters.osDiskExcludePaths`        | Paths/Mountpoints to be excluded by OS Disk Filter| `/,/etc/hosts,/boot`                           |
-| `ndm.filters.enableVendorFilter`        | Enable filters of vendors                     | `true`                                    |
-| `ndm.filters.excludeVendors`            | Exclude devices with specified vendor         | `CLOUDBYT,OpenEBS`                        |
-| `ndm.filters.enablePathFilter`          | Enable filters of paths                       | `true`                                    |
-| `ndm.filters.includePaths`              | Include devices with specified path patterns  | `""`                                      |
-| `ndm.filters.excludePaths`              | Exclude devices with specified path patterns  | `/dev/loop,/dev/fd0,/dev/sr0,/dev/ram,/dev/dm-,/dev/md,/dev/rbd,/dev/zd`|
-| `ndm.probes.enableSeachest`             | Enable Seachest probe for NDM                 | `false`                                   |
-| `ndm.resources`                         | Set resource limits for NDM                   | `{}`                                      |
-| `ndmOperator.enabled`                   | Enable NDM Operator                           | `true`                                    |
-| `ndmOperator.image`                     | Image for NDM Operator                        | `openebs/node-disk-operator`        |
-| `ndmOperator.imageTag`                  | Image Tag for NDM Operator                    | `1.6.1`                                   |
-| `ndmOperator.resources`                 | Set resource limits for NDM Operator          | `{}`                                      |
-| `ndmExporter.enabled`                   | Enable NDM Exporters                          | `false`                                   |
-| `ndmExporter.image.registry`            | Registry for NDM Exporters image              | `""`                                      |
-| `ndmExporter.repository`                | Image repository for NDM Exporters            | `openebs/node-disk-exporter`              |
-| `ndmExporter.pullPolicy`                | Image pull policy for NDM Exporters           | `IfNotPresent`                            |
-| `ndmExporter.tag`                       | Image tag for NDM Exporters                   | `1.6.1`                                   |
-| `ndmExporter.nodeExporter.metricsPort`  | The TCP port number used for exposing NDM node exporter metrics    | `9101`               |
-| `ndmExporter.clusterExporter.metricsPort`   | The TCP port number used for exposing NDM cluster exporter metrics  | `9100`          |
-| `jiva.image`                            | Image for Jiva                                | `openebs/jiva`                            |
-| `jiva.imageTag`                         | Image Tag for Jiva                            | `2.12.1`                                  |
-| `jiva.replicas`                         | Number of Jiva Replicas                       | `3`                                       |
-| `jiva.defaultStoragePath`               | hostpath used by default Jiva StorageClass    | `/var/openebs`                            |
+| `cleanup.image.registry`                | Cleanup pre hook image registry               | `nil`                                     |
+| `cleanup.image.repository`              | Cleanup pre hook image repository             | `"bitnami/kubectl"`                       |
+| `cleanup.image.tag`                     | Cleanup pre hook image tag                    | `if not provided determined by the k8s version`                       |
+| `crd.enableInstall`                     | Enable installation of CRDs by OpenEBS        | `true`                                    |
 | `cstor.pool.image`                      | Image for cStor Pool                          | `openebs/cstor-pool`                      |
 | `cstor.pool.imageTag`                   | Image Tag for cStor Pool                      | `2.12.0`                                  |
 | `cstor.poolMgmt.image`                  | Image for cStor Pool  Management              | `openebs/cstor-pool-mgmt`                 |
@@ -135,125 +108,61 @@ The following table lists the configurable parameters of the OpenEBS chart and t
 | `cstor.target.imageTag`                 | Image Tag for cStor Target                    | `2.12.0`                                  |
 | `cstor.volumeMgmt.image`                | Image for cStor Volume  Management            | `openebs/cstor-volume-mgmt`               |
 | `cstor.volumeMgmt.imageTag`             | Image Tag for cStor Volume Management         | `2.12.0`                                  |
-| `helper.image`                          | Image for helper                              | `openebs/linux-utils`                     |
-| `helper.imageTag`                       | Image Tag for helper                          | `2.12.0`                                  |
-| `featureGates.enabled`                  | Enable feature gates for OpenEBS              | `true`                                   |
-| `featureGates.APIService.enabled`       | Enable APIService in NDM                      | `false`                                  |
-| `featureGates.UseOSDisk.enabled`        | Enable using unused partitions on OS Disk     | `false`                                  |
-| `featureGates.MountChangeDetection.enabled` | Enable feature-gate to detect mountpoint/filesystem changes | `false`                                   |
-| `crd.enableInstall`                     | Enable installation of CRDs by OpenEBS        | `true`                                    |
-| `policies.monitoring.image`             | Image for Prometheus Exporter                 | `openebs/m-exporter`                      |
-| `policies.monitoring.imageTag`          | Image Tag for Prometheus Exporter             | `2.12.0`                                  |
-| `analytics.enabled`                     | Enable sending stats to Google Analytics      | `true`                                    |
-| `analytics.pingInterval`                | Duration(hours) between sending ping stat     | `24h`                                     |
 | `defaultStorageConfig.enabled`          | Enable default storage class installation     | `true`                                    |
-| `varDirectoryPath.baseDir`              | To store debug info of OpenEBS containers     | `/var/openebs`                            |
 | `healthCheck.initialDelaySeconds`       | Delay before liveness probe is initiated      | `30`                                      |
 | `healthCheck.periodSeconds`             | How often to perform the liveness probe       | `60`                                      |
-| `cleanup.image.registry`                | Cleanup pre hook image registry               | `nil`                                     |
-| `cleanup.image.repository`              | Cleanup pre hook image repository             | `"bitnami/kubectl"`                       |
-| `cleanup.image.tag`                     | Cleanup pre hook image tag             | `if not provided determined by the k8s version`                       |
+| `helper.image`                          | Image for helper                              | `openebs/linux-utils`                     |
+| `helper.imageTag`                       | Image Tag for helper                          | `2.12.0`                                  |
+| `image.pullPolicy`                      | Container pull policy                         | `IfNotPresent`                            |
+| `image.repository`                      | Specify which docker registry to use          | `""`                                      |
+| `jiva.defaultStoragePath`               | hostpath used by default Jiva StorageClass    | `/var/openebs`                            |
+| `jiva.image`                            | Image for Jiva                                | `openebs/jiva`                            |
+| `jiva.imageTag`                         | Image Tag for Jiva                            | `2.12.1`                                  |
+| `jiva.replicas`                         | Number of Jiva Replicas                       | `3`                                       |
+| `localprovisioner.basePath`             | BasePath for hostPath volumes on Nodes        | `/var/openebs/local`                      |
+| `localprovisioner.enabled`              | Enable localProvisioner                       | `true`                                    |
+| `localprovisioner.image`                | Image for localProvisioner                    | `openebs/provisioner-localpv`             |
+| `localprovisioner.imageTag`             | Image Tag for localProvisioner                | `2.12.0`                                  |
+| `ndm.enabled`                           | Enable Node Disk Manager                      | `true`                                    |
+| `ndm.filters.enableOsDiskExcludeFilter` | Enable filters of OS disk exclude             | `true`                                    |
+| `ndm.filters.enablePathFilter`          | Enable filters of paths                       | `true`                                    |
+| `ndm.filters.enableVendorFilter`        | Enable filters of vendors                     | `true`                                    |
+| `ndm.filters.excludePaths`              | Exclude devices with specified path patterns  | `/dev/loop,/dev/fd0,/dev/sr0,/dev/ram,/dev/dm-,/dev/md,/dev/rbd,/dev/zd`|
+| `ndm.filters.excludeVendors`            | Exclude devices with specified vendor         | `CLOUDBYT,OpenEBS`                        |
+| `ndm.filters.includePaths`              | Include devices with specified path patterns  | `""`                                      |
+| `ndm.filters.osDiskExcludePaths`        | Paths/Mounts to be excluded by OS Disk Filter | `/,/etc/hosts,/boot`                      |
+| `ndm.image`                             | Image for Node Disk Manager                   | `openebs/node-disk-manager`               |
+| `ndm.imageTag`                          | Image Tag for Node Disk Manager               | `1.6.1`                                   |
+| `ndmOperator.enabled`                   | Enable NDM Operator                           | `true`                                    |
+| `ndmOperator.image`                     | Image for NDM Operator                        | `openebs/node-disk-operator`              |
+| `ndmOperator.imageTag`                  | Image Tag for NDM Operator                    | `1.6.1`                                   |
+| `ndm.probes.enableSeachest`             | Enable Seachest probe for NDM                 | `false`                                   |
+| `policies.monitoring.image`             | Image for Prometheus Exporter                 | `openebs/m-exporter`                      |
+| `policies.monitoring.imageTag`          | Image Tag for Prometheus Exporter             | `2.12.0`                                  |
+| `provisioner.enabled`                   | Enable Provisioner                            | `true`                                    |
+| `provisioner.image`                     | Image for Provisioner                         | `openebs/openebs-k8s-provisioner`         |
+| `provisioner.imageTag`                  | Image Tag for Provisioner                     | `2.12.0`                                  |
+| `rbac.create`                           | Enable RBAC Resources                         | `true`                                    |
+| `rbac.kyvernoEnabled`                   | Create Kyverno policy resources               | `false`                                   |
+| `rbac.pspEnabled`                       | Create pod security policy resources          | `false`                                   |
+| `snapshotOperator.controller.image`     | Image for Snapshot Controller                 | `openebs/snapshot-controller`             |
+| `snapshotOperator.controller.imageTag`  | Image Tag for Snapshot Controller             | `2.12.0`                                  |
+| `snapshotOperator.enabled`              | Enable Snapshot Provisioner                   | `true`                                    |
+| `snapshotOperator.provisioner.image`    | Image for Snapshot Provisioner                | `openebs/snapshot-provisioner`            |
+| `snapshotOperator.provisioner.imageTag` | Image Tag for Snapshot Provisioner            | `2.12.0`                                  |
+| `varDirectoryPath.baseDir`              | To store debug info of OpenEBS containers     | `/var/openebs`                            |
+| `webhook.enabled`                       | Enable admission server                       | `true`                                    |
+| `webhook.hostNetwork`                   | Use hostNetwork in admission server           | `false`                                   |
+| `webhook.image`                         | Image for admission server                    | `openebs/admission-server`                |
+| `webhook.imageTag`                      | Image Tag for admission server                | `2.12.0`                                  |
+
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash
-helm install --name openebs -f values.yaml openebs/openebs
+helm install --name `my-release` -f values.yaml --namespace openebs openebs/openebs --create-namespace
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
 
-## Below charts are dependent charts of this chart
--  [openebs-ndm](https://openebs.github.io/node-disk-manager)
--  [localpv-provisioner](https://openebs.github.io/dynamic-localpv-provisioner)
--  [cstor](https://openebs.github.io/cstor-operators)
--  [jiva](https://openebs.github.io/jiva-operator)
--  [zfs-localpv](https://openebs.github.io/zfs-localpv)
--  [lvm-localpv](https://openebs.github.io/lvm-localpv)
--  [nfs](https://openebs.github.io/dynamic-nfs-provisioner)
-
-## Dependency tree of this chart
-```bash
-openebs
-├── openebs-ndm
-├── localpv-provisioner
-│   └── openebs-ndm (optional)
-├── jiva
-│   └── localpv-provisioner
-│       └── openebs-ndm (optional)
-├── cstor
-│   └── openebs-ndm
-├── zfs-localpv
-└── lvm-localpv
-└── nfs-provisioner
-
-```
-
-#### (Default) Install Jiva, cStor and Local PV with out-of-tree provisioners
-```bash
-helm install openebs openebs/openebs --namespace openebs --create-namespace
-```
-
-#### Install cStor with CSI driver
-```bash
-helm install openebs openebs/openebs --namespace openebs --create-namespace \
---set legacy.enabled=false \
---set cstor.enabled=true \
---set openebs-ndm.enabled=true
-```
-
-#### Install Jiva with CSI driver
-```bash
-helm install openebs openebs/openebs --namespace openebs --create-namespace \
---set legacy.enabled=false \
---set jiva.enabled=true \
---set openebs-ndm.enabled=true \
---set localpv-provisioner.enabled=true
-```
-
-#### Install ZFS Local PV
-```bash
-helm install openebs openebs/openebs --namespace openebs --create-namespace \
---set legacy.enabled=false \
---set zfs-localpv.enabled=true
-```
-
-#### Install LVM Local PV
-```bash
-helm install openebs openebs/openebs --namespace openebs --create-namespace \
---set legacy.enabled=false \
---set lvm-localpv.enabled=true
-```
-
-#### Install Local PV hostpath and device
-```bash
-helm install openebs openebs/openebs --namespace openebs --create-namespace \
---set legacy.enabled=false \
---set localpv-provisioner.enabled=true
---set openebs-ndm.enabled=true \
-```
-
-#### Install NFS Provisioner
-```bash
-helm install openebs openebs/openebs --namespace openebs --create-namespace \
---set legacy.enabled=false \
---set nfs-provisioner.enabled=true
-```
-
-
-> **Tip**: You can install multiple csi driver by merging the configuration.
-
-## Kyverno Policy Integration
-
-PodSecurityPolicy(PSP) is being deprecated in Kubernetes 1.21 and will be removed in v1.25. So, the suitable alternative is Kyverno.
-Kyverno is an open-source policy engine built specifically for Kubernetes to not only validate and ensure requests comply with your
-internal best practices and policies.
-
-
-As part of kyverno integration, some required policies have been added as a helm template in openebs charts, installation disable by default and can be enabled using a flag. But before enabling that [Kyverno](https://kyverno.io/docs/installation/) should be installed in your Kubernetes cluster using 
-[Helm](https://kyverno.io/docs/installation/#install-kyverno-using-helm) or [YAMLs](https://kyverno.io/docs/installation/#install-kyverno-using-yamls).
-
-Check the default kyverno policies in Kubernetes cluster using
-```bash
-kubectl get pol
-```

--- a/charts/openebs/README.md
+++ b/charts/openebs/README.md
@@ -89,7 +89,7 @@ helm delete `my-release`
 
 ## Configuration
 
-The following table lists the common configurable parameters of the OpenEBS chart and their default values. For a full list of configurable parameters check out the [values.yaml](https://github.com/openebs/charts/blob/master/charts/openebs/values.yaml).
+The following table lists the common configurable parameters of the OpenEBS chart and their default values. For a full list of configurable parameters check out the [values.yaml](https://github.com/openebs/charts/blob/HEAD/charts/openebs/values.yaml).
 
 | Parameter                               | Description                                   | Default                                   |
 | ----------------------------------------| --------------------------------------------- | ----------------------------------------- |

--- a/charts/openebs/templates/NOTES.txt
+++ b/charts/openebs/templates/NOTES.txt
@@ -1,27 +1,22 @@
-The OpenEBS has been installed. Check its status by running:
-$ kubectl get pods -n {{ .Release.Namespace }}
 
-For dynamically creating OpenEBS Volumes, you can either create a new StorageClass or
-use one of the default storage classes provided by OpenEBS.
+Successfully installed OpenEBS.
 
-Use `kubectl get sc` to see the list of installed OpenEBS StorageClasses. A sample
-PVC spec using `openebs-jiva-default` StorageClass is given below:"
+Check the status by running: kubectl get pods -n {{ .Release.Namespace }}
 
----
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-  name: demo-vol-claim
-spec:
-  storageClassName: openebs-jiva-default
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 5G
----
+The default values enables OpenEBS hostpath, device and jiva engines along with 
+their default storage classes. Use `kubectl get sc` to see the list of installed 
+OpenEBS StorageClasses. 
 
-Please note that, OpenEBS uses iSCSI for connecting applications with the
-OpenEBS Volumes and your nodes should have the iSCSI initiator installed.
+For other engines, you will need to perform a few more additional steps to
+enable the engine, configure the engines (like creating pools) and create 
+storage classes. 
 
-For more information, visit our Slack at https://openebs.io/community or view the documentation online at http://docs.openebs.io/.
+For example, cStor can be enabled using commands like:
+
+helm upgrade {{ .Release.Name }} openebs/openebs  --set cstor.enabled=true --reuse-values --namespace {{ .Release.Namespace }}
+
+For more information, 
+- view the online documentation at https://openebs.io/ or
+- connect with an active community on Kubernetes slack #openebs channel.
+
+

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,5 +1,6 @@
 # See https://github.com/helm/chart-testing#configuration
 remote: origin
+target-branch: 2.x
 chart-dirs:
   - charts
 helm-extra-args: --timeout=500s


### PR DESCRIPTION
Updates the version of LVM and ZFS Local PV charts. 

And includes the changes proposed via #237

As a pre-step towards 3.0 and enabling CSI drivers for jiva and
cstor, made the necessary documentation and values.yaml updates.

The premise is that openebs chart will continue its current templates
of ndm and local provisioner, while jiva and cstor will be deprecated
in favor of the corresponding csi charts.

Once 3.0 is released, the recommended way to install cstor, jiva and other
engines would be to enable via this umbrella chart. If there is a strong
use-case for using only one type of engine in a cluster - the user can opt to
install the sub-charts directly.

Trimmed down the configuration options in the README to the commonly used
options.

Also, added Shovan as a maintainer.

Signed-off-by: kmova <kiran.mova@mayadata.io>

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[stable/openebs]`)
