### PR TITLE
chore(charts): update helm chart to v3.0.0

### DIFF
--- a/charts/openebs/Chart.yaml
+++ b/charts/openebs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
-version: 2.12.9
+version: 3.0.0
 name: openebs
-appVersion: 2.12.2
+appVersion: 3.0.0
 description: Containerized Attached Storage for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/HEAD/projects/openebs/icon/color/openebs-icon-color.png
 home: http://www.openebs.io/
@@ -24,19 +24,19 @@ maintainers:
     email: shovan.maity@mayadata.io
 dependencies:
   - name: openebs-ndm
-    version: "1.6.1"
+    version: "1.7.1"
     repository: "https://openebs.github.io/node-disk-manager"
     condition: openebs-ndm.enabled
   - name: localpv-provisioner
-    version: "2.12.1"
+    version: "3.0.1"
     repository: "https://openebs.github.io/dynamic-localpv-provisioner"
     condition: localpv-provisioner.enabled
   - name: cstor
-    version: "2.12.1"
+    version: "3.0.1"
     repository: "https://openebs.github.io/cstor-operators"
     condition: cstor.enabled
   - name: jiva
-    version: "2.12.2"
+    version: "3.0.1"
     repository: "https://openebs.github.io/jiva-operator"
     condition: jiva.enabled
   - name: zfs-localpv
@@ -44,7 +44,7 @@ dependencies:
     repository: "https://openebs.github.io/zfs-localpv"
     condition: zfs-localpv.enabled
   - name: lvm-localpv
-    version: "0.8.4"
+    version: "0.8.5"
     repository: "https://openebs.github.io/lvm-localpv"
     condition: lvm-localpv.enabled
   - name: nfs-provisioner

--- a/charts/openebs/README.md
+++ b/charts/openebs/README.md
@@ -95,34 +95,34 @@ The following table lists the common configurable parameters of the OpenEBS char
 | ----------------------------------------| --------------------------------------------- | ----------------------------------------- |
 | `apiserver.enabled`                     | Enable API Server                             | `true`                                    |
 | `apiserver.image`                       | Image for API Server                          | `openebs/m-apiserver`                     |
-| `apiserver.imageTag`                    | Image Tag for API Server                      | `2.12.0`                                  |
+| `apiserver.imageTag`                    | Image Tag for API Server                      | `2.12.2`                                  |
 | `cleanup.image.registry`                | Cleanup pre hook image registry               | `nil`                                     |
 | `cleanup.image.repository`              | Cleanup pre hook image repository             | `"bitnami/kubectl"`                       |
 | `cleanup.image.tag`                     | Cleanup pre hook image tag                    | `if not provided determined by the k8s version`                       |
 | `crd.enableInstall`                     | Enable installation of CRDs by OpenEBS        | `true`                                    |
 | `cstor.pool.image`                      | Image for cStor Pool                          | `openebs/cstor-pool`                      |
-| `cstor.pool.imageTag`                   | Image Tag for cStor Pool                      | `2.12.0`                                  |
+| `cstor.pool.imageTag`                   | Image Tag for cStor Pool                      | `2.12.2`                                  |
 | `cstor.poolMgmt.image`                  | Image for cStor Pool  Management              | `openebs/cstor-pool-mgmt`                 |
-| `cstor.poolMgmt.imageTag`               | Image Tag for cStor Pool Management           | `2.12.0`                                  |
+| `cstor.poolMgmt.imageTag`               | Image Tag for cStor Pool Management           | `2.12.2`                                  |
 | `cstor.target.image`                    | Image for cStor Target                        | `openebs/cstor-istgt`                     |
-| `cstor.target.imageTag`                 | Image Tag for cStor Target                    | `2.12.0`                                  |
+| `cstor.target.imageTag`                 | Image Tag for cStor Target                    | `2.12.2`                                  |
 | `cstor.volumeMgmt.image`                | Image for cStor Volume  Management            | `openebs/cstor-volume-mgmt`               |
