### PR TITLE
fix(lvm-operator): fix container image name

### DIFF
--- a/lvm-operator.yaml
+++ b/lvm-operator.yaml
@@ -1473,7 +1473,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: openebs-lvm-plugin
-          image: openebs/lvm-driver1.2.0
+          image: openebs/lvm-driver:1.2.0
           imagePullPolicy: IfNotPresent
           env:
             - name: OPENEBS_CONTROLLER_DRIVER
@@ -1669,7 +1669,7 @@ spec:
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
-          image: openebs/lvm-driver1.2.0
+          image: openebs/lvm-driver:1.2.0
           imagePullPolicy: IfNotPresent
           args:
             - "--nodeid=$(OPENEBS_NODE_ID)"

--- a/versioned/3.8.0/lvm-operator.yaml
+++ b/versioned/3.8.0/lvm-operator.yaml
@@ -1473,7 +1473,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: openebs-lvm-plugin
-          image: openebs/lvm-driver1.2.0
+          image: openebs/lvm-driver:1.2.0
           imagePullPolicy: IfNotPresent
           env:
             - name: OPENEBS_CONTROLLER_DRIVER
@@ -1669,7 +1669,7 @@ spec:
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
-          image: openebs/lvm-driver1.2.0
+          image: openebs/lvm-driver:1.2.0
           imagePullPolicy: IfNotPresent
           args:
             - "--nodeid=$(OPENEBS_NODE_ID)"


### PR DESCRIPTION
Fixes https://github.com/openebs/lvm-localpv/issues/246

#### Why is this change required?
The lvm-driver image name is invalid, the image name and the image tag does not have a separating ':'.

#### What is changed?
The container image names for the lvm-operator have a valid image name now.
