### PR TITLE
Fix maya-apiserver liveness probe

### DIFF
--- a/charts/openebs/templates/legacy/deployment-maya-apiserver.yaml
+++ b/charts/openebs/templates/legacy/deployment-maya-apiserver.yaml
@@ -158,9 +158,9 @@ spec:
         livenessProbe:
           exec:
             command:
-            - /usr/local/bin/mayactl
-            - -m $MY_POD_IP
-            - version
+            - /bin/sh
+            - -c
+            - /usr/local/bin/mayactl -m $MY_POD_IP version
           initialDelaySeconds: {{ .Values.apiserver.healthCheck.initialDelaySeconds }}
           periodSeconds: {{ .Values.apiserver.healthCheck.periodSeconds }}
 {{- if .Values.apiserver.nodeSelector }}


### PR DESCRIPTION
#### Why is this change required?
Liveness probe of maya-apiserver is failing ('Liveness probe failed: Invalid m-apiserver address')
It also affect microk8s (v1.21+) installs of openebs as an addon.

#### What is changed?
The maya-apiserver liveness probe

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/openebs/charts/blob/HEAD/CONTRIBUTING.md#sign-your-commits) signed
- [ ] Chart Version bumped
- [] Variables are documented in the README.md