-| `cstor.volumeMgmt.imageTag`             | Image Tag for cStor Volume Management         | `2.12.0`                                  |
+| `cstor.volumeMgmt.imageTag`             | Image Tag for cStor Volume Management         | `2.12.2`                                  |
 | `defaultStorageConfig.enabled`          | Enable default storage class installation     | `true`                                    |
 | `healthCheck.initialDelaySeconds`       | Delay before liveness probe is initiated      | `30`                                      |
 | `healthCheck.periodSeconds`             | How often to perform the liveness probe       | `60`                                      |
 | `helper.image`                          | Image for helper                              | `openebs/linux-utils`                     |
-| `helper.imageTag`                       | Image Tag for helper                          | `2.12.0`                                  |
+| `helper.imageTag`                       | Image Tag for helper                          | `3.0.0`                                  |
 | `image.pullPolicy`                      | Container pull policy                         | `IfNotPresent`                            |
 | `image.repository`                      | Specify which docker registry to use          | `""`                                      |
 | `jiva.defaultStoragePath`               | hostpath used by default Jiva StorageClass    | `/var/openebs`                            |
 | `jiva.image`                            | Image for Jiva                                | `openebs/jiva`                            |
-| `jiva.imageTag`                         | Image Tag for Jiva                            | `2.12.1`                                  |
+| `jiva.imageTag`                         | Image Tag for Jiva                            | `2.12.2`                                  |
 | `jiva.replicas`                         | Number of Jiva Replicas                       | `3`                                       |
 | `localprovisioner.basePath`             | BasePath for hostPath volumes on Nodes        | `/var/openebs/local`                      |
 | `localprovisioner.enabled`              | Enable localProvisioner                       | `true`                                    |
 | `localprovisioner.image`                | Image for localProvisioner                    | `openebs/provisioner-localpv`             |
-| `localprovisioner.imageTag`             | Image Tag for localProvisioner                | `2.12.0`                                  |
+| `localprovisioner.imageTag`             | Image Tag for localProvisioner                | `3.0.0`                                  |
 | `ndm.enabled`                           | Enable Node Disk Manager                      | `true`                                    |
 | `ndm.filters.enableOsDiskExcludeFilter` | Enable filters of OS disk exclude             | `true`                                    |
 | `ndm.filters.enablePathFilter`          | Enable filters of paths                       | `true`                                    |
@@ -132,29 +132,29 @@ The following table lists the common configurable parameters of the OpenEBS char
 | `ndm.filters.includePaths`              | Include devices with specified path patterns  | `""`                                      |
 | `ndm.filters.osDiskExcludePaths`        | Paths/Mounts to be excluded by OS Disk Filter | `/,/etc/hosts,/boot`                      |
 | `ndm.image`                             | Image for Node Disk Manager                   | `openebs/node-disk-manager`               |
-| `ndm.imageTag`                          | Image Tag for Node Disk Manager               | `1.6.1`                                   |
+| `ndm.imageTag`                          | Image Tag for Node Disk Manager               | `1.7.0`                                   |
 | `ndmOperator.enabled`                   | Enable NDM Operator                           | `true`                                    |
 | `ndmOperator.image`                     | Image for NDM Operator                        | `openebs/node-disk-operator`              |
-| `ndmOperator.imageTag`                  | Image Tag for NDM Operator                    | `1.6.1`                                   |
+| `ndmOperator.imageTag`                  | Image Tag for NDM Operator                    | `1.7.0`                                   |
 | `ndm.probes.enableSeachest`             | Enable Seachest probe for NDM                 | `false`                                   |
 | `policies.monitoring.image`             | Image for Prometheus Exporter                 | `openebs/m-exporter`                      |
-| `policies.monitoring.imageTag`          | Image Tag for Prometheus Exporter             | `2.12.0`                                  |
+| `policies.monitoring.imageTag`          | Image Tag for Prometheus Exporter             | `1.7.0`                                  |
 | `provisioner.enabled`                   | Enable Provisioner                            | `true`                                    |
 | `provisioner.image`                     | Image for Provisioner                         | `openebs/openebs-k8s-provisioner`         |
