### PR TITLE
Bump lvm-localpv subchart version

### DIFF
--- a/charts/openebs/Chart.yaml
+++ b/charts/openebs/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 3.4.0
+version: 3.4.1
 name: openebs
 appVersion: 3.4.0
 description: Containerized Attached Storage for Kubernetes
@@ -44,7 +44,7 @@ dependencies:
     repository: "https://openebs.github.io/zfs-localpv"
     condition: zfs-localpv.enabled
   - name: lvm-localpv
-    version: "1.0.0"
+    version: "1.0.1"
     repository: "https://openebs.github.io/lvm-localpv"
     condition: lvm-localpv.enabled
   - name: nfs-provisioner


### PR DESCRIPTION
#### Why is this change required?
This PR fixes a bug in helm chart where the chart cannot be installed if imagePullSecret is specified.

Depends on https://github.com/openebs/lvm-localpv/pull/221

#### What is changed?
 Fixes indentation of imagePullSecret in helm chart.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/openebs/charts/blob/HEAD/CONTRIBUTING.md#sign-your-commits) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md

Signed-off-by: Ondrej Vasko <o.vasko@pan-net.eu>