### PR TITLE
fix: ensure deployments matchLabels do not overlap

### DIFF
--- a/charts/openebs/Chart.yaml
+++ b/charts/openebs/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 3.5.0
+version: 3.5.1
 name: openebs
 appVersion: 3.5.0
 description: Containerized Attached Storage for Kubernetes

--- a/charts/openebs/templates/legacy/deployment-maya-apiserver.yaml
+++ b/charts/openebs/templates/legacy/deployment-maya-apiserver.yaml
@@ -21,6 +21,7 @@ spec:
     matchLabels:
       app: {{ template "openebs.name" . }}
       release: {{ .Release.Name }}
+      component: apiserver
   template:
     metadata:
       labels:

--- a/charts/openebs/templates/legacy/deployment-maya-provisioner.yaml
+++ b/charts/openebs/templates/legacy/deployment-maya-provisioner.yaml
@@ -21,6 +21,7 @@ spec:
     matchLabels:
       app: {{ template "openebs.name" . }}
       release: {{ .Release.Name }}
+      component: provisioner
   template:
     metadata:
       labels:

--- a/charts/openebs/templates/legacy/deployment-maya-snapshot-operator.yaml
+++ b/charts/openebs/templates/legacy/deployment-maya-snapshot-operator.yaml
@@ -17,6 +17,7 @@ spec:
     matchLabels:
       app: {{ template "openebs.name" . }}
       release: {{ .Release.Name }}
+      component: snapshot-operator
   strategy:
     type: "Recreate"
     rollingUpdate: null

--- a/charts/openebs/templates/localprovisioner/deployment-local-provisioner.yaml
+++ b/charts/openebs/templates/localprovisioner/deployment-local-provisioner.yaml
@@ -23,6 +23,7 @@ spec:
     matchLabels:
       app: {{ template "openebs.name" . }}
       release: {{ .Release.Name }}
+      component: localpv-provisioner
   template:
     metadata:
       labels:

--- a/charts/openebs/templates/ndm/deployment-ndm-operator.yaml
+++ b/charts/openebs/templates/ndm/deployment-ndm-operator.yaml
@@ -24,6 +24,7 @@ spec:
     matchLabels:
       app: {{ template "openebs.name" . }}
       release: {{ .Release.Name }}
+      component: ndm-operator
   template:
     metadata:
       labels:


### PR DESCRIPTION
#### Why is this change required?
The deployments for several components has overlapping `matchLabels` which may cause issues.

#### What is changed?
Add `component` label that is unique per deployment

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/openebs/charts/blob/HEAD/CONTRIBUTING.md#sign-your-commits) signed
- [ ] Chart Version bumped
- [X] Variables are documented in the README.md
