### PR TITLE
fix(OpenEBS-chart): update ZFS-LocalPV dependency

### DIFF
--- a/charts/openebs/Chart.yaml
+++ b/charts/openebs/Chart.yaml
@@ -40,7 +40,7 @@ dependencies:
     repository: "https://openebs.github.io/jiva-operator"
     condition: jiva.enabled
   - name: zfs-localpv
-    version: "2.4.0"
+    version: "2.5.0"
     repository: "https://openebs.github.io/zfs-localpv"
     condition: zfs-localpv.enabled
   - name: lvm-localpv


### PR DESCRIPTION
#### Why is this change required?

Does what it says on the tin.
2.5.0 includes significant improvement and changes to the ZFS-LocalPV helm-chart

#### What is changed?

OpenEBS ZFS-LocalPV dependency updated from 2.4.0 to 2.5.0

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/openebs/charts/blob/HEAD/CONTRIBUTING.md#sign-your-commits) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
