### PR TITLE
charts(openebs-3.4.1): helm chart for OpenEBS v3.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ OpenEBS helm chart will includes common components that are used by multiple eng
 - Security Policies like RBAC, PSP, Kyverno 
 
 Engine charts included as dependencies are:
-- [mayastor] (https://github.com/openebs/mayastor-extensions/tree/release/2.0/chart)
+- [Mayastor](https://github.com/openebs/mayastor-extensions/tree/v2.0.1/chart)
 - [cStor](https://github.com/openebs/cstor-operators/tree/HEAD/deploy/helm/charts)
 - [Jiva](https://github.com/openebs/jiva-operator/tree/HEAD/deploy/helm/charts)
 - [ZFS Local PV](https://github.com/openebs/zfs-localpv/tree/HEAD/deploy/helm/charts)

--- a/charts/openebs/Chart.yaml
+++ b/charts/openebs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
-version: 3.4.1
+version: 3.4.2
 name: openebs
-appVersion: 3.4.0
+appVersion: 3.4.1
 description: Containerized Attached Storage for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/HEAD/projects/openebs/icon/color/openebs-icon-color.png
 home: http://www.openebs.io/
@@ -52,6 +52,6 @@ dependencies:
     repository: "https://openebs.github.io/dynamic-nfs-provisioner"
     condition: nfs-provisioner.enabled
   - name: mayastor
-    version: "2.0.0"
+    version: "2.0.1"
     repository: "https://openebs.github.io/mayastor-extensions"
     condition: mayastor.enabled

--- a/charts/openebs/README.md
+++ b/charts/openebs/README.md
@@ -148,7 +148,7 @@ The following table lists the common configurable parameters of the OpenEBS char
 | `mayastor.etcd.persistence.size`            | Set the size of the volume(s) used by the etcd                               | `""`                                                                     |
 | `mayastor.image.registry`                   | Set the container image registry for the mayastor containers                 | `"docker.io"`                                                            |
 | `mayastor.image.repo`                       | Set the container image repository for the mayastor containers               | `"openebs"`                                                              |
-| `mayastor.image.tag`                        | Set the container image tag for the mayastor containers                      | `"release-2.0"`                                                          |
+| `mayastor.image.tag`                        | Set the container image tag for the mayastor containers                      | `"v2.0.1"`                                                          |
 | `mayastor.image.pullPolicy`                 | Set the container ImagePullPolicy for the mayastor containers                | `"Always"`                                                               |
 | `mayastor.csi.image.registry`               | Set the container image registry for the Kubernetes CSI sidecar containers   | `"registry.k8s.io"`                                                      |
 | `mayastor.csi.image.repo`                   | Set the container image repository for the Kubernetes CSI sidecar containers | `"sig-storage"`                                                          |

--- a/charts/openebs/values.yaml
+++ b/charts/openebs/values.yaml
@@ -18,7 +18,7 @@ imagePullSecrets: []
 
 release:
   # "openebs.io/version" label for control plane components
-  version: "3.4.0"
+  version: "3.4.1"
 
 # Legacy components will be installed if it is enabled.
 # Legacy components are - admission-server, maya api-server, snapshot-operator
@@ -401,152 +401,142 @@ mayastor:
   # -- Enable Mayastor storage engine
   # Note: Enabling this will remove LocalPV Provisioner and NDM (default chart components).
   enabled: false
-  image:
-    # -- Image registry to pull Mayastor product images
-    registry: docker.io
-    # -- Image registry's namespace
-    repo: openebs
-    # -- Release tag for Mayastor images
-    tag: v2.0.0
-    # -- ImagePullPolicy for Mayastor images
-    pullPolicy: Always
 
-  base:
-    initContainers:
-      enabled: true
-      containers:
-        - name: agent-core-grpc-probe
-          image: busybox:latest
-          command: ['sh', '-c', 'trap "exit 1" TERM; until nc -vzw 5 {{ .Release.Name }}-agent-core 50051; do date; echo "Waiting for agent-core-grpc services..."; sleep 1; done;']
-        - name: etcd-probe
-          image: busybox:latest
-          command: ['sh', '-c', 'trap "exit 1" TERM; until nc -vzw 5 {{ .Release.Name }}-etcd {{.Values.etcd.service.port}}; do date; echo "Waiting for etcd..."; sleep 1; done;']
-    initCoreContainers:
-      enabled: true
-      containers:
-        - name: etcd-probe
-          image: busybox:latest
-          command: ['sh', '-c', 'trap "exit 1" TERM; until nc -vzw 5 {{ .Release.Name }}-etcd {{.Values.etcd.service.port}}; do date; echo "Waiting for etcd..."; sleep 1; done;']
-    # docker-secrets required to pull images if the container registry from image.Registry is protected
-    imagePullSecrets:
-      # -- Enable imagePullSecrets for pulling our container images
-      enabled: false
-      # Name of the imagePullSecret in the installed namespace
-      secrets:
-        - name: login
+  # Sample configuration, if you want to configure mayastor with custom values.
+  # This is a small part of the full configuration. Full configuration available
+  # here - https://github.com/openebs/mayastor-extensions/blob/v2.0.1/chart/values.yaml
 
-    metrics:
-      # -- Enable the metrics exporter
-      enabled: true
+  # image:
+  #   # -- Image registry to pull Mayastor product images
+  #   registry: docker.io
+  #   # -- Image registry's namespace
+  #   repo: openebs
+  #   # -- Release tag for Mayastor images
+  #   tag: v2.0.1
+  #   # -- ImagePullPolicy for Mayastor images
+  #   pullPolicy: Always
 
-    jaeger:
-      # -- Enable jaeger tracing
-      enabled: false
+  # base:
+  #   # docker-secrets required to pull images if the container registry from image.Registry is protected
+  #   imagePullSecrets:
+  #     # -- Enable imagePullSecrets for pulling our container images
+  #     enabled: false
+  #     # Name of the imagePullSecret in the installed namespace
+  #     secrets:
+  #       - name: login
 
-  operators:
-    pool:
-      # -- Log level for diskpool operator service
-      logLevel: info
+  #   metrics:
+  #     # -- Enable the metrics exporter
+  #     enabled: true
 
-  jaeger-operator:
-    # Name of jaeger operator
-    name: "{{ .Release.Name }}"
-    crd:
-      # Install jaeger CRDs
-      install: false
-    jaeger:
-      # Install jaeger-operator
-      create: false
-    rbac:
-      # Create a clusterRole for Jaeger
-      clusterRole: true
+  #   jaeger:
+  #     # -- Enable jaeger tracing
+  #     enabled: false
 
-  agents:
-    core:
-      # -- Log level for the core service
-      logLevel: info
-    ha:
-      enabled: true
-      node:
-        # -- Log level for the ha node service
-        logLevel: info
-      cluster:
-        # -- Log level for the ha cluster service
-        logLevel: info
+  # operators:
+  #   pool:
+  #     # -- Log level for diskpool operator service
+  #     logLevel: info
 
-  apis:
-    rest:
-      # -- Log level for the rest service
-      logLevel: info
-      # -- Number of replicas of rest
-      replicaCount: 1
+  # jaeger-operator:
+  #   # Name of jaeger operator
+  #   name: "{{ .Release.Name }}"
+  #   crd:
+  #     # Install jaeger CRDs
+  #     install: false
+  #   jaeger:
+  #     # Install jaeger-operator
+  #     create: false
+  #   rbac:
+  #     # Create a clusterRole for Jaeger
+  #     clusterRole: true
 
-  csi:
-    image:
-      # -- Image registry to pull all CSI Sidecar images
-      registry: registry.k8s.io
-      # -- Image registry's namespace
-      repo: sig-storage
-      # -- imagePullPolicy for all CSI Sidecar images
-      pullPolicy: IfNotPresent
-      # -- csi-provisioner image release tag
-      provisionerTag: v2.2.1
-      # -- csi-attacher image release tag
-      attacherTag: v3.2.1
-      # -- csi-node-driver-registrar image release tag
-      registrarTag: v2.1.0
+  # agents:
+  #   core:
+  #     # -- Log level for the core service
+  #     logLevel: info
+  #   ha:
+  #     enabled: true
+  #     node:
+  #       # -- Log level for the ha node service
+  #       logLevel: info
+  #     cluster:
+  #       # -- Log level for the ha cluster service
+  #       logLevel: info
 
-    controller:
-      # -- Log level for the csi controller
-      logLevel: info
+  # apis:
+  #   rest:
+  #     # -- Log level for the rest service
+  #     logLevel: info
+  #     # -- Number of replicas of rest
+  #     replicaCount: 1
 
-    node:
-      logLevel: info
-      topology:
-        segments:
-          openebs.io/csi-node: mayastor
-        # -- Add topology segments to the csi-node daemonset node selector
-        nodeSelector: false
-      kubeletDir: /var/lib/kubelet
+  # csi:
+  #   image:
+  #     # -- Image registry to pull all CSI Sidecar images
+  #     registry: registry.k8s.io
+  #     # -- Image registry's namespace
+  #     repo: sig-storage
+  #     # -- imagePullPolicy for all CSI Sidecar images
+  #     pullPolicy: IfNotPresent
+  #     # -- csi-provisioner image release tag
+  #     provisionerTag: v2.2.1
+  #     # -- csi-attacher image release tag
+  #     attacherTag: v3.2.1
+  #     # -- csi-node-driver-registrar image release tag
+  #     registrarTag: v2.1.0
 
-  io_engine:
-    # -- Log level for the io-engine service
-    logLevel: info,io_engine=info
-    # -- Node selectors to designate storage nodes for diskpool creation
-    # Note that if multi-arch images support 'kubernetes.io/arch: amd64'
-    # should be removed.
-    nodeSelector:
-      openebs.io/engine: mayastor
-      kubernetes.io/arch: amd64
+  #   controller:
+  #     # -- Log level for the csi controller
+  #     logLevel: info
 
-  etcd:
-    # Pod labels; okay to remove the openebs logging label if required
-    podLabels:
-      app: etcd
-      openebs.io/logging: "true"
-    # -- Number of replicas of etcd
-    replicaCount: 3
-    persistence:
-      # -- If true, use a Persistent Volume Claim. If false, use emptyDir.
-      enabled: true
-      # -- Will define which storageClass to use in etcd's StatefulSets
-      # a `manual` storageClass will provision a hostpath PV on the same node
-      # an empty storageClass will use the default StorageClass on the cluster
-      storageClass: ""
-      # -- Volume size
-      size: 2Gi
-    podAntiAffinityPreset: "hard"
+  #   node:
+  #     logLevel: info
+  #     topology:
+  #       segments:
+  #         openebs.io/csi-node: mayastor
+  #       # -- Add topology segments to the csi-node daemonset node selector
+  #       nodeSelector: false
+  #     kubeletDir: /var/lib/kubelet
 
-  loki-stack:
-    # -- Enable loki log collection for Mayastor components
-    enabled: true
+  # io_engine:
+  #   # -- Log level for the io-engine service
+  #   logLevel: info,io_engine=info
+  #   # -- Node selectors to designate storage nodes for diskpool creation
+  #   # Note that if multi-arch images support 'kubernetes.io/arch: amd64'
+  #   # should be removed.
+  #   nodeSelector:
+  #     openebs.io/engine: mayastor
+  #     kubernetes.io/arch: amd64
 
-  obs:
-    callhome:
-      # -- Enable callhome
-      enabled: true
-      # -- Log level for callhome
-      logLevel: "info"
+  # etcd:
+  #   # Pod labels; okay to remove the openebs logging label if required
+  #   podLabels:
+  #     app: etcd
+  #     openebs.io/logging: "true"
+  #   # -- Number of replicas of etcd
+  #   replicaCount: 3
+  #   persistence:
+  #     # -- If true, use a Persistent Volume Claim. If false, use emptyDir.
+  #     enabled: true
+  #     # -- Will define which storageClass to use in etcd's StatefulSets
+  #     # a `manual` storageClass will provision a hostpath PV on the same node
+  #     # an empty storageClass will use the default StorageClass on the cluster
+  #     storageClass: ""
+  #     # -- Volume size
+  #     size: 2Gi
+  #   podAntiAffinityPreset: "hard"
+
+  # loki-stack:
+  #   # -- Enable loki log collection for Mayastor components
+  #   enabled: true
+
+  # obs:
+  #   callhome:
+  #     # -- Enable callhome
+  #     enabled: true
+  #     # -- Log level for callhome
+  #     logLevel: "info"
 
 jiva:
   # non csi configuration
@@ -879,7 +869,7 @@ lvm-localpv:
 nfs-provisioner:
   enabled: false
 
-  # Sample configuration if you want to configure lvm localpv with custom values.
+  # Sample configuration if you want to configure nfs-provisioner with custom values.
   # This is a small part of the full configuration. Full configuration available
   # here - https://openebs.github.io/dynamic-nfs-provisioner
 

--- a/charts/openebs/values.yaml
+++ b/charts/openebs/values.yaml
@@ -406,15 +406,15 @@ mayastor:
   # This is a small part of the full configuration. Full configuration available
   # here - https://github.com/openebs/mayastor-extensions/blob/v2.0.1/chart/values.yaml
 
-  # image:
-  #   # -- Image registry to pull Mayastor product images
-  #   registry: docker.io
-  #   # -- Image registry's namespace
-  #   repo: openebs
-  #   # -- Release tag for Mayastor images
-  #   tag: v2.0.1
-  #   # -- ImagePullPolicy for Mayastor images
-  #   pullPolicy: Always
+  image:
+    # -- Image registry to pull Mayastor product images
+    registry: docker.io
+    # -- Image registry's namespace
+    repo: openebs
+    # -- Release tag for Mayastor images
+    tag: v2.0.1
+    # -- ImagePullPolicy for Mayastor images
+    pullPolicy: Always
 
   # base:
   #   # docker-secrets required to pull images if the container registry from image.Registry is protected


### PR DESCRIPTION
This add release v3.4.1 for the OpenEBS chart. changes:
- mayastor dependency updated to 2.0.1
- values.yaml typo fix for dynamic-nfs-provisioner options
- comment mayastor configuration set to enable the use of subchart options, by default
- remove mayastor base.initContainer and containers configuration, the subchart options will be used by default