-| `provisioner.imageTag`                  | Image Tag for Provisioner                     | `2.12.0`                                  |
+| `provisioner.imageTag`                  | Image Tag for Provisioner                     | `2.12.2`                                  |
 | `rbac.create`                           | Enable RBAC Resources                         | `true`                                    |
 | `rbac.kyvernoEnabled`                   | Create Kyverno policy resources               | `false`                                   |
 | `rbac.pspEnabled`                       | Create pod security policy resources          | `false`                                   |
 | `snapshotOperator.controller.image`     | Image for Snapshot Controller                 | `openebs/snapshot-controller`             |
-| `snapshotOperator.controller.imageTag`  | Image Tag for Snapshot Controller             | `2.12.0`                                  |
+| `snapshotOperator.controller.imageTag`  | Image Tag for Snapshot Controller             | `2.12.2`                                  |
 | `snapshotOperator.enabled`              | Enable Snapshot Provisioner                   | `true`                                    |
 | `snapshotOperator.provisioner.image`    | Image for Snapshot Provisioner                | `openebs/snapshot-provisioner`            |
-| `snapshotOperator.provisioner.imageTag` | Image Tag for Snapshot Provisioner            | `2.12.0`                                  |
+| `snapshotOperator.provisioner.imageTag` | Image Tag for Snapshot Provisioner            | `2.12.2`                                  |
 | `varDirectoryPath.baseDir`              | To store debug info of OpenEBS containers     | `/var/openebs`                            |
 | `webhook.enabled`                       | Enable admission server                       | `true`                                    |
 | `webhook.hostNetwork`                   | Use hostNetwork in admission server           | `false`                                   |
 | `webhook.image`                         | Image for admission server                    | `openebs/admission-server`                |
-| `webhook.imageTag`                      | Image Tag for admission server                | `2.12.0`                                  |
+| `webhook.imageTag`                      | Image Tag for admission server                | `2.12.2`                                  |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/charts/openebs/README.md
+++ b/charts/openebs/README.md
@@ -138,7 +138,7 @@ The following table lists the common configurable parameters of the OpenEBS char
 | `ndmOperator.imageTag`                  | Image Tag for NDM Operator                    | `1.7.0`                                   |
 | `ndm.probes.enableSeachest`             | Enable Seachest probe for NDM                 | `false`                                   |
 | `policies.monitoring.image`             | Image for Prometheus Exporter                 | `openebs/m-exporter`                      |
-| `policies.monitoring.imageTag`          | Image Tag for Prometheus Exporter             | `1.7.0`                                  |
+| `policies.monitoring.imageTag`          | Image Tag for Prometheus Exporter             | `2.12.2`                                  |
 | `provisioner.enabled`                   | Enable Provisioner                            | `true`                                    |
 | `provisioner.image`                     | Image for Provisioner                         | `openebs/openebs-k8s-provisioner`         |
 | `provisioner.imageTag`                  | Image Tag for Provisioner                     | `2.12.2`                                  |

--- a/charts/openebs/templates/NOTES.txt
+++ b/charts/openebs/templates/NOTES.txt
@@ -3,20 +3,31 @@ Successfully installed OpenEBS.
 
 Check the status by running: kubectl get pods -n {{ .Release.Namespace }}
 
-The default values enables OpenEBS hostpath, device and jiva engines along with 
-their default storage classes. Use `kubectl get sc` to see the list of installed 
-OpenEBS StorageClasses. 
+The default values will install NDM and enable OpenEBS hostpath and device
+storage engines along with their default StorageClasses. Use `kubectl get sc`
+to see the list of installed OpenEBS StorageClasses.
+
+**Note**: If you are upgrading from the older helm chart that was using cStor
+and Jiva (non-csi) volumes, you will have to run the following command to include
+the older provisioners:
+
+helm upgrade {{ .Release.Name }} openebs/openebs \
+	--namespace {{ .Release.Namespace }} \
+	--set legacy.enabled=true \
+	--reuse-values
 
 For other engines, you will need to perform a few more additional steps to
