### PR TITLE
chore(ci): rename 2.x to main in ci actions

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -5,12 +5,12 @@ on:
     paths:
       - 'charts/openebs/**'
     branches:
-      - 2.x
+      - main
   pull_request:
     paths:
       - 'charts/openebs/**'
     branches:
-      - 2.x
+      - main
 
 jobs:
   lint-test:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: Release Charts
 on:
   push:
     branches:
-      - 2.x
+      - main
 
 jobs:
   release:

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,6 +1,6 @@
 # See https://github.com/helm/chart-testing#configuration
 remote: origin
-target-branch: 2.x
+target-branch: main
 chart-dirs:
   - charts
 helm-extra-args: --timeout=500s


### PR DESCRIPTION
Signed-off-by: kmova <kiran.mova@mayadata.io>

#### Why is this change required?
Having two branches like main and 2.x pushing the images
doesn't work well with helm chart releaser when users
tend install with latest. A 2.12.5 can be shown as latst
if 2.12.5 chart is released post 3.0.0.

We will have the legacy components continue to maintain
in the main chart itself under the older version.

#### What is changed?
Update the branch detail to "main"

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/openebs/charts/blob/HEAD/CONTRIBUTING.md#sign-your-commits) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
