### PR TITLE
fix(chart): fix mayastor image tag

### DIFF
--- a/charts/openebs/Chart.yaml
+++ b/charts/openebs/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 3.4.0
+version: 3.4.1
 name: openebs
 appVersion: 3.4.0
 description: Containerized Attached Storage for Kubernetes

--- a/charts/openebs/values.yaml
+++ b/charts/openebs/values.yaml
@@ -407,7 +407,7 @@ mayastor:
     # -- Image registry's namespace
     repo: openebs
     # -- Release tag for Mayastor images
-    tag: release-2.0
+    tag: v2.0.0
     # -- ImagePullPolicy for Mayastor images
     pullPolicy: Always
 


### PR DESCRIPTION
#### Why is this change required?
The image tag used for the Mayastor subchart is incorrect.