-enable the engine, configure the engines (like creating pools) and create 
-storage classes. 
+enable the engine, configure the engines (e.g. creating pools) and create 
+StorageClasses. 
 
 For example, cStor can be enabled using commands like:
 
-helm upgrade {{ .Release.Name }} openebs/openebs  --set cstor.enabled=true --reuse-values --namespace {{ .Release.Namespace }}
+helm upgrade {{ .Release.Name }} openebs/openebs \
+	--namespace {{ .Release.Namespace }} \
+	--set cstor.enabled=true \
+	--reuse-values
 
 For more information, 
 - view the online documentation at https://openebs.io/ or
 - connect with an active community on Kubernetes slack #openebs channel.
-
 

--- a/charts/openebs/templates/localprovisioner/hostpath-class.yaml
+++ b/charts/openebs/templates/localprovisioner/hostpath-class.yaml
@@ -13,7 +13,7 @@ metadata:
         value: "hostpath"
 {{- if .Values.localprovisioner.basePath }}
       - name: BasePath
-        value: {{ .Values.localprovisioner.basePath }}
+        value: "{{ .Values.localprovisioner.basePath }}"
 {{- end }}
 provisioner: openebs.io/local
 volumeBindingMode: WaitForFirstConsumer

--- a/charts/openebs/templates/ndm/daemonset-ndm.yaml
+++ b/charts/openebs/templates/ndm/daemonset-ndm.yaml
@@ -60,8 +60,8 @@ spec:
 {{- if .Values.featureGates.UseOSDisk.enabled }}
           - --feature-gates={{ .Values.featureGates.UseOSDisk.featureGateFlag }}
 {{- end}}
-{{- if .Values.featureGates.MountChangeDetection.enabled }}
-          - --feature-gates={{ .Values.featureGates.MountChangeDetection.featureGateFlag }}
+{{- if .Values.featureGates.ChangeDetection.enabled }}
+          - --feature-gates={{ .Values.featureGates.ChangeDetection.featureGateFlag }}
 {{- end}}
 {{- end}}
         imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/charts/openebs/values.yaml
+++ b/charts/openebs/values.yaml
@@ -21,10 +21,10 @@ release:
   version: "3.0.0"
 
 # Legacy components will be installed if it is enabled.
-# Legacy components are - admission-server, api-server, snapshot-operator
-# and storage-provisioner
+# Legacy components are - admission-server, maya api-server, snapshot-operator
+# and k8s-provisioner
 legacy:
-  enabled: true
+  enabled: false
 
 image:
   pullPolicy: IfNotPresent

--- a/charts/openebs/values.yaml
+++ b/charts/openebs/values.yaml
@@ -18,7 +18,7 @@ imagePullSecrets: []
 
 release:
   # "openebs.io/version" label for control plane components
-  version: "2.12.2"
+  version: "3.0.0"
 
 # Legacy components will be installed if it is enabled.
 # Legacy components are - admission-server, api-server, snapshot-operator
@@ -95,7 +95,7 @@ provisioner:
 localprovisioner:
   enabled: true
   image: "openebs/provisioner-localpv"
-  imageTag: "2.12.2"
+  imageTag: "3.0.0"
   replicas: 1
   enableLeaderElection: true
   enableDeviceClass: true
@@ -164,7 +164,7 @@ snapshotOperator:
 ndm:
   enabled: true
   image: "openebs/node-disk-manager"
-  imageTag: "1.6.1"
+  imageTag: "1.7.0"
   sparse:
     path: "/var/openebs/sparse"
     size: "10737418240"
@@ -200,7 +200,7 @@ ndm:
 ndmOperator:
   enabled: true
   image: "openebs/node-disk-operator"
-  imageTag: "1.6.1"
+  imageTag: "1.7.0"
   replicas: 1
   upgradeStrategy: Recreate
   nodeSelector: {}
@@ -228,7 +228,7 @@ ndmExporter:
     repository: openebs/node-disk-exporter
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 1.6.1
+    tag: 1.7.0
   nodeExporter:
     name: ndm-node-exporter
     podLabels:
@@ -273,7 +273,7 @@ webhook:
 # then put this configuration under `localpv-provisioner` and `openebs-ndm` key.
 helper:
   image: "openebs/linux-utils"
-  imageTag: "2.12.2"
+  imageTag: "3.0.0"
 
 # These are ndm related configuration. If you want to enable openebs as a dependency
 # chart then set `ndm.enabled: false`, `ndmOperator.enabled: false` and enable it as
@@ -291,9 +291,9 @@ featureGates:
   UseOSDisk:
     enabled: false
     featureGateFlag: "UseOSDisk"
-  MountChangeDetection:
+  ChangeDetection:
     enabled: false
-    featureGateFlag: "MountChangeDetection"
+    featureGateFlag: "ChangeDetection"
 
 crd:
   enableInstall: true
@@ -358,17 +358,17 @@ jiva:
 #      image:
 #        registry: quay.io/
 #        repository: openebs/jiva
-#        tag: 2.12.2
+#        tag: 3.0.0
 #    replica:
 #      image:
 #        registry: quay.io/
 #        repository: openebs/jiva
-#        tag: 2.12.2
+#        tag: 3.0.0
 #    image:
 #      registry: quay.io/
 #      repository: openebs/jiva-operator
 #      pullPolicy: IfNotPresent
-#      tag: 2.12.2
+#      tag: 3.0.0
 #
 #  jivaCSIPlugin:
 #    remount: "true"
@@ -376,7 +376,7 @@ jiva:
 #      registry: quay.io/
 #      repository: openebs/jiva-csi
 #      pullPolicy: IfNotPresent
-#      tag: 2.12.2
+#      tag: 3.0.0
 
 cstor:
 
@@ -427,51 +427,51 @@ cstor:
 #      image:
 #        registry: quay.io/
 #        repository: openebs/cstor-pool-manager
-#        tag: 2.12.2
+#        tag: 3.0.0
 #    cstorPool:
 #      image:
 #        registry: quay.io/
 #        repository: openebs/cstor-pool
-#        tag: 2.12.2
+#        tag: 3.0.0
 #    cstorPoolExporter:
 #      image:
 #        registry: quay.io/
 #        repository: openebs/m-exporter
-#        tag: 2.12.2
+#        tag: 3.0.0
 #    image:
 #      registry: quay.io/
 #      repository: openebs/cspc-operator
 #      pullPolicy: IfNotPresent
-#      tag: 2.12.2
+#      tag: 3.0.0
 #
 #  cvcOperator:
 #    target:
 #      image:
 #        registry: quay.io/
 #        repository: openebs/cstor-istgt
-#        tag: 2.12.2
+#        tag: 3.0.0
 #    volumeMgmt:
 #      image:
 #        registry: quay.io/
 #        repository: openebs/cstor-volume-manager
-#        tag: 2.12.2
+#        tag: 3.0.0
 #    volumeExporter:
 #      image:
 #        registry: quay.io/
 #        repository: openebs/m-exporter
-#        tag: 2.12.2
+#        tag: 3.0.0
 #    image:
 #      registry: quay.io/
 #      repository: openebs/cvc-operator
 #      pullPolicy: IfNotPresent
-#      tag: 2.12.2
+#      tag: 3.0.0
 #
 #  cstorCSIPlugin:
 #    image:
 #      registry: quay.io/
 #      repository: openebs/cstor-csi-driver
 #      pullPolicy: IfNotPresent
-#      tag: 2.12.2
+#      tag: 3.0.0
 #
 #  admissionServer:
 #    componentName: cstor-admission-webhook
@@ -479,7 +479,7 @@ cstor:
 #      registry: quay.io/
 #      repository: openebs/cstor-webhook
 #      pullPolicy: IfNotPresent
-#      tag: 2.12.2
+#      tag: 3.0.0
 
 # ndm configuration goes here
 # https://openebs.github.io/node-disk-manager
@@ -497,7 +497,7 @@ openebs-ndm:
 #      registry: quay.io/
 #      repository: openebs/node-disk-manager
 #      pullPolicy: IfNotPresent
-#      tag: 1.6.1
+#      tag: 1.7.0
 #    sparse:
 #      path: "/var/openebs/sparse"
 #      size: "10737418240"
@@ -520,14 +520,14 @@ openebs-ndm:
 #      registry: quay.io/
 #      repository: openebs/node-disk-operator
 #      pullPolicy: IfNotPresent
-#      tag: 1.6.1
+#      tag: 1.7.0
 #
 #  helperPod:
 #    image:
 #      registry: quay.io/
 #      repository: openebs/linux-utils
 #      pullPolicy: IfNotPresent
-#      tag: 2.12.2
+#      tag: 3.0.0
 #
 #  featureGates:
 #    enabled: true
@@ -535,12 +535,15 @@ openebs-ndm:
 #      enabled: true
 #      featureGateFlag: "GPTBasedUUID"
 #    APIService:
-#      enabled: true
+#      enabled: false
 #      featureGateFlag: "APIService"
 #      address: "0.0.0.0:9115"
 #    UseOSDisk:
 #      enabled: false
 #      featureGateFlag: "UseOSDisk"
+#    ChangeDetection:
+#      enabled: false
+#      featureGateFlag: "ChangeDetection"
 #
 #  varDirectoryPath:
 #    baseDir: "/var/openebs"
@@ -577,7 +580,7 @@ localpv-provisioner:
 #    image:
 #      registry: quay.io/
 #      repository: openebs/provisioner-localpv
-#      tag: 2.12.2
+#      tag: 3.0.0
 #      pullPolicy: IfNotPresent
 #    healthCheck:
 #      initialDelaySeconds: 30
@@ -591,7 +594,7 @@ localpv-provisioner:
 #      registry: quay.io/
 #      repository: openebs/linux-utils
 #      pullPolicy: IfNotPresent
-#      tag: 2.12.2
+#      tag: 3.0.0
 
 # zfs local pv configuration goes here
 # ref - https://openebs.github.io/zfs-localpv
@@ -612,7 +615,7 @@ zfs-localpv:
 #      registry: quay.io/
 #      repository: openebs/zfs-driver
 #      pullPolicy: IfNotPresent
-#      tag: 1.9.2
+#      tag: 1.9.3
 
 # lvm local pv configuration goes here
 # ref - https://openebs.github.io/lvm-localpv
@@ -633,7 +636,7 @@ lvm-localpv:
 #      registry: quay.io/
 #      repository: openebs/lvm-driver
 #      pullPolicy: IfNotPresent
-#      tag: 0.8.1
+#      tag: 0.8.2
 
 # openebs nfs provisioner configuration goes here
 # ref - https://openebs.github.io/dynamic-nfs-provisioner
@@ -653,9 +656,13 @@ nfs-provisioner:
 #    image:
 #      registry:
 #      repository: openebs/provisioner-nfs
-#      tag: 0.6.1
+#      tag: 0.7.1
 #      pullPolicy: IfNotPresent
 #    enableLeaderElection: "true"
+#    nfsServerAlpineImage:
+#      registry:
+#      repository: openebs/nfs-server-alpine
+#      tag: 0.7.1
 
 cleanup:
   image:


### PR DESCRIPTION
Signed-off-by: Niladri Halder <niladri.halder@mayadata.io>

Changes:
1. All legacy components (except NDM and localpv-provisioner) image tags set to 2.12.2
2. NDM image tags set to 1.7.0
3. localpv-provisioner image tags set to 3.0.0
4. Updated dependent chart versions to the latest version
5. Bumped chart version and appVersion
6. NDM changes:
       i. Ranamed MountChangeDetection to ChangeDetection in DaemonSet yaml and values.yaml

7. OPENEBS_IO_INSTALLER_TYPE is set to "charts-helm" across all components.
8. `--legacy.enabled=false` is now set.